### PR TITLE
Fix: GameCountU16

### DIFF
--- a/src/client/item.h
+++ b/src/client/item.h
@@ -150,7 +150,7 @@ private:
     void internalDraw(int animationPhase, const Point& dest, const Color& color, bool drawThings, bool isMarked, LightView* lightView = nullptr);
     void setConductor();
 
-    int m_countOrSubType{ 0 };
+    uint16_t m_countOrSubType{ 0 };
 
     Color m_color{ Color::white };
 

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -150,7 +150,7 @@ private:
     void internalDraw(int animationPhase, const Point& dest, const Color& color, bool drawThings, bool isMarked, LightView* lightView = nullptr);
     void setConductor();
 
-    uint8_t m_countOrSubType{ 0 };
+    int m_countOrSubType{ 0 };
 
     Color m_color{ Color::white };
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2408,7 +2408,7 @@ void ProtocolGame::parseChannelEvent(const InputMessagePtr& msg)
 void ProtocolGame::parseItemInfo(const InputMessagePtr& msg) const
 {
     std::vector<std::tuple<ItemPtr, std::string>> list;
-    const uint8_t size = msg->getU8();
+    const int size = msg->getU8();
     for (int_fast32_t i = 0; i < size; ++i) {
         const auto& item = std::make_shared<Item>();
         item->setId(msg->getU16());

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2408,7 +2408,7 @@ void ProtocolGame::parseChannelEvent(const InputMessagePtr& msg)
 void ProtocolGame::parseItemInfo(const InputMessagePtr& msg) const
 {
     std::vector<std::tuple<ItemPtr, std::string>> list;
-    const int size = msg->getU8();
+    const uint8_t size = msg->getU8();
     for (int_fast32_t i = 0; i < size; ++i) {
         const auto& item = std::make_shared<Item>();
         item->setId(msg->getU16());


### PR DESCRIPTION
# Description

item max count was limited to uint8_t, when you have uint16 on server.
When players had more than 255 items, the count as reseting to 1, so was not correct.

## Behaviour
### **Actual**

when you have more than 255 items on stack, it will reset the count, following uint8_t

### **Expected**

when you have more than 255 items on stack, it will no more reset the count on client, it will follow uint16_t feature.

## Fixes

\# GameCountU16 max count

## Type of change

Please delete options that are not relevant.

  - [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X ] i created more than 255 itens and it worked.

**Test Configuration**:

  - Server Version: 0.3.6
  - Client: 8.54
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
