### PR TITLE
fix: android sound crash

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,6 +483,7 @@ elseif(ANDROID)
 
 		Threads::Threads
 		asio::asio
+		OpenSLES
 		Vorbis::vorbis
 		Vorbis::vorbisfile
 		LibLZMA::LibLZMA


### PR DESCRIPTION
# Description
The OpenAL library was crashing on arm processors, then I had to update the Android's library pack and fix the build.

## Behaviour
### **Actual**

Android is crashing on arm processors

### **Expected**

Don't crash.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
