### PR TITLE
fix: charges/duration parsing

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -244,19 +244,19 @@ void ThingType::unserializeAppearance(uint16_t clientId, ThingCategory category,
     // reverse_addons_south
     // reverse_addons_north
 
-    if (flags.has_wearout() && flags.clip()) {
+    if (flags.has_wearout()) {
         m_flags |= ThingFlagAttrWearOut;
     }
 
-    if (flags.has_clockexpire() && flags.clip()) {
+    if (flags.has_clockexpire()) {
         m_flags |= ThingFlagAttrClockExpire;
     }
 
-    if (flags.has_expire() && flags.clip()) {
+    if (flags.has_expire()) {
         m_flags |= ThingFlagAttrExpire;
     }
 
-    if (flags.has_expirestop() && flags.clip()) {
+    if (flags.has_expirestop()) {
         m_flags |= ThingFlagAttrExpireStop;
     }
 


### PR DESCRIPTION
# Description
Game screen breaks when playing with newest client.
Just tried the client with 13.17 and the flags for charges/duration were not passed properly. This seems to resolve that problem, though **this may require testing to make sure it doesn't break anything on other versions**.

## Behaviour
### **Actual**
game screen is breaking like crazy when you run into a might ring, inventory fails to load

### **Expected**
smooth performance as usual

## Fixes
no issue to tag, some people possibly reported this on OTC Redemption discord

## Type of change
Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested
I ran my server in "safe mode" - sending only packets required to login and walk.

**Test Configuration**:

  - Server Version: Kitsune 1.6 (custom with stable 13.17 protocol working fine with vanilla client)
  - Client: 13.17
  - Operating System: Windows 10

before (the packet parsing was breaking on might ring which has "wearout" flag):
![obraz](https://github.com/mehah/otclient/assets/5205079/ce0d7d99-f88a-4e44-a3ef-db869c9cb05c)

after (I ran my server in "normal mode", the client is able to load both the might ring and my inventory now):
![obraz](https://github.com/mehah/otclient/assets/5205079/10003fb3-efaf-4723-94a1-5c3dbefec63a)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
