### PR TITLE
Fix crash when creature looktype has no animations

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -497,6 +497,10 @@ void Creature::updateWalkAnimation()
         return;
 
     const int footAnimPhases = getTotalAnimationPhase();
+    if (footAnimPhases == 0) {
+        // looktype has no animations
+        return;
+    }
 
     const int footDelay = m_stepCache.getDuration(m_lastStepDirection) / footAnimPhases;
 


### PR DESCRIPTION
Fix #26 