### PR TITLE
fix: spells cooldown if UINT16 is expected

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -928,6 +928,10 @@ function onSpellCooldown(spellId, duration)
     local slot
     for v, k in pairs(actionBarPanel:getChildren()) do
         local spell, profile, spellName = Spells.getSpellByIcon(spellId)
+        if not spell then
+            print('[WARNING] Can not set cooldown on spell with id: ' .. spellId)
+            return true
+        end
         if k.words == spell.words or spell.clientId and spell.clientId == k.itemId then
             slot = k
             local progressRect = slot:recursiveGetChildById('progress' .. spell.id)

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -1882,7 +1882,7 @@ void ProtocolGame::parsePlayerModes(const InputMessagePtr& msg)
 
 void ProtocolGame::parseSpellCooldown(const InputMessagePtr& msg)
 {
-    uint16_t spellId = msg->getU8();
+    uint16_t spellId;
     if (g_game.getFeature(Otc::GameUshortSpell)) {
         spellId = msg->getU16();
     } else {


### PR DESCRIPTION
# Description

Fix spells cooldown if UINT16 is expected.
Fix by **fusion32** from otland.

## Behaviour
### **Actual**

* There is no spell cooldown in client 10.98, after using spell.
* If last hit is done by spell, creature still appear as alive in battle list and game screen
* There is nil value error in OTC

Same issue:
https://otland.net/threads/solved-otclient-lua-exception-attempt-to-index-local-spell-a-nil-value.284728/#post-2722382
https://otland.net/threads/help-request-spell-damage-causes-visual-bug-on-monster-death.284723/#post-2722327


### **Expected**

 - Show spell cooldown in client 10.98, after using spell.
 - Killed monster die
 - There is no error in OTC

## Fixes

It is partialy resolve  
\# https://github.com/mehah/otclient/issues/527

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

 - I used `exura` to test healing spells.
 - I used `exori vis` to test killing monsters with spells

**Test Configuration**:

  - Server Version: TFS 1.4.2
  - Client: commit 47a3e59349acda593086bdd49b70373f90371f73
  - Operating System: Linux (Ubuntu 20.04)
  - I use docker to run client

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
