### PR TITLE
improve: Load init.lua from pref dir

### DIFF
--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -49,6 +49,7 @@ bool ResourceManager::discoverWorkDir(const std::string& existentFile)
 {
     // search for modules directory
     std::string possiblePaths[] = { g_platform.getCurrentDir(),
+                                    g_resources.getPrefDir(),
                                     g_resources.getBaseDir(),
                                     g_resources.getBaseDir() + "/game_data/",
                                     g_resources.getBaseDir() + "../",
@@ -384,6 +385,11 @@ std::string ResourceManager::getBaseDir()
 #else
     return PHYSFS_getBaseDir();
 #endif
+}
+
+std::string ResourceManager::getPrefDir() const
+{
+    return PHYSFS_getPrefDir("com.github.Mehah", g_app.getCompactName());
 }
 
 std::string ResourceManager::getUserDir()

--- a/src/framework/core/resourcemanager.h
+++ b/src/framework/core/resourcemanager.h
@@ -68,6 +68,7 @@ public:
     std::string getRealDir(const std::string& path);
     std::string getRealPath(const std::string& path);
     std::string getBaseDir();
+    std::string getPrefDir() const;
     std::string getUserDir();
     std::string getWriteDir() { return m_writeDir; }
     std::string getWorkDir() { return m_workDir; }


### PR DESCRIPTION
# Description

[See documentation about "pref dir"](https://man.archlinux.org/man/community/physfs/PHYSFS_getPrefDir.3.en#const_char_*_PHYSFS_getPrefDir_(const_char_*_org,_const_char_*_app))

This allows reading from the app-specific personal file directory. On Linux, this is inside `$HOME/.local/share`, and on Mac it is inside `/Users/bob/Library/Application Support`. This effectively allows otclient to be installed as a package, from the package manager (apt/dnf/pacman/flatpak/brew) which will install it to a read-only directory. In that scenario, neither the current directory nor the base directory (where the executable is located) are suitable for read/write configuration.

It does not affect current behavior and will still work for any current setup. It gives precedence to loading from the current directory.

This is a more correct

## Behaviour
### **Actual**

otclient tries to read files in the current directory, or where the executable is located, trying to find `init.lua`.

### **Expected**

It will try to load from a known location, regardless of where otclient is run from.

## Fixes

N/A

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

## How Has This Been Tested

I am making a Flathub package so that Linux users can install otclient easily without needing to install dependencies, and it runs in a sandbox, so there is absolutely no way of loading files from any of the current search locations. With this patch, I can store game data in a read/write directory so that the user/player can modify.

**Test Configuration**:

  - Server Version: N/A
  - Client: N/A
  - Operating System: N/A, but for me any Linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
