### PR TITLE
fix: UIWidget::setIcon crash

### DIFF
--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -402,7 +402,7 @@ void UIWidget::drawIcon(const Rect& screenCoords) const
 
 void UIWidget::setIcon(const std::string& iconFile)
 {
-    g_mainDispatcher.addEvent([&, iconFile = iconFile]() {
+    g_dispatcher.addEvent([&, iconFile = iconFile]() {
         m_icon = iconFile.empty() ? nullptr : g_textures.getTexture(iconFile);
         if (m_icon && !m_iconClipRect.isValid()) {
             m_iconClipRect = Rect(0, 0, m_icon->getSize());


### PR DESCRIPTION
From what I understand, you can't edit widget properties in mainDispatcher.

This fixed a random crash that was occurring in my custom client. I guess it could also occur here.



## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

