### PR TITLE
Add access to widget children via widget.childId

### DIFF
--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -167,6 +167,14 @@ void UIWidget::addChild(const UIWidgetPtr& child)
     // update new child states
     child->updateStates();
 
+    // add access to child via widget.childId
+    std::string widgetId = child->getId();
+    if (!widgetId.empty()) {
+        if (!hasLuaField(widgetId)) {
+            setLuaField(widgetId, child);
+        }
+    }
+	
     // update old child index states
     if(oldLastChild) {
         oldLastChild->updateState(Fw::MiddleState);


### PR DESCRIPTION
By now we need to use widget:getChildById(childId), with this modification, widget.childId can be used