### PR TITLE
feat: add support for num_plays in animatedTexture (.aPNG) files

### DIFF
--- a/src/framework/graphics/animatedtexture.cpp
+++ b/src/framework/graphics/animatedtexture.cpp
@@ -67,15 +67,31 @@ void AnimatedTexture::setRepeat(bool repeat)
     m_repeat = repeat;
     for (const TexturePtr& frame : m_frames)
         frame->setRepeat(repeat);
+
+    if (repeat)
+        startAnimation();
+}
+
+void AnimatedTexture::startAnimation()
+{
+    m_animTimer.restart();
+    m_currentFrame = 0;
+    m_id = m_frames[m_currentFrame]->getId();
 }
 
 void AnimatedTexture::updateAnimation()
 {
+    if (!m_animTimer.running())
+        return;
+
     if (m_animTimer.ticksElapsed() < m_framesDelay[m_currentFrame])
         return;
 
-    if (++m_currentFrame >= m_frames.size())
+    if (++m_currentFrame >= m_frames.size()) {
         m_currentFrame = 0;
+        if (!m_repeat)
+            m_animTimer.stop();
+    }
 
     const auto& txt = m_frames[m_currentFrame];
     txt->create();

--- a/src/framework/graphics/animatedtexture.cpp
+++ b/src/framework/graphics/animatedtexture.cpp
@@ -28,7 +28,7 @@
 
 #include <utility>
 
-AnimatedTexture::AnimatedTexture(const Size& size, const std::vector<ImagePtr>& frames, std::vector<int> framesDelay, bool buildMipmaps, bool compress)
+AnimatedTexture::AnimatedTexture(const Size& size, const std::vector<ImagePtr>& frames, std::vector<uint16_t> framesDelay, uint16_t numPlays, bool buildMipmaps, bool compress)
 {
     if (!setupSize(size))
         return;
@@ -39,12 +39,10 @@ AnimatedTexture::AnimatedTexture(const Size& size, const std::vector<ImagePtr>& 
 
     m_framesDelay = std::move(framesDelay);
     m_hasMipmaps = buildMipmaps;
+    m_numPlays = numPlays;
     m_id = m_frames[0]->getId();
     m_animTimer.restart();
 }
-
-AnimatedTexture::~AnimatedTexture()
-= default;
 
 void AnimatedTexture::buildHardwareMipmaps()
 {
@@ -67,19 +65,9 @@ void AnimatedTexture::setRepeat(bool repeat)
     m_repeat = repeat;
     for (const TexturePtr& frame : m_frames)
         frame->setRepeat(repeat);
-
-    if (repeat)
-        startAnimation();
 }
 
-void AnimatedTexture::startAnimation()
-{
-    m_animTimer.restart();
-    m_currentFrame = 0;
-    m_id = m_frames[m_currentFrame]->getId();
-}
-
-void AnimatedTexture::updateAnimation()
+void AnimatedTexture::update()
 {
     if (!m_animTimer.running())
         return;
@@ -87,9 +75,11 @@ void AnimatedTexture::updateAnimation()
     if (m_animTimer.ticksElapsed() < m_framesDelay[m_currentFrame])
         return;
 
+    m_animTimer.restart(); // it is necessary to restart the animation before stop()
+
     if (++m_currentFrame >= m_frames.size()) {
         m_currentFrame = 0;
-        if (!m_repeat)
+        if (m_numPlays > 0 && ++m_currentPlay == m_numPlays)
             m_animTimer.stop();
     }
 
@@ -97,7 +87,6 @@ void AnimatedTexture::updateAnimation()
     txt->create();
 
     m_id = txt->getId();
-    m_animTimer.restart();
 
     g_app.repaint();
 }

--- a/src/framework/graphics/animatedtexture.h
+++ b/src/framework/graphics/animatedtexture.h
@@ -37,6 +37,7 @@ public:
     void setRepeat(bool repeat) override;
 
     void updateAnimation();
+    void startAnimation();
 
     bool isAnimatedTexture() const override { return true; }
 

--- a/src/framework/graphics/animatedtexture.h
+++ b/src/framework/graphics/animatedtexture.h
@@ -28,22 +28,25 @@
 class AnimatedTexture : public Texture
 {
 public:
-    AnimatedTexture(const Size& size, const std::vector<ImagePtr>& frames, std::vector<int> framesDelay, bool buildMipmaps = false, bool compress = false);
-    ~AnimatedTexture() override;
+    AnimatedTexture(const Size& size, const std::vector<ImagePtr>& frames, std::vector<uint16_t> framesDelay, uint16_t numPlays, bool buildMipmaps = false, bool compress = false);
+    ~AnimatedTexture() override = default;
 
     void buildHardwareMipmaps() override;
 
     void setSmooth(bool smooth) override;
     void setRepeat(bool repeat) override;
 
-    void updateAnimation();
-    void startAnimation();
+    void update();
+    void restart() { m_animTimer.restart(); m_currentPlay = 0; }
 
     bool isAnimatedTexture() const override { return true; }
 
 private:
     std::vector<TexturePtr> m_frames;
-    std::vector<int> m_framesDelay;
+    std::vector<uint16_t> m_framesDelay;
     uint32_t m_currentFrame{ 0 };
+    uint32_t m_currentPlay{ 0 };
+    uint32_t m_numPlays{ 0 };
+
     Timer m_animTimer;
 };

--- a/src/framework/graphics/apngloader.h
+++ b/src/framework/graphics/apngloader.h
@@ -35,7 +35,7 @@ struct apng_data
     uint8_t coltype;
     uint32_t num_frames;
     uint32_t num_plays;
-    unsigned short* frames_delay; // each frame delay in ms
+    uint16_t* frames_delay; // each frame delay in ms
 };
 
 // returns -1 on error, 0 on success

--- a/src/framework/graphics/texture.h
+++ b/src/framework/graphics/texture.h
@@ -85,7 +85,7 @@ protected:
     bool m_hasMipmaps{ false };
     bool m_smooth{ false };
     bool m_upsideDown{ false };
-    bool m_repeat{ true };
+    bool m_repeat{ false };
     bool m_compress{ false };
     bool m_buildMipmaps{ false };
 };

