### PR TITLE
Rebind Alt key to "Command" key if MacOS.

### DIFF
--- a/src/framework/platform/platformwindow.cpp
+++ b/src/framework/platform/platformwindow.cpp
@@ -71,12 +71,18 @@ void PlatformWindow::processKeyDown(Fw::Key keyCode)
     if(keyCode == Fw::KeyUnknown)
         return;
 
-    if(keyCode == Fw::KeyCtrl) {
+    if (keyCode == Fw::KeyCtrl) {
         m_inputEvent.keyboardModifiers |= Fw::KeyboardCtrlModifier;
         return;
-    } else if(keyCode == Fw::KeyAlt) {
+#if defined(__APPLE__)
+    } else if (keyCode == Fw::KeyMeta) {
         m_inputEvent.keyboardModifiers |= Fw::KeyboardAltModifier;
         return;
+#else
+    } else if (keyCode == Fw::KeyAlt) {
+        m_inputEvent.keyboardModifiers |= Fw::KeyboardAltModifier;
+        return;
+#endif
     } else if(keyCode == Fw::KeyShift) {
         m_inputEvent.keyboardModifiers |= Fw::KeyboardShiftModifier;
         return;
@@ -111,9 +117,15 @@ void PlatformWindow::processKeyUp(Fw::Key keyCode)
     if(keyCode == Fw::KeyCtrl) {
         m_inputEvent.keyboardModifiers &= ~Fw::KeyboardCtrlModifier;
         return;
-    } else if(keyCode == Fw::KeyAlt) {
+#if defined(__APPLE__)
+    } else if(keyCode == Fw::KeyMeta) {
         m_inputEvent.keyboardModifiers &= ~Fw::KeyboardAltModifier;
         return;
+#else
+    } else if (keyCode == Fw::KeyAlt) {
+        m_inputEvent.keyboardModifiers &= ~Fw::KeyboardAltModifier;
+        return;
+#endif
     } else if(keyCode == Fw::KeyShift) {
         m_inputEvent.keyboardModifiers &= ~Fw::KeyboardShiftModifier;
         return;

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -563,8 +563,13 @@ Fw::Key WIN32Window::retranslateVirtualKey(WPARAM wParam, LPARAM lParam)
         key = m_keyMap[wParam];
 
     // actually ignore alt/ctrl/shift keys, they is states are already stored in m_inputEvent.keyboardModifiers
+#if defined(__APPLE__)
+    if(key == Fw::KeyMeta || key == Fw::KeyCtrl || key == Fw::KeyShift)
+        key = Fw::KeyUnknown;
+#else
     if(key == Fw::KeyAlt || key == Fw::KeyCtrl || key == Fw::KeyShift)
         key = Fw::KeyUnknown;
+#endif
 
     return key;
 }
@@ -578,8 +583,13 @@ LRESULT WIN32Window::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
         m_inputEvent.keyboardModifiers |= Fw::KeyboardCtrlModifier;
     if(IsKeyDown(VK_SHIFT))
         m_inputEvent.keyboardModifiers |= Fw::KeyboardShiftModifier;
+#if defined(__APPLE__)
+    if(IsKeyDown(VK_LWIN))
+        m_inputEvent.keyboardModifiers |= Fw::KeyboardAltModifier;
+#else
     if(IsKeyDown(VK_MENU))
         m_inputEvent.keyboardModifiers |= Fw::KeyboardAltModifier;
+#endif
 
     bool notificateMapKeyEvent = false;
     switch(uMsg)


### PR DESCRIPTION
Rebound Alt key to Command key (windows key) when compiling on MacOS. Tested on both windows and MacOS, and works fine in both cases.