### PR TITLE
build: add shellapi and timeapi includes to fix visual studio solution

### DIFF
--- a/src/framework/platform/win32platform.cpp
+++ b/src/framework/platform/win32platform.cpp
@@ -22,6 +22,7 @@
 
 #ifdef WIN32
 
+#include <shellapi.h>
 #include <tchar.h>
 #include <framework/stdext/stdext.h>
 

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -22,6 +22,7 @@
 
 #ifdef WIN32
 
+#include <timeapi.h>
 #include "win32window.h"
 #include <client/map.h>
 #include <framework/core/application.h>


### PR DESCRIPTION
# Description

When trying to build on certain Windows 10 versions through the SLN file from Visual Studio, you will encounter some 'identifier not found' errors.

![image](https://github.com/mehah/otclient/assets/31557160/72135920-7448-4c54-aabc-405e257008f6)


## Behaviour
### **Actual**

When following the compilation tutorial you shouldn't have any issues compiling.

### **Expected**

Errors out on some identifiers in the `framework/platform/win32platform.cpp` and `framework/platform/win32window.cpp` files as can be seen above

## Fixes

Added `#include <timeapi.h>` in `framework/platform/win32window.cpp`.
Added `#include <shellapi.h>` in `framework/platform/win32platform.cpp`.

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Attempted to build as was described in the documentation and got the error. Once the fix is implemented, project compiles successfully

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
