### PR TITLE
Fix text overflow in NPC trade window

### DIFF
--- a/modules/game_npctrade/npctrade.otui
+++ b/modules/game_npctrade/npctrade.otui
@@ -9,7 +9,7 @@ NPCItemBox < UICheckBox
   border-color: #000000
   color: #aaaaaa
   text-align: center
-  text-offset: 0 30
+  text-offset: 0 20
   @onCheckChange: modules.game_npctrade.onItemBoxChecked(self)
 
   Item
@@ -85,7 +85,7 @@ MainWindow
       margin-right: 5
       layout:
         type: grid
-        cell-size: 160 90
+        cell-size: 160 95
         flow: true
         auto-spacing: true
 


### PR DESCRIPTION
The text part showing price of an item would overflow its assigned cell due to text-offset and cell-size. Adjusted the values slightly so they fit together much better. 

## Before:
![image](https://user-images.githubusercontent.com/1552144/152626186-493ef02a-4ff7-4373-8874-ad9bc6112769.png)

## After:
![image](https://user-images.githubusercontent.com/1552144/152626194-4625c403-4a62-46b6-90eb-bb7be9899d96.png)
