### PR TITLE
fix: parse packets for protocol 13.20

### DIFF
--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -79,6 +79,7 @@ namespace Proto
         GameServerFloorDescription = 75,
 
         // original tibia ONLY
+        GameServerImbuementDurations = 93,
         GameServerPassiveCooldown = 94,
         GameServerBosstiaryData = 97,
         GameServerBosstiarySlots = 98,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -269,6 +269,7 @@ private:
     void parseSupplyStash(const InputMessagePtr& msg);
     void parseSpecialContainer(const InputMessagePtr& msg);
     void parsePartyAnalyzer(const InputMessagePtr& msg);
+    void parseImbuementDurations(const InputMessagePtr& msg);
     void parsePassiveCooldown(const InputMessagePtr& msg);
     void parseClientCheck(const InputMessagePtr& msg);
     void parseGameNews(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2932,29 +2932,27 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id)
 
     if (item->isContainer()) {
         if (g_game.getFeature(Otc::GameContainerTypes)) {
-            const uint8_t type = msg->getU8();
-            switch (type) {
-                case 0: // Empty
-                    break;
-                case 1: {
-                    if (g_game.getFeature(Otc::GameThingQuickLoot)) {
-                        msg->getU32(); // quick loot flags
-                    }
-                    break;
-                }
-                case 2: {
-                    if (g_game.getFeature(Otc::GameThingQuiver)) {
-                        msg->getU32(); // ammoTotal
-                    }
-                    break;
-                }
-                case 4: // Empty (Loot highlight boolean)
-                    break;
-                default: {
-                    throw Exception("unknown container type %d", type);
-                    break;
-                }
+            // container flags
+            // 1: quick loot, 2: quiver, 4: unlooted corpse
+            const uint8_t containerFlags = msg->getU8();
+
+            // quick loot categories
+            if ((containerFlags & 1) != 0) {
+                msg->getU32();
             }
+
+            // quover ammo count
+            if ((containerFlags & 2) != 0) {
+                msg->getU32();
+            }
+
+            // corpse not looted yet
+            /*
+            if ((containerFlags & 4) != 0) {
+                // this flag has no bytes to parse
+                // draw effect 252 on top of the tile
+            }
+            */
         } else {
             if (g_game.getFeature(Otc::GameThingQuickLoot)) {
                 const bool hasQuickLootFlags = msg->getU8() != 0;

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2941,7 +2941,7 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id)
                 msg->getU32();
             }
 
-            // quover ammo count
+            // quiver ammo count
             if ((containerFlags & 2) != 0) {
                 msg->getU32();
             }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3314,10 +3314,10 @@ void ProtocolGame::parseItemsPrice(const InputMessagePtr& msg)
         const uint16_t itemId = msg->getU16(); // item client id
         if (g_game.getClientVersion() >= 1281) {
             const auto& item = Item::create(itemId);
-            if (item->getId() == 0)
-                throw Exception("unable to create item with invalid id %d", itemId);
 
-            if (item->getClassification() > 0) {
+            // note: vanilla client allows made-up client ids
+            // their classification is assumed as 0
+            if (item->getId() != 0 && item->getClassification() > 0) {
                 msg->getU8();
             }
             msg->getU64(); // price

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -449,6 +449,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 case Proto::GameServerSendShowDescription:
                     parseShowDescription(msg);
                     break;
+                case Proto::GameServerImbuementDurations:
+                    parseImbuementDurations(msg);
+                    break;
                 case Proto::GameServerPassiveCooldown:
                     parsePassiveCooldown(msg);
                     break;
@@ -3197,6 +3200,28 @@ void ProtocolGame::parsePartyAnalyzer(const InputMessagePtr& msg)
         for (uint8_t i = 0; i < names; i++) {
             msg->getU32(); // MemberID
             msg->getString(); // Member name
+        }
+    }
+}
+
+void ProtocolGame::parseImbuementDurations(const InputMessagePtr& msg)
+{
+    uint8_t itemListSize = msg->getU8(); // amount of items to display
+
+    for (uint8_t itemIndex = 0; itemIndex < itemListSize; ++itemIndex) {
+        msg->getU8(); // item slot id
+        getItem(msg); // imbued item
+        uint8_t imbuingSlotCount = msg->getU8(); // total amount of imbuing slots on item
+
+        for (uint8_t imbuIndex = 0; imbuIndex < imbuingSlotCount; ++imbuIndex) {
+            bool slotImbued = msg->getU8(); // 0 - empty, 1 - imbued
+
+            if (slotImbued) {
+                msg->getString(); // imbuement name
+                msg->getU16(); // imbuement icon id
+                msg->getU32(); // imbuement duration (NOTE: this is a SIGNED 32-bit variable)
+                msg->getU8(); // decaystate: 0 - paused, 1 - decaying
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

This PR corrects inaccuracies in 13.20 protocol.

## Behaviour
### **Actual**

parsing these packets causes otc to desync and show errors in terminal

### **Expected**

handle the packets the same way as vanilla (rl) client

## Fixes

- terminal errors, client desync
- mentioned in #681, does NOT close it

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Connecting to local testserver and checking terminal.

Server was running with vanilla client for several months and the features were used by hundreds of players so I have full confidence in server side protocol being correct.

**Test Configuration**:

  - Server Version: Kitsune 2.0 (an engine used in Noveria, built for vanilla 13.20 client)
  - Client: 13.20
  - Operating System: Windows 10 (client)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
