### PR TITLE
rework: remove client code from framework (fps & ASYNC_DISPATCHER_MAX_THREAD)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -164,6 +164,7 @@ void Game::processEnterGame()
 void Game::processGameStart()
 {
     m_online = true;
+    g_app.setTargetFps(60u);
 
     // synchronize fight modes with the server
     m_protocolGame->sendChangeFightModes(m_fightMode, m_chaseMode, m_safeFight, m_pvpMode);
@@ -191,6 +192,7 @@ void Game::processGameStart()
 void Game::processGameEnd()
 {
     m_online = false;
+    g_app.resetTargetFps();
     g_lua.callGlobalField("g_game", "onGameEnd");
 
     if (m_connectionFailWarned) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -164,7 +164,7 @@ void Game::processEnterGame()
 void Game::processGameStart()
 {
     m_online = true;
-    g_app.setTargetFps(60u);
+    g_app.resetTargetFps();
 
     // synchronize fight modes with the server
     m_protocolGame->sendChangeFightModes(m_fightMode, m_chaseMode, m_safeFight, m_pvpMode);
@@ -191,8 +191,10 @@ void Game::processGameStart()
 
 void Game::processGameEnd()
 {
+    // FPS fixed at 60 for when UI is rendering alone.
+    g_app.setTargetFps(60u);
+
     m_online = false;
-    g_app.resetTargetFps();
     g_lua.callGlobalField("g_game", "onGameEnd");
 
     if (m_connectionFailWarned) {

--- a/src/framework/core/adaptativeframecounter.cpp
+++ b/src/framework/core/adaptativeframecounter.cpp
@@ -26,7 +26,7 @@
 
 void AdaptativeFrameCounter::update()
 {
-    const uint8_t maxFps = m_targetFps == 0 ? m_maxFps : std::min<uint8_t>(m_maxFps, m_targetFps);
+    const uint8_t maxFps = m_targetFps == 0 ? m_maxFps : std::clamp<uint8_t>(m_targetFps, 1, std::max<uint8_t>(m_maxFps, m_targetFps));
     if (maxFps > 0) {
         const int32_t sleepPeriod = (getMaxPeriod(maxFps) - 1000) - m_timer.elapsed_micros();
         if (sleepPeriod > 0) stdext::microsleep(sleepPeriod);

--- a/src/framework/core/adaptativeframecounter.cpp
+++ b/src/framework/core/adaptativeframecounter.cpp
@@ -21,14 +21,12 @@
  */
 
 #include "adaptativeframecounter.h"
-#include <client/game.h>
 #include <framework/core/eventdispatcher.h>
 #include <framework/platform/platformwindow.h>
 
 void AdaptativeFrameCounter::update()
 {
-    // FPS 60 for foreground rendering alone
-    const uint8_t maxFps = g_game.isOnline() ? m_maxFps : 60u;
+    const uint8_t maxFps = m_targetFps == 0 ? m_maxFps : std::min<uint8_t>(m_maxFps, m_targetFps);
     if (maxFps > 0) {
         const int32_t sleepPeriod = (getMaxPeriod(maxFps) - 1000) - m_timer.elapsed_micros();
         if (sleepPeriod > 0) stdext::microsleep(sleepPeriod);

--- a/src/framework/core/adaptativeframecounter.h
+++ b/src/framework/core/adaptativeframecounter.h
@@ -37,13 +37,18 @@ public:
 
     uint16_t getFps() const { return m_fps; }
     uint8_t getMaxFps() const { return m_maxFps; }
+    uint8_t getTargetFps() const { return m_targetFps; }
 
     void setMaxFps(const uint16_t max) { m_maxFps = max; }
+    void setTargetFps(const uint16_t target) { m_targetFps = target; }
+
+    void resetTargetFps() { m_targetFps = 0; }
 
 private:
     uint32_t getMaxPeriod(uint16_t fps) const { return 1000000u / fps; }
 
     uint8_t m_maxFps{};
+    uint8_t m_targetFps{ 60u };
 
     uint16_t m_fps{};
     uint16_t m_fpsCount{};

--- a/src/framework/core/application.cpp
+++ b/src/framework/core/application.cpp
@@ -56,7 +56,7 @@ void exitSignalHandler(int sig)
     }
 }
 
-void Application::init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads)
+void Application::init(std::vector<std::string>& args, uint8_t asyncDispatchMaxThreads)
 {
     // capture exit signals
     signal(SIGTERM, exitSignalHandler);

--- a/src/framework/core/application.cpp
+++ b/src/framework/core/application.cpp
@@ -56,7 +56,7 @@ void exitSignalHandler(int sig)
     }
 }
 
-void Application::init(std::vector<std::string>& args)
+void Application::init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads)
 {
     // capture exit signals
     signal(SIGTERM, exitSignalHandler);
@@ -72,7 +72,7 @@ void Application::init(std::vector<std::string>& args)
     // process args encoding
     g_platform.init(args);
 
-    g_asyncDispatcher.init();
+    g_asyncDispatcher.init(asyncDispatchMaxThreads);
 
     std::string startupOptions;
     for (uint32_t i = 1; i < args.size(); ++i) {

--- a/src/framework/core/application.h
+++ b/src/framework/core/application.h
@@ -30,7 +30,7 @@ class Application
 public:
     virtual ~Application() = default;
 
-    virtual void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads);
+    virtual void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads = 0);
     virtual void deinit();
     virtual void terminate();
     virtual void run() = 0;

--- a/src/framework/core/application.h
+++ b/src/framework/core/application.h
@@ -30,7 +30,7 @@ class Application
 public:
     virtual ~Application() = default;
 
-    virtual void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads = 0);
+    virtual void init(std::vector<std::string>& args, uint8_t asyncDispatchMaxThreads = 0);
     virtual void deinit();
     virtual void terminate();
     virtual void run() = 0;

--- a/src/framework/core/application.h
+++ b/src/framework/core/application.h
@@ -30,7 +30,7 @@ class Application
 public:
     virtual ~Application() = default;
 
-    virtual void init(std::vector<std::string>& args);
+    virtual void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads);
     virtual void deinit();
     virtual void terminate();
     virtual void run() = 0;

--- a/src/framework/core/asyncdispatcher.cpp
+++ b/src/framework/core/asyncdispatcher.cpp
@@ -26,7 +26,7 @@
 
 AsyncDispatcher g_asyncDispatcher;
 
-void AsyncDispatcher::init(uint16_t maxThreads)
+void AsyncDispatcher::init(uint8_t maxThreads)
 {
     if (maxThreads != 0)
         m_maxThreads = maxThreads;

--- a/src/framework/core/asyncdispatcher.cpp
+++ b/src/framework/core/asyncdispatcher.cpp
@@ -23,14 +23,16 @@
 #include <algorithm>
 
 #include "asyncdispatcher.h"
-#include <client/config.h>
 
 AsyncDispatcher g_asyncDispatcher;
 
-void AsyncDispatcher::init()
+void AsyncDispatcher::init(uint16_t maxThreads)
 {
+    if (maxThreads != 0)
+        m_maxThreads = maxThreads;
+
     // -2 = Main Thread and Map Thread
-    int_fast8_t threads = std::clamp<int_fast8_t>(std::thread::hardware_concurrency() - 2, 1, ASYNC_DISPATCHER_MAX_THREAD);
+    int_fast8_t threads = std::clamp<int_fast8_t>(std::thread::hardware_concurrency() - 2, 1, m_maxThreads);
     for (; --threads >= 0;)
         spawn_thread();
 }

--- a/src/framework/core/asyncdispatcher.h
+++ b/src/framework/core/asyncdispatcher.h
@@ -28,7 +28,7 @@
 class AsyncDispatcher
 {
 public:
-    void init(uint16_t maxThreads = 0);
+    void init(uint8_t maxThreads = 0);
     void terminate();
 
     void spawn_thread();
@@ -60,7 +60,7 @@ private:
     std::mutex m_mutex;
     std::condition_variable m_condition;
     bool m_running{ false };
-    uint16_t m_maxThreads{ 6 };
+    uint8_t m_maxThreads{ 6 };
 };
 
 extern AsyncDispatcher g_asyncDispatcher;

--- a/src/framework/core/asyncdispatcher.h
+++ b/src/framework/core/asyncdispatcher.h
@@ -28,7 +28,7 @@
 class AsyncDispatcher
 {
 public:
-    void init();
+    void init(uint16_t maxThreads = 0);
     void terminate();
 
     void spawn_thread();
@@ -60,6 +60,7 @@ private:
     std::mutex m_mutex;
     std::condition_variable m_condition;
     bool m_running{ false };
+    uint16_t m_maxThreads{ 6 };
 };
 
 extern AsyncDispatcher g_asyncDispatcher;

--- a/src/framework/core/eventdispatcher.cpp
+++ b/src/framework/core/eventdispatcher.cpp
@@ -23,7 +23,6 @@
 #include "eventdispatcher.h"
 
 #include <framework/core/clock.h>
-#include <framework/core/graphicalapplication.h>
 #include "timer.h"
 
 EventDispatcher g_dispatcher, g_textDispatcher, g_mainDispatcher;

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -44,9 +44,9 @@
 
 GraphicalApplication g_app;
 
-void GraphicalApplication::init(std::vector<std::string>& args)
+void GraphicalApplication::init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads)
 {
-    Application::init(args);
+    Application::init(args, asyncDispatchMaxThreads);
 
     // setup platform window
     g_window.init();

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -44,7 +44,7 @@
 
 GraphicalApplication g_app;
 
-void GraphicalApplication::init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads)
+void GraphicalApplication::init(std::vector<std::string>& args, uint8_t asyncDispatchMaxThreads)
 {
     Application::init(args, asyncDispatchMaxThreads);
 

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -32,7 +32,7 @@
 class GraphicalApplication : public Application
 {
 public:
-    void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads) override;
+    void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads = 0) override;
     void deinit() override;
     void terminate() override;
     void run() override;

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -32,7 +32,7 @@
 class GraphicalApplication : public Application
 {
 public:
-    void init(std::vector<std::string>& args) override;
+    void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads) override;
     void deinit() override;
     void terminate() override;
     void run() override;
@@ -41,9 +41,13 @@ public:
     void close() override;
 
     void setMaxFps(uint16_t maxFps) { m_frameCounter.setMaxFps(maxFps); }
+    void setTargetFps(uint16_t targetFps) { m_frameCounter.setTargetFps(targetFps); }
 
     uint16_t getFps() { return m_frameCounter.getFps(); }
     uint8_t getMaxFps() { return m_frameCounter.getMaxFps(); }
+    uint8_t getTargetFps() { return m_frameCounter.getTargetFps(); }
+
+    void resetTargetFps() { m_frameCounter.resetTargetFps(); }
 
     bool isOnInputEvent() { return m_onInputEvent; }
     bool mustOptimize() {

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -32,7 +32,7 @@
 class GraphicalApplication : public Application
 {
 public:
-    void init(std::vector<std::string>& args, uint16_t asyncDispatchMaxThreads = 0) override;
+    void init(std::vector<std::string>& args, uint8_t asyncDispatchMaxThreads = 0) override;
     void deinit() override;
     void terminate() override;
     void run() override;

--- a/src/framework/core/logger.cpp
+++ b/src/framework/core/logger.cpp
@@ -38,7 +38,7 @@ Logger g_logger;
 
 namespace
 {
-    constexpr std::string_view s_logPrefixes[] = { "", "WARNING: ", "", "ERROR: ", "FATAL ERROR: " };
+    constexpr std::string_view s_logPrefixes[] = { "", "", "WARNING: ", "", "ERROR: ", "FATAL ERROR: " };
 #if ENABLE_ENCRYPTION == 1
     bool s_ignoreLogs = true;
 #else

--- a/src/framework/core/logger.cpp
+++ b/src/framework/core/logger.cpp
@@ -38,7 +38,7 @@ Logger g_logger;
 
 namespace
 {
-    constexpr std::string_view s_logPrefixes[] = { "", "", "WARNING: ", "", "ERROR: ", "FATAL ERROR: " };
+    constexpr std::string_view s_logPrefixes[] = { "", "", "", "WARNING: ", "ERROR: ", "FATAL ERROR: " };
 #if ENABLE_ENCRYPTION == 1
     bool s_ignoreLogs = true;
 #else

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -264,6 +264,9 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_app", "getFps", &GraphicalApplication::getFps, &g_app);
     g_lua.bindSingletonFunction("g_app", "getMaxFps", &GraphicalApplication::getMaxFps, &g_app);
     g_lua.bindSingletonFunction("g_app", "setMaxFps", &GraphicalApplication::setMaxFps, &g_app);
+    g_lua.bindSingletonFunction("g_app", "getTargetFps", &GraphicalApplication::getTargetFps, &g_app);
+    g_lua.bindSingletonFunction("g_app", "setTargetFps", &GraphicalApplication::setTargetFps, &g_app);
+    g_lua.bindSingletonFunction("g_app", "resetTargetFps", &GraphicalApplication::resetTargetFps, &g_app);
 
     g_lua.bindSingletonFunction("g_app", "isDrawingTexts", &GraphicalApplication::isDrawingTexts, &g_app);
     g_lua.bindSingletonFunction("g_app", "setDrawTexts", &GraphicalApplication::setDrawTexts, &g_app);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, const char* argv[])
 #endif
 
     // initialize application framework and otclient
-    g_app.init(args);
+    g_app.init(args, ASYNC_DISPATCHER_MAX_THREAD);
     g_client.init(args);
 #ifdef FRAMEWORK_NET
     g_http.init();


### PR DESCRIPTION
# Description

Removes client code from framework (fps & ASYNC_DISPATCHER_MAX_THREAD)

We can now assign a `targetFps` for out of game framerate & we assign max threads of `asyncDispatcher` with init

Also fix logging prefixes