### PR TITLE
Update game_actionbar.lua

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -105,7 +105,7 @@ function createMenu(slotId)
     local menu = g_ui.createWidget("PopupMenu")
     slotToEdit = slotId
     menu:addOption("Assign Spell", function() openSpellAssignWindow() end)
-    --menu:addOption("Assign Object", function() startChooseItem() openObjectAssignWindow() end)
+    menu:addOption("Assign Object", function() startChooseItem() openObjectAssignWindow() end)
     menu:addOption("Assign Text", function() openTextAssignWindow() end)
     menu:addOption("Edit Hotkey", function() openEditHotkeyWindow() end)
     local actionSlot = actionBarPanel:recursiveGetChildById(slotToEdit)
@@ -145,7 +145,7 @@ function initializeSpelllist()
             
 
             if not table.find(info.vocations, getVocationForFilter()) then
-                tmpLabel:setVisible(false)
+                --tmpLabel:setVisible(false)
             end
 
             tmpLabel:setHeight(SpelllistSettings[SpelllistProfile].iconSize.height + 4)


### PR DESCRIPTION
Uncommented "assign object" which allows users to assign object properly, it was initially commented because I have a 7.72 server and do not support this option.
Commented line 148 because this relies on "getVocation()" which is only supported on newer clients. Users were complaining of spell list not showing