### PR TITLE
Fix walk animation in old outfits

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -481,8 +481,10 @@ void Creature::updateWalkAnimation()
         return;
 
     int footAnimPhases = m_outfit.hasMount() ? m_mountType->getAnimationPhases() : getAnimationPhases();
-    if (!g_game.getFeature(Otc::GameItemAnimationPhase))
-        --footAnimPhases;
+    if (!g_game.getFeature(Otc::GameItemAnimationPhase)) {
+        if (footAnimPhases > 2)
+            --footAnimPhases;
+    }
 
     // looktype has no animations
     if (footAnimPhases == 0)

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -481,9 +481,8 @@ void Creature::updateWalkAnimation()
         return;
 
     int footAnimPhases = m_outfit.hasMount() ? m_mountType->getAnimationPhases() : getAnimationPhases();
-    if (!g_game.getFeature(Otc::GameItemAnimationPhase)) {
-        if (footAnimPhases > 2)
-            --footAnimPhases;
+    if (!g_game.getFeature(Otc::GameItemAnimationPhase) && footAnimPhases > 2) {
+        --footAnimPhases;
     }
 
     // looktype has no animations


### PR DESCRIPTION
Fix walk animation in outfits with less then 8 animations (version 12.8x+)

Demonstration of the problem:
https://i.imgur.com/0y1yAW6.mp4

Demonstration of the fix:
![GIF 10-12-2022 21-57-46](https://user-images.githubusercontent.com/7372287/206881461-04415f38-7d74-47a8-97b5-75e92277faff.gif)
