### PR TITLE
fixes login error for prey, which allows the rest of the player data to load

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3225,10 +3225,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         }
         case Otc::PREY_STATE_SELECTION:
         {
-            const uint8_t listSize = msg->getU8();
-            for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonster(msg);
-            }
+            getPreyMonsters(msg);
             break;
         }
         case Otc::PREY_STATE_SELECTION_CHANGE_MONSTER:
@@ -3236,10 +3233,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
             msg->getU8(); // bonus type
             msg->getU16(); // bonus value
             msg->getU8(); // bonus grade
-            const uint8_t listSize = msg->getU8();
-            for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonster(msg);
-            }
+            getPreyMonsters(msg);
             break;
         }
         case Otc::PREY_STATE_LIST_SELECTION:

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3227,7 +3227,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         {
             const uint8_t listSize = msg->getU8();
             for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonsters(msg);
+                getPreyMonster(msg);
             }
             break;
         }
@@ -3238,7 +3238,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
             msg->getU8(); // bonus grade
             const uint8_t listSize = msg->getU8();
             for (uint8_t i = 0; i < listSize; i++) {
-                getPreyMonsters(msg);
+                getPreyMonster(msg);
             }
             break;
         }


### PR DESCRIPTION
This makes the packet structure match Canary sources, so that the load basic player data function can continue past this point, which clears up some additional errors.

# Description

When you login, you get an error, input eof reached, which makes the client stop parsing the packet at that point, which makes additional errors occur.

## Behaviour
### **Actual**

Login and check terminal, you get an error, then when a creature comes onto your screen you get more errors.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

**Test Configuration**:

  - Server Version: Canary 1.3.30
  - Client: 12.86
  - Operating System: Windows

## Checklist

  - [x ] My code follows the style guidelines of this project
  - [ x] I have performed a self-review of my own code
  - [ x] I checked the PR checks reports
  - [ x] I have commented my code, particularly in hard-to-understand areas
  - [ x] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [ x] I have added tests that prove my fix is effective or that my feature works
