### PR TITLE
fix: added missing CMake module for asio library

### DIFF
--- a/cmake/Findasio.cmake
+++ b/cmake/Findasio.cmake
@@ -1,0 +1,8 @@
+find_path(ASIO_INCLUDE_DIR asio.hpp)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(asio DEFAULT_MSG ASIO_INCLUDE_DIR)
+
+add_library(asio::asio INTERFACE IMPORTED)
+target_include_directories(asio::asio INTERFACE "${ASIO_INCLUDE_DIR}")
+target_compile_definitions(asio::asio INTERFACE "ASIO_STANDALONE")


### PR DESCRIPTION
# Description

When Boost got removed in favor of standalone Asio, it stopped working on CMake because Asio is not one of the modules usually shipped with CMake (Boost is), thus it failed to configure. Adds a simple script to look for Asio and link as expected.

## Behaviour
### **Actual**

```
CMake Error at src/CMakeLists.txt:179 (find_package):
  By not providing "Findasio.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "asio", but
  CMake did not find one.

  Could not find a package configuration file provided by "asio" with any of
  the following names:

    asioConfig.cmake
    asio-config.cmake

  Add the installation prefix of "asio" to CMAKE_PREFIX_PATH or set
  "asio_DIR" to a directory containing one of the above files.  If "asio"
  provides a separate development package or SDK, be sure it has been
  installed.
```

### **Expected**

Asio is found and linked against.

## Fixes
fix #259
fix #295
but you closed it without fixing

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

N/A

**Test Configuration**:

  - Server Version: N/A
  - Client: latest commit
  - Operating System: Arch Linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
