### PR TITLE
feat: shaders with custom vertex

### DIFF
--- a/modules/game_shaders/shaders.lua
+++ b/modules/game_shaders/shaders.lua
@@ -65,6 +65,10 @@ OUTFIT_SHADERS = {{
 }, {
     name = 'Outfit - Fragmented',
     frag = 'shaders/fragment/noise.frag'
+}, {
+    name = 'Outfit - Outline RED',
+    vert = 'shaders/fragment/outline_red_vertex',
+    frag = 'shaders/fragment/outline_red_fragment'
 }}
 
 MOUNT_SHADERS = {{
@@ -176,7 +180,11 @@ function init()
 
         if fragmentShaderPath ~= nil then
             --  local shader = g_shaders.createShader()
-            g_shaders.createFragmentShader(opts.name, opts.frag)
+            if (method == 'setupOutfitShader' and opts.vert ~= nil) then 
+                g_shaders.createOutfitShader(opts.name, opts.vert, opts.frag)
+            else
+                g_shaders.createFragmentShader(opts.name, opts.frag)
+            end
 
             if opts.tex1 then
                 g_shaders.addMultiTexture(opts.name, opts.tex1)

--- a/modules/game_shaders/shaders/fragment/outline_red_fragment.frag
+++ b/modules/game_shaders/shaders/fragment/outline_red_fragment.frag
@@ -1,0 +1,38 @@
+uniform mat4 u_Color;
+varying vec2 v_TexCoord;
+varying vec2 v_TexCoord2;
+varying vec2 v_TexCoord3;
+uniform sampler2D u_Tex0;
+uniform float u_Time;
+
+void main()
+{
+    gl_FragColor = texture2D(u_Tex0, v_TexCoord);
+    vec4 texcolor = texture2D(u_Tex0, v_TexCoord2);
+    if(texcolor.r > 0.9) {
+        gl_FragColor *= texcolor.g > 0.9 ? u_Color[0] : u_Color[1];
+    } else if(texcolor.g > 0.9) {
+        gl_FragColor *= u_Color[2];
+    } else if(texcolor.b > 0.9) {
+        gl_FragColor *= u_Color[3];
+    }
+
+    vec2 texel = vec2(1.0/1024.0, 1.0/1728.0);
+    
+    float leftPixel = texture2D(u_Tex0, v_TexCoord + vec2(-texel.x, 0.0)).a;
+    float upPixel = texture2D(u_Tex0, v_TexCoord + vec2(0.0, texel.y)).a;
+    float rightPixel = texture2D(u_Tex0, v_TexCoord + vec2(texel.x, 0.0)).a;
+    float bottomPixel = texture2D(u_Tex0, v_TexCoord + vec2(0.0, -texel.y)).a;
+
+    float outline = (1. - leftPixel * upPixel * rightPixel * bottomPixel) * gl_FragColor.a;
+    
+    vec4 col;
+	col.r = 0.8 + abs(0.5 - mod(u_Time, 1.0));
+	col.g = 0.0;
+	col.b = 0.0;
+    col.a = 1.0;
+
+    gl_FragColor = mix(gl_FragColor, col, outline);
+
+    if(gl_FragColor.a < 0.01) discard;
+}

--- a/modules/game_shaders/shaders/fragment/outline_red_vertex.frag
+++ b/modules/game_shaders/shaders/fragment/outline_red_vertex.frag
@@ -1,0 +1,16 @@
+attribute vec2 a_Vertex;
+attribute vec2 a_TexCoord;
+uniform mat3 u_TextureMatrix;
+varying vec2 v_TexCoord;
+varying vec2 v_TexCoord2;
+uniform mat3 u_TransformMatrix;
+uniform mat3 u_ProjectionMatrix;
+uniform vec2 u_Offset;
+
+void main()
+{
+    gl_Position = vec4((u_ProjectionMatrix * u_TransformMatrix * vec3(a_Vertex.xy, 1.0)).xy, 1.0, 1.0);
+    v_TexCoord = (u_TextureMatrix * vec3(a_TexCoord,1.0)).xy;
+    v_TexCoord2 = (u_TextureMatrix * vec3(a_TexCoord + u_Offset,1.0)).xy;
+}
+

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -351,6 +351,8 @@ void Client::registerLuaFunctions()
 
     g_lua.registerSingletonClass("g_shaders");
     g_lua.bindSingletonFunction("g_shaders", "createShader", &ShaderManager::createShader, &g_shaders);
+    g_lua.bindSingletonFunction("g_shaders", "createShaderNew", &ShaderManager::createShaderNew, &g_shaders);
+    g_lua.bindSingletonFunction("g_shaders", "createOutfitShader", &ShaderManager::createOutfitShader, &g_shaders);
     g_lua.bindSingletonFunction("g_shaders", "createFragmentShader", &ShaderManager::createFragmentShader, &g_shaders);
     g_lua.bindSingletonFunction("g_shaders", "createFragmentShaderFromCode", &ShaderManager::createFragmentShaderFromCode, &g_shaders);
     g_lua.bindSingletonFunction("g_shaders", "setupMapShader", &ShaderManager::setupMapShader, &g_shaders);

--- a/src/client/shadermanager.cpp
+++ b/src/client/shadermanager.cpp
@@ -41,6 +41,41 @@ void ShaderManager::createShader(const std::string_view name)
     });
 }
 
