### PR TITLE
fix: use port for http login and allow custom URL

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -41,7 +41,6 @@ end
 
 local function onCharacterList(protocol, characters, account, otui)
     -- Try add server to the server list
-    print("Add Server 1")
     ServerList.add(G.host, G.port, g_game.getClientVersion())
 
     -- Save 'Stay logged in' setting

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -54,14 +54,14 @@ local function onCharacterList(protocol, characters, account, otui)
         g_settings.set('account', account)
         g_settings.set('password', password)
 
-        ServerList.setServerAccount(G.host .. ':' .. G.port, account)
-        ServerList.setServerPassword(G.host .. ':' .. G.port, password)
+        ServerList.setServerAccount(G.host, account)
+        ServerList.setServerPassword(G.host, password)
 
         g_settings.set('autologin', enterGame:getChildById('autoLoginBox'):isChecked())
     else
         -- reset server list account/password
-        ServerList.setServerAccount(G.host .. ':' .. G.port, '')
-        ServerList.setServerPassword(G.host .. ':' .. G.port, '')
+        ServerList.setServerAccount(G.host, '')
+        ServerList.setServerPassword(G.host, '')
 
         EnterGame.clearAccountFields()
     end

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -401,7 +401,7 @@ function EnterGame.tryHttpLogin(clientVersion)
         onCharacterList(nil, characters, account)
     end
 
-    HTTP.post(G.host .. ':' .. G.port .. "/login.php",
+    HTTP.post(G.host .. ':' .. G.port,
         json.encode({
             email = G.account,
             password = G.password,

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -401,8 +401,16 @@ function EnterGame.tryHttpLogin(clientVersion)
         onCharacterList(nil, characters, account)
     end
 
-    local host, path = G.host:match("([^/]+)/([^/]+)")
-    HTTP.post(host .. ':' .. G.port .. '/' .. path,
+    local host, path = G.host:match("([^/]+)/([^/].*)")
+    local url = G.host
+
+    if G.port ~= nil and path ~= nil then
+      url = host .. ':' .. G.port .. '/' .. path
+    elseif path ~= nil then
+      url = host .. '/' .. path
+    end
+
+    HTTP.post(url,
         json.encode({
             email = G.account,
             password = G.password,
@@ -453,7 +461,7 @@ function EnterGame.doLogin()
     g_settings.set('client-version', clientVersion)
 
     if clientVersion >= 1281 and G.port ~= 7171 then
-        if G.port == nil or G.port == 0 then
+        if G.port == 0 then
             G.port = 80
         end
 

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -401,7 +401,8 @@ function EnterGame.tryHttpLogin(clientVersion)
         onCharacterList(nil, characters, account)
     end
 
-    HTTP.post(G.host .. ':' .. G.port,
+    local host, path = G.host:match("([^/]+)/([^/]+)")
+    HTTP.post(host .. ':' .. G.port .. '/' .. path,
         json.encode({
             email = G.account,
             password = G.password,

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -41,6 +41,7 @@ end
 
 local function onCharacterList(protocol, characters, account, otui)
     -- Try add server to the server list
+    print("Add Server 1")
     ServerList.add(G.host, G.port, g_game.getClientVersion())
 
     -- Save 'Stay logged in' setting
@@ -53,14 +54,14 @@ local function onCharacterList(protocol, characters, account, otui)
         g_settings.set('account', account)
         g_settings.set('password', password)
 
-        ServerList.setServerAccount(G.host, account)
-        ServerList.setServerPassword(G.host, password)
+        ServerList.setServerAccount(G.host .. ':' .. G.port, account)
+        ServerList.setServerPassword(G.host .. ':' .. G.port, password)
 
         g_settings.set('autologin', enterGame:getChildById('autoLoginBox'):isChecked())
     else
         -- reset server list account/password
-        ServerList.setServerAccount(G.host, '')
-        ServerList.setServerPassword(G.host, '')
+        ServerList.setServerAccount(G.host .. ':' .. G.port, '')
+        ServerList.setServerPassword(G.host .. ':' .. G.port, '')
 
         EnterGame.clearAccountFields()
     end
@@ -401,7 +402,7 @@ function EnterGame.tryHttpLogin(clientVersion)
         onCharacterList(nil, characters, account)
     end
 
-    HTTP.post(G.host .. "/login.php",
+    HTTP.post(G.host .. ':' .. G.port .. "/login.php",
         json.encode({
             email = G.account,
             password = G.password,
@@ -452,6 +453,10 @@ function EnterGame.doLogin()
     g_settings.set('client-version', clientVersion)
 
     if clientVersion >= 1281 and G.port ~= 7171 then
+        if G.port == nil or G.port == 0 then
+            G.port = 80
+        end
+
         EnterGame.tryHttpLogin(clientVersion)
     else
         protocolLogin = ProtocolLogin.create()

--- a/src/framework/net/connection.cpp
+++ b/src/framework/net/connection.cpp
@@ -95,17 +95,17 @@ void Connection::connect(const std::string_view host, uint16_t port, const std::
     m_connectCallback = connectCallback;
 
     const asio::ip::tcp::resolver::query query(host.data(), stdext::unsafe_cast<std::string>(port));
-    m_resolver.async_resolve(query, [capture0 = asConnection()](auto&& PH1, auto&& PH2) {
-        capture0->onResolve(std::forward<decltype(PH1)>(PH1),
-        std::forward<decltype(PH2)>(PH2));
+    m_resolver.async_resolve(query, [this](auto&& error, auto&& endpointIterator) {
+       onResolve(std::move(error), std::move(endpointIterator));
     });
 
     m_readTimer.cancel();
-    m_readTimer.expires_from_now(asio::chrono::seconds(static_cast<uint32_t>(READ_TIMEOUT)));
-    m_readTimer.async_wait([capture0 = asConnection()](auto&& PH1) {
-        capture0->onTimeout(std::forward<decltype(PH1)>(PH1));
+    m_readTimer.expires_after(std::chrono::seconds(static_cast<uint32_t>(READ_TIMEOUT)));
+    m_readTimer.async_wait([this](auto&& error) {
+        onTimeout(std::move(error));
     });
 }
+
 
 void Connection::internal_connect(const asio::ip::basic_resolver<asio::ip::tcp>::iterator& endpointIterator)
 {


### PR DESCRIPTION
# Description

When using the HTTP login it is not using the port field, so we had to add the port on the IP address, with this change it will now get the port from the port field that we have on the login screen.

Updated code to also allow custom login URLs.

## Behavior

### **Actual**

Doesn't use the port field when making logon through HTTP.
Doesn't allow to customize the login URL, always append login.php on the URL.

### **Expected**

Use the port specified on the port field.
Allow customized URL, 'myserver.com/api/login/endpoint', will be 'myserver.com:<port>/api/login/endpoint'

## Fixes

Start to use the port field and avoid that we have to add the port together with the IP/URL of the server.  Also make the default port if not specified the port 80, the default HTTP port.

Allow to have customized login URLs.

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Tested removing the port fro the IP address and added it to the port field. Also saw that when not setting the port it is using the port 80.


## Checklist

  - [ ] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
