### PR TITLE
Update vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,5 +29,5 @@
       "platform": "windows | osx"
     }
   ],
-  "builtin-baseline":"6ba86f3584f98aa16944408341f7c8e363c3356b"
+  "builtin-baseline":"13c3c0fcc203d179f4443fe48d252e3ff220cbeb"
 }


### PR DESCRIPTION
Update baseline to use newer versions of packages and fix the build of one package that is broken on the previous baseline.