+void ShaderManager::createShaderNew(const std::string_view name ,const std::string_view vertex, const std::string_view fragment, const bool colorMatrix)
+{
+    
+    std::string vertexContent, farmentContent;
+    if (vertex.find("\n") == std::string::npos) { // file
+        vertexContent = g_resources.guessFilePath(vertex.data(), "frag");
+        vertexContent = g_resources.readFileContents(vertexContent);
+    }
+    if (fragment.find("\n") == std::string::npos) { // file
+        farmentContent = g_resources.guessFilePath(fragment.data(), "frag");
+        farmentContent = g_resources.readFileContents(farmentContent);
+    }
+
+    g_mainDispatcher.addEvent([&, name = name.data(), vertex = vertexContent, fragment = farmentContent, colorMatrix] {
+        const auto& program = std::make_shared<PainterShaderProgram>();
+
+        if (!program) {
+            return nullptr;
+        }
+        if (!program->addShaderFromSourceCode(ShaderType::VERTEX, vertex))
+            return nullptr;
+        if (!program->addShaderFromSourceCode(ShaderType::FRAGMENT, fragment))
+            return nullptr;
+
+        if (colorMatrix) {
+            program->enableColorMatrix();
+        }
+        if (!program->link()) {
+            return nullptr;
+        }
+        if (program)
+            m_shaders[name] = program;
+    });
+}
+
 void ShaderManager::createFragmentShader(const std::string_view name, const std::string_view file)
 {
     const auto& filePath = g_resources.resolvePath(file.data());

--- a/src/client/shadermanager.h
+++ b/src/client/shadermanager.h
@@ -50,6 +50,11 @@ public:
     void setupMountShader(const std::string_view name);
 
     void createShader(const std::string_view name);
+    void createShaderNew(const std::string_view name, const std::string_view vertex, const std::string_view fragment, const bool colorMatrix);
+    void createOutfitShader(const std::string& name, std::string vertex, std::string fragment)
+    {
+        return createShaderNew(name, vertex, fragment, true);
+    }
     void createFragmentShader(const std::string_view name, const std::string_view file);
     void createFragmentShaderFromCode(const std::string_view name, const std::string_view code);
 

--- a/src/framework/graphics/painter.h
+++ b/src/framework/graphics/painter.h
@@ -52,6 +52,18 @@ enum class BlendEquation
     REVER_SUBTRACT = GL_FUNC_REVERSE_SUBTRACT,
 };
 
