### PR TITLE
Fix linux build, improvement log of FileStream and fix windows cmake build

### DIFF
--- a/src/framework/core/filestream.cpp
+++ b/src/framework/core/filestream.cpp
@@ -227,7 +227,7 @@ uint64 FileStream::getU64()
 {
     uint64 v = 0;
     if (!m_caching) {
-        if (PHYSFS_readULE64(m_fileHandle, static_cast<PHYSFS_uint64*>(&v)) == 0)
+        if (PHYSFS_readULE64(m_fileHandle, (PHYSFS_uint64*)&v) == 0)
             throwError("read failed", true);
     } else {
         if (m_pos + 8 > m_data.size())
@@ -290,7 +290,7 @@ int64 FileStream::get64()
 {
     int64 v = 0;
     if (!m_caching) {
-        if (PHYSFS_readSLE64(m_fileHandle, static_cast<PHYSFS_sint64*>(&v)) == 0)
+        if (PHYSFS_readSLE64(m_fileHandle, (PHYSFS_sint64*)&v) == 0)
             throwError("read failed", true);
     } else {
         if (m_pos + 8 > m_data.size())
@@ -314,15 +314,15 @@ std::string FileStream::getString()
                 str = std::string(buffer, len);
         } else {
             if (m_pos + len > m_data.size()) {
-                throwError("read failed");
-                return nullptr;
+                throwError("[FileStream::getString] - Read failed");
+                return std::string();
             }
 
             str = std::string((char*)&m_data[m_pos], len);
             m_pos += len;
         }
     } else if (len != 0)
-        throwError("read failed because string is too big");
+        throwError("[FileStream::getString] - Read failed because string is too big");
     return str;
 }
 

--- a/src/framework/xml/tinyxml.cpp
+++ b/src/framework/xml/tinyxml.cpp
@@ -493,7 +493,7 @@ std::string TiXmlElement::Attribute(const std::string& name, int* i) const
 std::string TiXmlElement::Attribute(const std::string& name, double* d) const
 {
     const TiXmlAttribute* attrib = attributeSet.Find(name);
-    std::string result = nullptr;
+    std::string result = std::string();
 
     if (attrib) {
         result = attrib->ValueStr();


### PR DESCRIPTION
Fixed wrong "nullptr" to "string", string not accept nullptr, because is only for pointer (only break in cmake build)
Fixed linux build cast in the "FileStream"