### PR TITLE
Update game_actionbar.lua

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -504,7 +504,7 @@ function hotkeyClear(assignWindow)
     comboPreview:setText(tr('Current hotkey to change: none'))
     comboPreview.keyCombo = ''
     comboPreview:resizeToText()
-    assignWindow:getChildById('applyButton'):disable()
+    assignWindow:getChildById('applyButton'):enable()
 end
 
 function hotkeyCaptureOk(assignWindow, keyCombo)


### PR DESCRIPTION
allow user to Clear a hotkey
Previously: Apply F5 to a hotkey, you can reassign it, however you cannot reset F5 to blank
Now: You can press Edit Hotkey -> Clear -> Apply, and the hotkey will be removed.