### PR TITLE
Walk + Turn + UpdateTile fix

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2297,7 +2297,7 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
 
         if(creature) {
             creature->setHealthPercent(healthPercent);
-            creature->setDirection(direction);
+            creature->turn(direction);
             creature->setOutfit(outfit);
             creature->setSpeed(speed);
             creature->setSkull(skull);


### PR DESCRIPTION
Creating a new pull request, because it is a small change, but could affect many things, as it modifies how we receive the creature update info. It may have more implications.

The problem that it solves is:
https://i.imgur.com/1KRK1Et.mp4
While walking, if you turn and the tile below you is updated, your direction walking animation changes...

So, before setting the direction, the turn methods checks if the player is walking before doing so, so that would be perfect in this case:
```c++
void Creature::turn(Otc::Direction direction)
{
    // if is not walking change the direction right away
    if(!m_walking)
        setDirection(direction);
    // schedules to set the new direction when walk ends
    else
        m_walkTurnDirection = direction;
}
```

After the modification:
https://i.imgur.com/FiExANl.mp4