### PR TITLE
Sound pitch patch

### DIFF
--- a/src/framework/sound/soundchannel.cpp
+++ b/src/framework/sound/soundchannel.cpp
@@ -51,11 +51,11 @@ void SoundChannel::stop(float fadetime)
     }
 }
 
-void SoundChannel::enqueue(const std::string& filename, float fadetime, float gain)
+void SoundChannel::enqueue(const std::string& filename, float fadetime, float gain, float pitch)
 {
     if (gain == 0)
         gain = 1.0f;
-    m_queue.push_back(QueueEntry{ g_sounds.resolveSoundFile(filename), fadetime, gain });
+    m_queue.push_back(QueueEntry{ g_sounds.resolveSoundFile(filename), fadetime, gain, pitch });
 
     std::shuffle(m_queue.begin(), m_queue.end(), std::mt19937(std::random_device()()));
     //update();
@@ -70,7 +70,7 @@ void SoundChannel::update()
         const QueueEntry entry = m_queue.front();
         m_queue.pop_front();
         m_queue.push_back(entry);
-        play(entry.filename, entry.fadetime, entry.gain);
+        play(entry.filename, entry.fadetime, entry.gain, entry.pitch);
     }
 }
 

--- a/src/framework/sound/soundchannel.h
+++ b/src/framework/sound/soundchannel.h
@@ -33,7 +33,7 @@ public:
 
     SoundSourcePtr play(const std::string& filename, float fadetime = 0, float gain = 1.0f, float pitch = 1.0f);
     void stop(float fadetime = 0);
-    void enqueue(const std::string& filename, float fadetime = 0, float gain = 1.0f);
+    void enqueue(const std::string& filename, float fadetime = 0, float gain = 1.0f, float pitch = 1.0f);
     void enable() { setEnabled(true); }
     void disable() { setEnabled(false); }
 
@@ -55,6 +55,7 @@ private:
         std::string filename;
         float fadetime;
         float gain;
+        float pitch;
     };
     std::deque<QueueEntry> m_queue;
     SoundSourcePtr m_currentSource;

--- a/src/framework/sound/soundmanager.cpp
+++ b/src/framework/sound/soundmanager.cpp
@@ -175,7 +175,7 @@ SoundSourcePtr SoundManager::play(std::string filename, float fadetime, float ga
         gain = 1.0f;
 
     if (pitch == 0)
-        pitch == 1.0f;
+        pitch = 1.0f;
 
     filename = resolveSoundFile(filename);
     SoundSourcePtr soundSource = createSoundSource(filename);

--- a/src/framework/sound/soundmanager.cpp
+++ b/src/framework/sound/soundmanager.cpp
@@ -174,6 +174,9 @@ SoundSourcePtr SoundManager::play(std::string filename, float fadetime, float ga
     if (gain == 0)
         gain = 1.0f;
 
+    if (pitch == 0)
+        pitch == 1.0f;
+
     filename = resolveSoundFile(filename);
     SoundSourcePtr soundSource = createSoundSource(filename);
     if (!soundSource) {

--- a/src/framework/sound/soundmanager.h
+++ b/src/framework/sound/soundmanager.h
@@ -47,7 +47,7 @@ public:
     void stopAll();
 
     void preload(std::string filename);
-    SoundSourcePtr play(std::string filename, float fadetime = 0, float gain = 0, float pitch = 0);
+    SoundSourcePtr play(std::string filename, float fadetime = 0, float gain = 1.0f, float pitch = 1.0f);
     SoundChannelPtr getChannel(int channel);
 
     std::string resolveSoundFile(std::string file);


### PR DESCRIPTION
I added pitch to the soundchannel:enqueue() method of playing sound as a parameter for it as well. We found a small bug in the previous implementation, as the default was being 0 when none, should instead be 1. So this adds pitch to enque, and fixes use-case of not using pitch in play. 

