### PR TITLE
fix: android initialization crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,8 @@ int main(int argc, const char* argv[])
 
     // initialize resources
 #ifdef ANDROID
+    // Unzip Android assets/data.zip
+    g_androidManager.unZipAssetData();
     g_resources.init(nullptr);
 #else
     g_resources.init(args[0].data());
@@ -81,11 +83,6 @@ int main(int argc, const char* argv[])
     g_client.init(args);
 #ifdef FRAMEWORK_NET
     g_http.init();
-#endif
-
-#ifdef ANDROID
-    // Unzip Android assets/data.zip
-    g_androidManager.unZipAssetData();
 #endif
 
     if (!g_lua.safeRunScript("init.lua"))


### PR DESCRIPTION
# Description
Android is always crashing because `data.zip` is not unziped before `discoverWorkDir` is called.

## Behaviour
### **Actual**
Unzip `data.zip` is called after `discoverWorkDir`.

### **Expected**
Unzip `data.zip` should be called before `discoverWorkDir`.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
