### PR TITLE
camera problem

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -119,7 +119,9 @@ void LocalPlayer::cancelWalk(Otc::Direction direction)
     // only cancel client side walks
     if(m_walking && m_preWalking)
         stopWalk();
-
+    
+    g_map.notificateCameraMove(m_walkOffset); 
+    
     lockWalk();
     retryAutoWalk();
 


### PR DESCRIPTION
sometimes there is a problem with the camera if player (local) enters on sqm where a creature enters (the server responds with 'GameServerCancelWalk') and our character is not in center of screen or camera is moved ~ 15px;