### PR TITLE
fix: clang compilation for android build - added QueueEntry construct

### DIFF
--- a/src/framework/sound/soundchannel.h
+++ b/src/framework/sound/soundchannel.h
@@ -51,6 +51,8 @@ protected:
 private:
     struct QueueEntry
     {
+        QueueEntry(std::string fn, float ft, float g, float p) : filename(fn), fadetime(ft), gain(g), pitch(p) {};
+
         std::string filename;
         float fadetime;
         float gain;


### PR DESCRIPTION
# Description

Fixes compilation for clang (android build)