### PR TITLE
TFS 12.71 compatibility

### DIFF
--- a/modules/gamelib/game.lua
+++ b/modules/gamelib/game.lua
@@ -42,7 +42,7 @@ end
 
 function g_game.isOfficialTibia() return G.currentRsa == CIPSOFT_RSA end
 
-function g_game.getSupportedClients() return {1264} end
+function g_game.getSupportedClients() return {1271} end
 
 -- The client version and protocol version where
 -- unsynchronized for some releases, not sure if this

--- a/modules/gamelib/market.lua
+++ b/modules/gamelib/market.lua
@@ -120,11 +120,15 @@ MarketItemDescription = {
     Charges = 13,
     WeaponName = 14,
     Weight = 15,
-    Slot = 16
+    MagicShieldCapacity = 16,
+    Cleave = 17,
+    DamageReflection = 18,
+    PerfectShot = 19,
+    ImbuingSlots = 20
 }
 
 MarketItemDescription.First = MarketItemDescription.Armor
-MarketItemDescription.Last = MarketItemDescription.Slot
+MarketItemDescription.Last = MarketItemDescription.ImbuingSlots
 
 MarketItemDescriptionStrings = {
     [1] = 'Armor',
@@ -142,7 +146,11 @@ MarketItemDescriptionStrings = {
     [13] = 'Charges',
     [14] = 'Weapon Type',
     [15] = 'Weight',
-    [16] = 'Slot'
+    [16] = 'Magic Shield Capacity',
+    [17] = 'Cleave',
+    [18] = 'Damage Reflection',
+    [19] = 'Perfect Shot',
+    [20] = 'Imbuing Slots'
 }
 
 function getMarketDescriptionName(id)

--- a/modules/gamelib/protocol.lua
+++ b/modules/gamelib/protocol.lua
@@ -91,6 +91,7 @@ GameServerOpcodes = {
     GameServerCoinBalance = 223, -- 1080
     GameServerStoreError = 224, -- 1080
     GameServerRequestPurchaseData = 225, -- 1080
+    GameServerSendResourceBalance = 238, -- 1264
     GameServerQuestLog = 240,
     GameServerQuestLine = 241,
     GameServerCoinBalanceUpdating = 242, -- 1080

--- a/modules/gamelib/protocollogin.lua
+++ b/modules/gamelib/protocollogin.lua
@@ -64,13 +64,9 @@ function ProtocolLogin:sendLoginPacket()
     msg:addU32(xteaKey[4])
 
     msg:addString(self.accountName)
-
     msg:addString(self.accountPassword)
-
-    if self.getLoginExtendedData then
-        local data = self:getLoginExtendedData()
-        msg:addString(data)
-    end
+	msg:addString("")
+	msg:addString(math.floor(os.time() / 30))
 
     local paddingBytes = g_crypt.rsaGetSize() - (msg:getMessageSize() - offset)
     assert(paddingBytes >= 0)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -34,7 +34,7 @@
 #include <client/thing/text/statictext.h>
 #include <client/map/tile.h>
 
-const uint16_t CLIENT_VERSION = 1264;
+const uint16_t CLIENT_VERSION = 1271;
 
 Game g_game;
 

--- a/src/client/protocol/protocolgameparse.cpp
+++ b/src/client/protocol/protocolgameparse.cpp
@@ -1478,17 +1478,19 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg)
 
 void ProtocolGame::parsePlayerSkills(const InputMessagePtr& msg)
 {
-    const uint16_t magicLevel = msg->getU16(),
-        baseMagicLevel = msg->getU16(),
-        magicLevelPercent = msg->getU16();
+	const uint16_t magicLevel = msg->getU16();
+	const uint16_t baseMagicLevel = msg->getU16();
+	msg->getU16(); // base + loyalty bonus (?)
+	const uint16_t magicLevelPercent = msg->getU16();
 
     m_localPlayer->setMagicLevel(magicLevel, magicLevelPercent);
     m_localPlayer->setBaseMagicLevel(baseMagicLevel);
 
     for(uint8_t skill = Otc::SKILL_FIRST; skill <= Otc::SKILL_FISHING; ++skill) {
-        const uint16_t level = msg->getU16(),
-            baseLevel = msg->getU16(),
-            levelPercent = msg->getU16();
+				const uint16_t level = msg->getU16();
+				const uint16_t baseLevel = msg->getU16();
+				msg->getU16(); // base + loyalty bonus (?)
+				const uint16_t levelPercent = msg->getU16();
 
         m_localPlayer->setSkill(static_cast<Otc::skills_t>(skill), level, levelPercent);
         m_localPlayer->setBaseSkill(static_cast<Otc::skills_t>(skill), baseLevel);
@@ -2405,13 +2407,13 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, uint16 id)
     if(item->isStackable() || item->isSplash() || item->isFluidContainer() || item->isChargeable())
         item->setCountOrSubType(msg->getU8());
     else if(item->isContainer()) {
-        /*uint8 hasQuickLootFlags = msg->getU8();
+        uint8 hasQuickLootFlags = msg->getU8();
         if(hasQuickLootFlags)
             msg->getU32(); // quick loot flags
 
         uint8 hasQuiverAmmoCount = msg->getU8();
         if(hasQuiverAmmoCount)
-            msg->getU32(); // ammoTotal*/
+            msg->getU32(); // ammoTotal
     }
 
     // Impl Podium


### PR DESCRIPTION
**BREAKS COMPATIBILTIY WITH CANARY**
reason: adds two extra strings for "token" and "timestamp" TFS originally had
(to make it compatible with Canary after updating it to 12.72, just merge this without protocollogin.lua)

### Notes
- market needs update to handle new bytes
- only simple tests were performed, very likely to desync in unexpected situations
- **login method:** legacy (like 10.98, no web service)
- checksum mode: adler32