### PR TITLE
Fixes the protocolgameparse error when you login with latest canary sources

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3227,7 +3227,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         {
             const uint8_t listSize = msg->getU8();
             for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonsters(msg);
+                getPreyMonster(msg);
             }
             break;
         }
@@ -3238,7 +3238,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
             msg->getU8(); // bonus grade
             const uint8_t listSize = msg->getU8();
             for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonsters(msg);
+                getPreyMonster(msg);
             }
             break;
         }


### PR DESCRIPTION
# Description

With latest canary sources, you get an error, protocolgameparse input eof reached, because the structure doesn't match what canary sources send. this makes the error go away so it can parse the rest of the player basic data.

## Behaviour
### **Actual**

Login and you get an error in terminal

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

No error message is presented, and the structure of the packet seems to match that of Canary sources.

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: Canary 1.3.29
  - Client: 12.86
  - Operating System:Windows

## Checklist

  - [ x] My code follows the style guidelines of this project
  - [ x] I have performed a self-review of my own code
  - [ x] I checked the PR checks reports
  - [ x] I have commented my code, particularly in hard-to-understand areas
  - [ x] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [ x] I have added tests that prove my fix is effective or that my feature works