+enum class DepthFunc
+{
+    DepthFunc_None,
+    DepthFunc_LESS,
+    DepthFunc_LESS_READ,
+    DepthFunc_LEQUAL,
+    DepthFunc_LEQUAL_READ,
+    DepthFunc_EQUAL,
+    DepthFunc_ALWAYS,
+    DepthFunc_ALWAYS_READ
+};
+
 class Painter
 {
 public:

--- a/src/framework/graphics/paintershaderprogram.h
+++ b/src/framework/graphics/paintershaderprogram.h
@@ -31,17 +31,30 @@ protected:
     {
         VERTEX_ATTR = 0,
         TEXCOORD_ATTR = 1,
+        DEPTH_ATTR = 2,
+        COLOR_ATTR = 3,
+        DEPTH_TEXCOORD_ATTR = 4,
+
+
         PROJECTION_MATRIX_UNIFORM = 0,
         TEXTURE_MATRIX_UNIFORM = 1,
-        COLOR_UNIFORM = 2,
+        TRANSFORM_MATRIX_UNIFORM = 2,
+
         OPACITY_UNIFORM = 3,
-        TIME_UNIFORM = 4,
-        TEX0_UNIFORM = 5,
-        TEX1_UNIFORM = 6,
-        TEX2_UNIFORM = 7,
-        TEX3_UNIFORM = 8,
-        RESOLUTION_UNIFORM = 9,
-        TRANSFORM_MATRIX_UNIFORM = 10
+        COLOR_UNIFORM = 4,
+        TIME_UNIFORM = 5,
+        DEPTH_UNIFORM = 6,
+
+        TEX0_UNIFORM = 7,
+        TEX1_UNIFORM = 8,
+        TEX2_UNIFORM = 9,
+        TEX3_UNIFORM = 10,
+        ATLAS_TEX0_UNIFORM = 11,
+        ATLAS_TEX1_UNIFORM = 12,
+
+        RESOLUTION_UNIFORM = 13,
+        OFFSET_UNIFORM = 14,
+        CENTER_UNIFORM = 15
     };
 
     friend class Painter;
@@ -57,17 +70,29 @@ public:
     void setProjectionMatrix(const Matrix3& projectionMatrix);
     void setTextureMatrix(const Matrix3& textureMatrix);
     void setColor(const Color& color);
+    void setMatrixColor(const Matrix4& colors);
+    void setDepth(float depth);
     void setOpacity(float opacity);
     void setResolution(const Size& resolution);
+    void setOffset(const Point& offset);
+    void setCenter(const Point& center);
     void updateTime();
 
     void addMultiTexture(const std::string& file);
     void bindMultiTextures() const;
+    void clearMultiTextures();
+
+    void enableColorMatrix()
+    {
+        m_useColorMatrix = true;
+    }
 
 private:
     float m_startTime{ 0 };
     float m_opacity{ 1.f };
     float m_time{ 0 };
+    float m_depth{ 0 };
+
 
     Color m_color{ Color::white };
 
@@ -76,6 +101,10 @@ private:
     Matrix3 m_textureMatrix;
 
     Size m_resolution;
+    Point m_offset;
+    Point m_center;
 
     std::vector<TexturePtr> m_multiTextures;
+    bool m_useColorMatrix = false;
+
 };

--- a/src/framework/graphics/shader/shadersources.h
+++ b/src/framework/graphics/shader/shadersources.h
@@ -78,4 +78,49 @@ static constexpr std::string_view glslMainVertexShader = "\n\
         if(texture2D(u_Tex0, v_TexCoord).a > 0.01)\n\
             return u_Color;\n\
         return vec4(0,0,0,0);\n\
+    }\n",
+
+    glslSolidColorOnTextureFragmentShader = "\n\
+    uniform vec4 u_Color;\n\
+    varying vec2 v_TexCoord;\n\
+    uniform sampler2D u_Tex0;\n\
+    vec4 calculatePixel() {\n\
+        if(texture2D(u_Tex0, v_TexCoord).a > 0.01)\n\
+            return u_Color;\n\
+        return vec4(0,0,0,0);\n\
+    }\n",
+
+    glslOutfitVertexShader = "\n\
+    attribute vec2 a_TexCoord;\n\
+    uniform mat3 u_TextureMatrix;\n\
+    varying vec2 v_TexCoord;\n\
+    varying vec2 v_TexCoord2;\n\
+    attribute vec2 a_Vertex;\n\
+    uniform mat3 u_TransformMatrix;\n\
+    uniform mat3 u_ProjectionMatrix;\n\
+    uniform float u_Depth;\n\
+    uniform vec2 u_Offset;\n\
+    void main()\n\
+    {\n\
+        gl_Position = vec4((u_ProjectionMatrix * u_TransformMatrix * vec3(a_Vertex.xy, 1.0)).xy, u_Depth / 16384.0, 1.0);\n\
+        v_TexCoord = (u_TextureMatrix * vec3(a_TexCoord,1.0)).xy;\n\
+        v_TexCoord2 = (u_TextureMatrix * vec3(a_TexCoord + u_Offset,1.0)).xy;\n\
+    }\n",
+
+    glslOutfitFragmentShader = "\n\
+    uniform mat4 u_Color;\n\
+    varying vec2 v_TexCoord;\n\
+    varying vec2 v_TexCoord2;\n\
+    uniform sampler2D u_Tex0;\n\
+    void main()\n\
+    {\n\
+        gl_FragColor = texture2D(u_Tex0, v_TexCoord);\n\
+        vec4 texcolor = texture2D(u_Tex0, v_TexCoord2);\n\
+        if(texcolor.r > 0.9)\n\
+            gl_FragColor *= texcolor.g > 0.9 ? u_Color[0] : u_Color[1];\n\
+        else if(texcolor.g > 0.9)\n\
+            gl_FragColor *= u_Color[2];\n\
+        else if(texcolor.b > 0.9)\n\
+            gl_FragColor *= u_Color[3];\n\
+        if(gl_FragColor.a < 0.01) discard;\n\
     }\n";

