### PR TITLE
Show only available client versions in entergame window

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -140,9 +140,24 @@ function EnterGame.init()
     enterGame:getChildById('autoLoginBox'):setChecked(autologin)
     enterGame:getChildById('stayLoggedBox'):setChecked(stayLogged)
 
+    local installedClients = {}
+    for _, dirItem in ipairs(g_resources.listDirectoryFiles('/data/things/')) do
+        if tonumber(dirItem) ~= nil then
+            installedClients[dirItem] = true
+        end
+    end
     clientBox = enterGame:getChildById('clientComboBox')
     for _, proto in pairs(g_game.getSupportedClients()) do
-        clientBox:addOption(proto)
+        local proto_str = tostring(proto)
+        if installedClients[proto_str] then
+            installedClients[proto_str] = nil
+            clientBox:addOption(proto)
+        end
+    end
+    for proto_str, status in pairs(installedClients) do
+        if status == true then
+            print(string.format("Warning: %s recognized as an installed client, but not supported.", proto_str))
+        end
     end
     clientBox:setCurrentOption(clientVersion)
 

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -141,15 +141,17 @@ function EnterGame.init()
     enterGame:getChildById('stayLoggedBox'):setChecked(stayLogged)
 
     local installedClients = {}
+    local installed_qty = 0
     for _, dirItem in ipairs(g_resources.listDirectoryFiles('/data/things/')) do
         if tonumber(dirItem) ~= nil then
             installedClients[dirItem] = true
+            installed_qty = installed_qty + 1
         end
     end
     clientBox = enterGame:getChildById('clientComboBox')
     for _, proto in pairs(g_game.getSupportedClients()) do
         local proto_str = tostring(proto)
-        if installedClients[proto_str] then
+        if installedClients[proto_str] or installed_qty == 0 then
             installedClients[proto_str] = nil
             clientBox:addOption(proto)
         end

--- a/modules/game_things/things.lua
+++ b/modules/game_things/things.lua
@@ -22,19 +22,19 @@ function load()
 
   local datPath, sprPath
   if filename then
-    datPath = resolvepath('/things/' .. filename)
-    sprPath = resolvepath('/things/' .. filename)
+    datPath = resolvepath('/data/things/' .. filename)
+    sprPath = resolvepath('/data/things/' .. filename)
   else
-    datPath = resolvepath('/things/' .. version .. '/Tibia')
-    sprPath = resolvepath('/things/' .. version .. '/Tibia')
+    datPath = resolvepath('/data/things/' .. version .. '/Tibia')
+    sprPath = resolvepath('/data/things/' .. version .. '/Tibia')
   end
 
   local errorMessage = ''
   if not g_things.loadDat(datPath) then
-    errorMessage = errorMessage .. tr("Unable to load dat file, please place a valid dat in '%s'", datPath) .. '\n'
+    errorMessage = errorMessage .. tr("Unable to load dat file, please place a valid dat in '%s.dat'", datPath) .. '\n'
   end
   if not g_sprites.loadSpr(sprPath) then
-    errorMessage = errorMessage .. tr("Unable to load spr file, please place a valid spr in '%s'", sprPath)
+    errorMessage = errorMessage .. tr("Unable to load spr file, please place a valid spr in '%s.spr'", sprPath)
   end
 
   loaded = (errorMessage:len() == 0)


### PR DESCRIPTION
If you have added a client to `data/things/` directory that is not a supported client, it will print a warning to the terminal:
![image](https://user-images.githubusercontent.com/1552144/152577083-d850e36d-7871-4c38-84c0-21fad89e1954.png)

When you select a client version, it will only show alternatives that exist, and is supported. So you dont have to scroll and pick from a massive list, when you only have a couple protocols installed.

![image](https://user-images.githubusercontent.com/1552144/152577348-0960c2c2-7f81-4f1e-a623-65dc5c141d56.png)

Which makes it much friendlier to use when you are jumping back and forth between protocols. Since I often engage with TFS 1.4, 1.5 and Nekiro's downports I often have to change the protocol when testing and reviewing pull requests.