### PR TITLE
feat: toggle on/off console using ENTER and toggle off console using ESC

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -228,9 +228,9 @@ function init()
     g_keyboard.bindKeyPress('Shift+Tab', function()
         consoleTabBar:selectPrevTab()
     end, consolePanel)
+    g_keyboard.bindKeyDown('Enter', switchChatOnCall, consolePanel)
     g_keyboard.bindKeyDown('Enter', sendCurrentMessage, consolePanel)
-    g_keyboard.bindKeyDown('Enter', switchChatOnCall)
-    g_keyboard.bindKeyDown('Escape', disableChatOnCall)
+    g_keyboard.bindKeyDown('Escape', disableChatOnCall, consolePanel)
     g_keyboard.bindKeyPress('Ctrl+A', function()
         consoleTextEdit:clearText()
     end, consolePanel)
@@ -345,8 +345,13 @@ function switchChatOnCall()
         return
     end
 
-    if isChatEnabled() and consoleToggleChat:isChecked() or not consoleTextEdit:isVisible() then
-        switchChat(not consoleTextEdit:isVisible())
+    if isChatEnabled() and consoleToggleChat:isChecked() then
+        toggleChat()
+    else
+        local message = consoleTextEdit:getText()
+        if message == '' then
+            toggleChat()
+        end
     end
 end
 
@@ -355,8 +360,8 @@ function disableChatOnCall()
         return
     end
 
-    if consoleToggleChat:isChecked() then
-        switchChat(false)
+    if isChatEnabled() and not consoleToggleChat:isChecked() then
+        toggleChat()
     end
 end
 


### PR DESCRIPTION
# Description

Toggle on/off WSAD walking using ENTER.
Toggle on WSAD walking using ESC.


## Behaviour
### **Actual**

You can toggle on/off WSAD walking only using mouse pointer.

### **Expected**

You can toggle on/off WSAD walking using mouse pointer.
You can toggle off WSAD walking using ENTER.
You can toggle on WSAD walking using ENTER if there is no text message in text field.
You can toggle on WSAD walking using ESC.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix?
  - [x] New feature?

## How Has This Been Tested

  - [x] Edit text on letter to check if ENTER and ESC works as usual
  - [x] Send some messages on chat to test if it's not broken
  - [x] Write spells on console
  - [x] Use spells using hotkeys

**Test Configuration**:

  - Server Version: TFS 1.4.2
  - Client commit: 5b409487880010db14deb189ec928c2684263673
  - Tested client protocol: 10.98, 12.86
  - Operating System: Linux, Ubuntu 20.04
  - Tested with docker container

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
