### PR TITLE
fix: crash when trying to attach a non existing attachedEffect

### DIFF
--- a/src/client/thing.cpp
+++ b/src/client/thing.cpp
@@ -98,6 +98,9 @@ void Thing::setShader(const std::string_view name) {
 }
 
 void Thing::attachEffect(const AttachedEffectPtr& obj) {
+    if (!obj)
+        return;
+
     if (isCreature()) {
         if (obj->m_thingType && (obj->m_thingType->isCreature() || obj->m_thingType->isMissile()))
             obj->m_direction = static_self_cast<Creature>()->getDirection();


### PR DESCRIPTION
Reproduction:

g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(9999))

![image](https://github.com/mehah/otclient/assets/2137569/8497b573-169c-441d-be61-4e9bd5cbc465)
