### PR TITLE
Adding upstream commit hash in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #### :heart:  If you are interested in supporting the project, go to this [link](https://www.paypal.com/donate/?business=CV9D5JF8E46LY&no_recurring=0&item_name=Thank+you+very+much+for+your+donation.&currency_code=BRL), any value is great help, thank you.
 
-### Based on [edubart/otclient](https://github.com/edubart/otclient) Rev: 2.758
+### Based on [edubart/otclient](https://github.com/edubart/otclient) Rev: [2.758](https://github.com/edubart/otclient/commit/45afb65b90284ce70f328733715043860186bf50)
 
 
 ### Features


### PR DESCRIPTION
The commit number can potentially change if upstream merges an old PR, so its nice to specify exactly which commit hash we are based on.