### PR TITLE
fix: Enable vip groups feature by default

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1719,6 +1719,7 @@ void Game::setClientVersion(int version)
         enableFeature(Otc::GamePrey);
         enableFeature(Otc::GameThingQuickLoot);
         enableFeature(Otc::GameTournamentPackets);
+        enableFeature(Otc::GameVipGroups);
     }
 
     if (version >= 1260) {


### PR DESCRIPTION
# Description
Enable the VIP groups parser by default if a specific client version is selected. Without it, errors can occur on newer versions. (12+ protocols)