--- a/src/framework/graphics/texture.h
+++ b/src/framework/graphics/texture.h
@@ -85,7 +85,7 @@ protected:
     bool m_hasMipmaps{ false };
     bool m_smooth{ false };
     bool m_upsideDown{ false };
-    bool m_repeat{ false };
+    bool m_repeat{ true };
     bool m_compress{ false };
     bool m_buildMipmaps{ false };
 };

--- a/src/framework/graphics/texturemanager.cpp
+++ b/src/framework/graphics/texturemanager.cpp
@@ -59,7 +59,7 @@ void TextureManager::poll() const
     lastUpdate = now;
 
     for (const AnimatedTexturePtr& animatedTexture : m_animatedTextures)
-        animatedTexture->updateAnimation();
+        animatedTexture->update();
 }
 
 void TextureManager::clearCache()
@@ -141,33 +141,25 @@ TexturePtr TextureManager::loadTexture(std::stringstream& file)
 {
     TexturePtr texture;
 
-    if (apng_data apng; load_apng(file, &apng) == 0) {
+    apng_data apng;
+    if (load_apng(file, &apng) == 0) {
         const Size imageSize(apng.width, apng.height);
         if (apng.num_frames > 1) { // animated texture
             std::vector<ImagePtr> frames;
-            std::vector<int> framesDelay;
+            std::vector<uint16_t> framesDelay;
+            for (uint32_t i = 0; i < apng.num_frames; ++i) {
+                uint8_t* frameData = apng.pdata + ((apng.first_frame + i) * imageSize.area() * apng.bpp);
 
-            const uint32_t plays = std::max<uint32_t>(1, apng.num_plays);
-            for (uint_fast32_t j = 0; ++j <= plays;) {
-                for (uint_fast32_t i = 0; i < apng.num_frames; ++i) {
-                    uint8_t* frameData = apng.pdata + ((apng.first_frame + i) * imageSize.area() * apng.bpp);
-                    int frameDelay = apng.frames_delay[i];
-
-                    framesDelay.push_back(frameDelay);
-                    frames.emplace_back(std::make_shared<Image>(imageSize, apng.bpp, frameData));
-                }
+                framesDelay.push_back(apng.frames_delay[i]);
+                frames.emplace_back(std::make_shared<Image>(imageSize, apng.bpp, frameData));
             }
 
-            const auto& animatedTexture = std::make_shared<AnimatedTexture>(imageSize, frames, framesDelay);
-            animatedTexture->setRepeat(apng.num_plays == 0);
-
-            m_animatedTextures.emplace_back(animatedTexture);
-            texture = animatedTexture;
+            const auto& animatedTexture = std::make_shared<AnimatedTexture>(imageSize, frames, framesDelay, apng.num_plays);
+            texture = m_animatedTextures.emplace_back(animatedTexture);
         } else {
             const auto& image = std::make_shared<Image>(imageSize, apng.bpp, apng.pdata);
             texture = std::make_shared<Texture>(image, false, false);
         }
-
         free_apng(&apng);
     }
 

--- a/src/framework/graphics/texturemanager.cpp
+++ b/src/framework/graphics/texturemanager.cpp
@@ -146,20 +146,28 @@ TexturePtr TextureManager::loadTexture(std::stringstream& file)
         if (apng.num_frames > 1) { // animated texture
             std::vector<ImagePtr> frames;
             std::vector<int> framesDelay;
-            for (uint32_t i = 0; i < apng.num_frames; ++i) {
-                uint8_t* frameData = apng.pdata + ((apng.first_frame + i) * imageSize.area() * apng.bpp);
-                int frameDelay = apng.frames_delay[i];
 
-                framesDelay.push_back(frameDelay);
-                frames.emplace_back(std::make_shared<Image>(imageSize, apng.bpp, frameData));
+            const uint32_t plays = std::max<uint32_t>(1, apng.num_plays);
+            for (uint_fast32_t j = 0; ++j <= plays;) {
+                for (uint_fast32_t i = 0; i < apng.num_frames; ++i) {
+                    uint8_t* frameData = apng.pdata + ((apng.first_frame + i) * imageSize.area() * apng.bpp);
+                    int frameDelay = apng.frames_delay[i];
+
+                    framesDelay.push_back(frameDelay);
+                    frames.emplace_back(std::make_shared<Image>(imageSize, apng.bpp, frameData));
+                }
             }
+
             const auto& animatedTexture = std::make_shared<AnimatedTexture>(imageSize, frames, framesDelay);
+            animatedTexture->setRepeat(apng.num_plays == 0);
+
             m_animatedTextures.emplace_back(animatedTexture);
             texture = animatedTexture;
         } else {
             const auto& image = std::make_shared<Image>(imageSize, apng.bpp, apng.pdata);
             texture = std::make_shared<Texture>(image, false, false);
         }
+
         free_apng(&apng);
     }
 

--- a/src/framework/ui/uiwidgetimage.cpp
+++ b/src/framework/ui/uiwidgetimage.cpp
@@ -22,6 +22,7 @@
 
 #include <framework/core/eventdispatcher.h>
 #include <framework/graphics/painter.h>
+#include <framework/graphics/animatedtexture.h>
 #include <framework/graphics/texture.h>
 #include <framework/graphics/texturemanager.h>
 #include "uiwidget.h"
@@ -181,8 +182,11 @@ void UIWidget::setImageSource(const std::string_view source)
     }
 
     m_imageTexture = g_textures.getTexture(m_imageSource = source);
+    if (m_imageTexture->isAnimatedTexture())
+        std::static_pointer_cast<AnimatedTexture>(m_imageTexture)->startAnimation();
+
     if (!m_rect.isValid() || m_imageAutoResize) {
-        const Size imageSize = m_imageTexture->getSize();
+        const auto& imageSize = m_imageTexture->getSize();
 
         Size size = getSize();
         if (size.width() <= 0 || m_imageAutoResize)

--- a/src/framework/ui/uiwidgetimage.cpp
+++ b/src/framework/ui/uiwidgetimage.cpp
@@ -183,7 +183,7 @@ void UIWidget::setImageSource(const std::string_view source)
 
     m_imageTexture = g_textures.getTexture(m_imageSource = source);
     if (m_imageTexture->isAnimatedTexture())
-        std::static_pointer_cast<AnimatedTexture>(m_imageTexture)->startAnimation();
+        std::static_pointer_cast<AnimatedTexture>(m_imageTexture)->restart();
 
     if (!m_rect.isValid() || m_imageAutoResize) {
         const auto& imageSize = m_imageTexture->getSize();


### PR DESCRIPTION
Addition of new functionality to the software by introducing support for the 'num_plays' variable in animatedTexture (.aPNG) files. This variable determines the number of times an animation should loop, and was not previously supported by the software. This changes affect multiple files and include the addition of a new function, as well as modifications to existing functions, in order to fully implement the new feature. The new feature allows for greater flexibility in using animated textures, such as using them for effects on widgets in addition to just backgrounds.

Implementation of https://otland.net/threads/otclient-mehah-apng-num_plays-handler-animatedtexture-synchronous-when-plays-once.279765/

by [@FreshyPeshy](https://github.com/FreshyPeshy)