--- a/src/framework/graphics/shaderprogram.h
+++ b/src/framework/graphics/shaderprogram.h
@@ -64,47 +64,30 @@ public:
     void setAttributeValue(int location, float value) { glVertexAttrib1f(location, value); }
     void setAttributeValue(int location, float x, float y) { glVertexAttrib2f(location, x, y); }
     void setAttributeValue(int location, float x, float y, float z) { glVertexAttrib3f(location, x, y, z); }
-    void setAttributeArray(const char* name, const float* values, int size, int stride = 0) const
-    { glVertexAttribPointer(getAttributeLocation(name), size, GL_FLOAT, GL_FALSE, stride, values); }
-    void setAttributeValue(const char* name, float value) const
-    { glVertexAttrib1f(getAttributeLocation(name), value); }
-    void setAttributeValue(const char* name, float x, float y) const
-    { glVertexAttrib2f(getAttributeLocation(name), x, y); }
-    void setAttributeValue(const char* name, float x, float y, float z) const
-    { glVertexAttrib3f(getAttributeLocation(name), x, y, z); }
+    void setAttributeArray(const char* name, const float* values, int size, int stride = 0) const { glVertexAttribPointer(getAttributeLocation(name), size, GL_FLOAT, GL_FALSE, stride, values); }
+    void setAttributeValue(const char* name, float value) const{ glVertexAttrib1f(getAttributeLocation(name), value); }
+    void setAttributeValue(const char* name, float x, float y) const{ glVertexAttrib2f(getAttributeLocation(name), x, y); }
+    void setAttributeValue(const char* name, float x, float y, float z) const{ glVertexAttrib3f(getAttributeLocation(name), x, y, z); }
 
