### PR TITLE
[Protobuf] Autogenerate proto compileds when building

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -128,7 +128,6 @@ set(framework_SOURCES ${framework_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/platform/platform.h
 )
 
-
 if(NOT MSVC)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/luafunctions.cpp
                                 PROPERTIES LANGUAGE CXX COMPILE_FLAGS "-g0 -Os")
@@ -243,27 +242,31 @@ set(framework_INCLUDE_DIRS ${framework_INCLUDE_DIRS}
 )
 
 # protobuf
-set(protobuf_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.cc
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.h
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.cc
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.h
-)
-set(framework_SOURCES ${framework_SOURCES} ${protobuf_SOURCES})
-
 if(NOT WIN32)
     set(protobuf_PATH ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto)
-    set(protobuf_FILES
-        ${protobuf_PATH}/appearances.proto
-        ${protobuf_PATH}/shared.proto
+    set(protobuf_MODULES
+        appearances
+        shared
     )
 
-    add_custom_command(
-        OUTPUT ${protobuf_SOURCES}
-        DEPENDS ${protobuf_FILES}
-        COMMAND protoc -I ${protobuf_PATH} --cpp_out=${protobuf_PATH}/../ ${protobuf_FILES}
-        WORKING_DIRECTORY ${PROTO_PATH}
-    )
+    foreach(protobuf_FILENAME ${protobuf_MODULES})
+
+        set(protobuf_SOURCES
+            ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.cc
+            ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.h
+        )
+
+        set(framework_SOURCES ${framework_SOURCES} ${protobuf_SOURCES})
+
+        add_custom_command(
+            OUTPUT ${protobuf_SOURCES}
+            DEPENDS ${protobuf_PATH}/${protobuf_FILENAME}.proto
+            COMMAND protoc --cpp_out=../ ${protobuf_FILENAME}.proto
+            WORKING_DIRECTORY ${protobuf_PATH}
+            COMMENT "Compiling ${protobuf_FILENAME}.proto"
+        )
+
+    endforeach()
 endif()
 
 find_package(OpenSSL QUIET)

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -242,22 +242,22 @@ set(framework_INCLUDE_DIRS ${framework_INCLUDE_DIRS}
 )
 
 # protobuf
-if(NOT WIN32)
-    set(protobuf_PATH ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto)
-    set(protobuf_MODULES
-        appearances
-        shared
+set(protobuf_PATH ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto)
+set(protobuf_MODULES
+    appearances
+    shared
+)
+
+foreach(protobuf_FILENAME ${protobuf_MODULES})
+
+    set(protobuf_SOURCES
+        ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.cc
+        ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.h
     )
 
-    foreach(protobuf_FILENAME ${protobuf_MODULES})
+    set(framework_SOURCES ${framework_SOURCES} ${protobuf_SOURCES})
 
-        set(protobuf_SOURCES
-            ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.cc
-            ${CMAKE_CURRENT_LIST_DIR}/protobuf/${protobuf_FILENAME}.pb.h
-        )
-
-        set(framework_SOURCES ${framework_SOURCES} ${protobuf_SOURCES})
-
+    if(NOT WIN32)
         add_custom_command(
             OUTPUT ${protobuf_SOURCES}
             DEPENDS ${protobuf_PATH}/${protobuf_FILENAME}.proto
@@ -265,9 +265,9 @@ if(NOT WIN32)
             WORKING_DIRECTORY ${protobuf_PATH}
             COMMENT "Compiling ${protobuf_FILENAME}.proto"
         )
+    endif()
 
-    endforeach()
-endif()
+endforeach()
 
 find_package(OpenSSL QUIET)
 

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -126,13 +126,8 @@ set(framework_SOURCES ${framework_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/platform/unixplatform.cpp
     ${CMAKE_CURRENT_LIST_DIR}/platform/platform.cpp
     ${CMAKE_CURRENT_LIST_DIR}/platform/platform.h
-
-    # protobuf
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.cc
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.h
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.cc
-    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.h
 )
+
 
 if(NOT MSVC)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/luafunctions.cpp
@@ -247,12 +242,27 @@ set(framework_INCLUDE_DIRS ${framework_INCLUDE_DIRS}
     ${NLOHMANN_JSON_INCLUDE_DIR}
 )
 
-# protobuf proto compiler
+# protobuf
+set(protobuf_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.cc
+    ${CMAKE_CURRENT_LIST_DIR}/protobuf/appearances.pb.h
+    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.cc
+    ${CMAKE_CURRENT_LIST_DIR}/protobuf/shared.pb.h
+)
+set(framework_SOURCES ${framework_SOURCES} ${protobuf_SOURCES})
+
 if(NOT WIN32)
-    set(proto_FILES appearances.proto shared.proto)
-    execute_process(
-        COMMAND protoc --cpp_out=../ ${proto_FILES}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto/
+    set(protobuf_PATH ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto)
+    set(protobuf_FILES
+        ${protobuf_PATH}/appearances.proto
+        ${protobuf_PATH}/shared.proto
+    )
+
+    add_custom_command(
+        OUTPUT ${protobuf_SOURCES}
+        DEPENDS ${protobuf_FILES}
+        COMMAND protoc -I ${protobuf_PATH} --cpp_out=${protobuf_PATH}/../ ${protobuf_FILES}
+        WORKING_DIRECTORY ${PROTO_PATH}
     )
 endif()
 

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -247,6 +247,15 @@ set(framework_INCLUDE_DIRS ${framework_INCLUDE_DIRS}
     ${NLOHMANN_JSON_INCLUDE_DIR}
 )
 
+# protobuf proto compiler
+if(NOT WIN32)
+    set(proto_FILES appearances.proto shared.proto)
+    execute_process(
+        COMMAND protoc --cpp_out=../ ${proto_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/protobuf/proto/
+    )
+endif()
+
 find_package(OpenSSL QUIET)
 
 if(NOT OPENSSL_FOUND)


### PR DESCRIPTION
This pull request serves like a continuation of #213.

The current version of the compiled proto files are compiled by protobuf v.3.18.0
https://github.com/mehah/otclient/blob/703b2f663e35785f6dd4a6dc62b195bdb3981c15/src/framework/protobuf/shared.pb.h#L11-L20

This means that, if vcpkg updates its protobuf library, or you have an updated version of protobuf, the code will not compile unless you execute any of these files:
[Windows - generate.bat](https://github.com/mehah/otclient/blob/main/src/framework/protobuf/proto/generate.bat)
[Linux - generate.sh](https://github.com/mehah/otclient/blob/main/src/framework/protobuf/proto/generate.sh)

This pull request is to try to prevent this step and make it automatic.