### PR TITLE
Fix area spells leaving a trail on minimap (mehah#344)

### DIFF
--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -93,7 +93,9 @@ void Map::notificateTileUpdate(const Position& pos, const ThingPtr& thing, const
         mapView->onTileUpdate(pos, thing, operation);
     }
 
-    g_minimap.updateTile(pos, getTile(pos));
+    if (thing && thing->isItem()) {
+        g_minimap.updateTile(pos, getTile(pos));
+    }
 }
 
 void Map::clean()


### PR DESCRIPTION
# Description

Problem was as described in issue #344.

## Behaviour
### **Actual**

Spam some spell (e.g. exevo gran mas vis) and start moving. Minimap will proceed to leave a black trail.

### **Expected**

Normal minimap behavior

## Fixes

\#344

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Fix has been tested as described in issue #344 

**Test Configuration**:

  - Server Version: TFS 1.4
  - Client: mehah/otclient
  - Operating System: Manjaro Unstable

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
## Credits
WeAreTibia team
