### PR TITLE
Replacing future._Is_ready member

### DIFF
--- a/src/framework/sound/soundmanager.cpp
+++ b/src/framework/sound/soundmanager.cpp
@@ -99,7 +99,7 @@ void SoundManager::poll()
         StreamSoundSourcePtr source = it->first;
         auto& future = it->second;
 
-        if(future._Is_ready()) {
+        if(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
             SoundFilePtr sound = future.get();
             if(sound)
                 source->setSoundFile(sound);


### PR DESCRIPTION
After the changes done on 5cce571a5504b8db68c21bc494a6d2f5c4002229, I'm receiving the next error when builiding:
```
/src/framework/sound/soundmanager.cpp:102:19: error: ‘class std::shared_future<stdext::shared_object_ptr<SoundFile> >’ has no member named ‘_Is_ready’
         if(future._Is_ready()) {
```

After some research, I found that the _Is_ready member is only available in the VC implementation of C++.
Source: https://stackoverflow.com/a/23462951

I changed this call for the alternative suggested in that same stackoverflow page.