### PR TITLE
Fix missing byte on change outfit

### DIFF
--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -757,6 +757,7 @@ void ProtocolGame::sendChangeOutfit(const Outfit& outfit)
 
     if (g_game.getClientVersion() >= 1281) {
         msg->addU16(0x00); //familiars
+        msg->addU8(0x00); //randomizeMount
     }
 
     send(msg);


### PR DESCRIPTION
# Description

Close connection on change outfit. Missing byte on change outfit.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Change outfit
  - [x] Change mount

**Test Configuration**:

  - Server Version: forgottenserver -> git hash 70df6acbc0024d8c4086d0ee1ba60111db5d8c33
  - Client: otclient_mehah -> git hash 6f453de8b8c26b3e96cc6f4372e9a6aedd0248d4
  - Operating System: Manjaro 22.0.0

