### PR TITLE
fix: onTextMessage message mode 50

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -86,6 +86,7 @@ MessageTypes = {
     [MessageModes.TutorialHint] = MessageSettings.centerWhite,
     [MessageModes.BeyondLast] = MessageSettings.centerWhite,
     [MessageModes.Report] = MessageSettings.consoleRed,
+    [MessageModes.GameHighlight] = MessageSettings.centerRed,
     [MessageModes.HotkeyUse] = MessageSettings.centerGreen,
     [MessageModes.Attention] = MessageSettings.bottomWhite,
     [MessageModes.BoostedCreature] = MessageSettings.centerWhite,


### PR DESCRIPTION
USE: player:sendTextMessage(MESSAGE_GAME_HIGHLIGHT, "testando")

![image](https://github.com/mehah/otclient/assets/6209529/64eba95f-0f8c-49bc-a5f5-12d9ab2df184)

ERROR: Unhandled onTextMessage message mode 50: testando