-    void setUniformValue(int location, const Color& color) const
-    { glUniform4f(m_uniformLocations[location], color.rF(), color.gF(), color.bF(), color.aF()); }
-    void setUniformValue(int location, int value) const
-    { glUniform1i(m_uniformLocations[location], value); }
-    void setUniformValue(int location, float value) const
-    { glUniform1f(m_uniformLocations[location], value); }
-    void setUniformValue(int location, float x, float y) const
-    { glUniform2f(m_uniformLocations[location], x, y); }
-    void setUniformValue(int location, float x, float y, float z) const
-    { glUniform3f(m_uniformLocations[location], x, y, z); }
-    void setUniformValue(int location, float x, float y, float z, float w) const
-    { glUniform4f(m_uniformLocations[location], x, y, z, w); }
-    void setUniformValue(int location, const Matrix2& mat) const
-    { glUniformMatrix2fv(m_uniformLocations[location], 1, GL_FALSE, mat.data()); }
-    void setUniformValue(int location, const Matrix3& mat) const
-    { glUniformMatrix3fv(m_uniformLocations[location], 1, GL_FALSE, mat.data()); }
-    void setUniformValue(const char* name, const Color& color) const
-    { glUniform4f(glGetUniformLocation(m_programId, name), color.rF(), color.gF(), color.bF(), color.aF()); }
-    void setUniformValue(const char* name, int value) const
-    { glUniform1i(glGetUniformLocation(m_programId, name), value); }
-    void setUniformValue(const char* name, float value) const
-    { glUniform1f(glGetUniformLocation(m_programId, name), value); }
-    void setUniformValue(const char* name, float x, float y) const
-    { glUniform2f(glGetUniformLocation(m_programId, name), x, y); }
-    void setUniformValue(const char* name, float x, float y, float z) const
-    { glUniform3f(glGetUniformLocation(m_programId, name), x, y, z); }
-    void setUniformValue(const char* name, float x, float y, float z, float w) const
-    { glUniform4f(glGetUniformLocation(m_programId, name), x, y, z, w); }
-    void setUniformValue(const char* name, const Matrix2& mat) const
-    { glUniformMatrix2fv(glGetUniformLocation(m_programId, name), 1, GL_FALSE, mat.data()); }
-    void setUniformValue(const char* name, const Matrix3& mat) const
-    { glUniformMatrix3fv(glGetUniformLocation(m_programId, name), 1, GL_FALSE, mat.data()); }
+    void setUniformValue(int location, const Color& color) const{ glUniform4f(m_uniformLocations[location], color.rF(), color.gF(), color.bF(), color.aF()); }
+    void setUniformValue(int location, int value) const{ glUniform1i(m_uniformLocations[location], value); }
+    void setUniformValue(int location, float value) const{ glUniform1f(m_uniformLocations[location], value); }
+    void setUniformValue(int location, float x, float y) const{ glUniform2f(m_uniformLocations[location], x, y); }
+    void setUniformValue(int location, float x, float y, float z) const{ glUniform3f(m_uniformLocations[location], x, y, z); }
+    void setUniformValue(int location, float x, float y, float z, float w) const{ glUniform4f(m_uniformLocations[location], x, y, z, w); }
+    void setUniformValue(int location, const Matrix2& mat) const{ glUniformMatrix2fv(m_uniformLocations[location], 1, GL_FALSE, mat.data()); }
+    void setUniformValue(int location, const Matrix3& mat) const{ glUniformMatrix3fv(m_uniformLocations[location], 1, GL_FALSE, mat.data()); }
+    void setUniformValue(int location, const Matrix4& mat) const{ glUniformMatrix4fv(m_uniformLocations[location], 1, GL_FALSE, mat.data()); }
+    void setUniformValue(const char* name, const Color& color) const{ glUniform4f(glGetUniformLocation(m_programId, name), color.rF(), color.gF(), color.bF(), color.aF()); }
+    void setUniformValue(const char* name, int value) const{ glUniform1i(glGetUniformLocation(m_programId, name), value); }
+    void setUniformValue(const char* name, float value) const{ glUniform1f(glGetUniformLocation(m_programId, name), value); }
+    void setUniformValue(const char* name, float x, float y) const{ glUniform2f(glGetUniformLocation(m_programId, name), x, y); }
+    void setUniformValue(const char* name, float x, float y, float z) const { glUniform3f(glGetUniformLocation(m_programId, name), x, y, z); }
+    void setUniformValue(const char* name, float x, float y, float z, float w) const { glUniform4f(glGetUniformLocation(m_programId, name), x, y, z, w); }
+    void setUniformValue(const char* name, const Matrix2& mat) const { glUniformMatrix2fv(glGetUniformLocation(m_programId, name), 1, GL_FALSE, mat.data()); }
+    void setUniformValue(const char* name, const Matrix3& mat) const { glUniformMatrix3fv(glGetUniformLocation(m_programId, name), 1, GL_FALSE, mat.data()); }
+    void setUniformValue(const char* name, const Matrix4& mat) const { glUniformMatrix4fv(glGetUniformLocation(m_programId, name), 1, GL_FALSE, mat.data()); }
+
     // TODO: Point, PointF, Color, Size, SizeF ?
 
     bool isLinked() const { return m_linked; }


### PR DESCRIPTION
. Code f…rom OTCv8


# Description

Code from OTCv8 regarding shaders with custom vertex (otcv8 shaders are not working in mehahs otc right now) 

Thiis is a WIP and I expect more people to help, as Im not good with shaders and OpenGL stuff. The greatest results (which for me are not acceptable) is:
No shader - 
![image](https://github.com/mehah/otclient/assets/7044883/2219b3e3-1e31-4d26-9240-4cbf3f4c0b4c)
Outline Shader - 
![image](https://github.com/mehah/otclient/assets/7044883/9c4978d2-7785-4930-8129-f356667ac9ef)

As you can see, some of the pixels from the outfit are not accurate and it breaks

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
