### PR TITLE
feat: game stash window

### DIFF
--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -36,5 +36,6 @@ Module
     - game_unjustifiedpoints
     - game_shaders
     - game_attachedeffects
+    - game_stash
   @onLoad: init()
   @onUnload: terminate()

--- a/modules/game_stash/game_stash.lua
+++ b/modules/game_stash/game_stash.lua
@@ -1,0 +1,157 @@
+stashWindow = nil
+itemsPanel = nil
+radioItemSet = nil
+stashSelectAmount = nil
+searchEdit = nil
+stashItems = {}
+
+function resetSelectAmount()
+    if stashSelectAmount then
+        stashSelectAmount:destroy()
+        stashSelectAmount = nil
+    end
+end
+
+function resetItems()
+    if itemsPanel then
+        itemsPanel:destroyChildren()
+    end
+    if radioItemSet then
+        radioItemSet:destroy()
+        radioItemSet = nil
+    end
+end
+
+function prepareWithdraw(itemId, itemAmount)
+    resetSelectAmount()
+
+    stashSelectAmount = g_ui.createWidget('StashSelectAmount', rootWidget)
+    stashSelectAmount:lock()
+
+    local itembox = stashSelectAmount:getChildById('item')
+    itembox:setItemId(itemId)
+    itembox:setItemCount(itemAmount)
+
+    local scrollbar = stashSelectAmount:getChildById('countScrollBar')
+    scrollbar:setMaximum(itemAmount)
+    scrollbar:setMinimum(1)
+    scrollbar:setValue(itemAmount)
+    scrollbar.onValueChange = function(self, value)
+        itembox:setItemCount(value)
+    end
+
+    g_keyboard.bindKeyPress('Up', function()
+        scrollbar:setValue(scrollbar:getValue() + 10)
+    end, stashSelectAmount)
+    g_keyboard.bindKeyPress('Down', function()
+        scrollbar:setValue(scrollbar:getValue() - 10)
+    end, stashSelectAmount)
+    g_keyboard.bindKeyPress('Right', function()
+        scrollbar:onIncrement()
+    end, stashSelectAmount)
+    g_keyboard.bindKeyPress('Left', function()
+        scrollbar:onDecrement()
+    end, stashSelectAmount)
+    g_keyboard.bindKeyPress('PageUp', function()
+        scrollbar:setValue(scrollbar:getMaximum())
+    end, stashSelectAmount)
+    g_keyboard.bindKeyPress('PageDown', function()
+        scrollbar:setValue(scrollbar:getMinimum())
+    end, stashSelectAmount)
+
+    local okButton = stashSelectAmount:getChildById('buttonOk')
+    local withdrawFunc = function()
+        g_game.stashWithdraw(itemId, itembox:getItemCount(), 1)
+        stashSelectAmount:unlock()
+        resetSelectAmount()
+    end
+    local cancelButton = stashSelectAmount:getChildById('buttonCancel')
+    local cancelFunc = function()
+        stashSelectAmount:unlock()
+        resetSelectAmount()
+    end
+
+    stashSelectAmount.onEnter = withdrawFunc
+    stashSelectAmount.onEscape = cancelFunc
+
+    okButton.onClick = withdrawFunc
+    cancelButton.onClick = cancelFunc
+end
+
+function renderItems()
+    if not g_game.isOnline() then
+        return
+    end
+    resetItems()
+    radioItemSet = UIRadioGroup.create()
+    local searchFilter = searchEdit:getText()
+    for itemId, amount in pairs(stashItems) do
+        local thingType = g_things.getThingType(itemId, 0)
+        if thingType then
+            local itemName = thingType:getName()
+            if not itemName or itemName:lower():find(searchFilter) then
+                local item = Item.create(itemId)
+                item:setCount(amount)
+                local itemBox = g_ui.createWidget('StashItemBox', itemsPanel)
+                itemBox:getChildById('item'):setItem(item)
+                radioItemSet:addWidget(itemBox)
+                if itemName then
+                    itemBox:setTooltip(itemName)
+                else
+                    itemBox:setTooltip("Loading...")
+                end
+                g_mouse.bindPress(itemBox, function()
+                    prepareWithdraw(itemId, amount)
+                end, MouseLeftButton)
+            end
+        end
+    end
+    if stashWindow:isHidden() then
+        stashWindow:show()
+        stashWindow:lock()
+    end
+end
+
+function onSupplyStashEnter(payload)
+    stashItems = {}
+    for i = 1, #payload do
+        local itemId = payload[i][1]
+        local amount = payload[i][2]
+        stashItems[itemId] = amount
+    end
+    renderItems()
+end
+
+function onSupplyStashClose()
+    stashItems = {}
+    resetItems()
+    resetSelectAmount()
+    if searchEdit then
+        searchEdit:setText('')
+    end
+    if not stashWindow:isHidden() then
+        stashWindow:hide()
+        stashWindow:unlock()
+        modules.game_interface.getRootPanel():focus()
+    end
+end
+
+function init()
+    g_ui.importStyle('game_stash')
+    connect(g_game, {
+        onSupplyStashEnter = onSupplyStashEnter,
+        onGameEnd = onSupplyStashClose,
+    })
+    stashWindow = g_ui.createWidget('StashWindow', rootWidget)
+    stashWindow:hide()
+    itemsPanel = stashWindow:recursiveGetChildById('itemsPanel')
+    searchEdit = stashWindow:recursiveGetChildById('searchEdit')
+end
+
+function terminate()
+    disconnect(g_game, {
+        onSupplyStashEnter = onSupplyStashEnter,
+        onGameEnd = onSupplyStashClose,
+    })
+    stashWindow:destroy()
+end

--- a/modules/game_stash/game_stash.otmod
+++ b/modules/game_stash/game_stash.otmod
@@ -1,0 +1,9 @@
+Module
+  name: game_stash
+  description: Global supply stash system
+  author: Aluisio Penna
+  website: https://github.com/mehah/otclient
+  sandboxed: false
+  scripts: [ game_stash ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/modules/game_stash/game_stash.otui
+++ b/modules/game_stash/game_stash.otui
@@ -1,0 +1,149 @@
+StashWindow < MainWindow
+  id: stashWindow
+  !text: tr('Supply Stash')
+  size: 700 530
+
+  @onEscape: onSupplyStashClose()
+
+  // Main Panel Window
+
+  Panel
+    id: supraPanel
+    width: 164
+    height: 25
+    anchors.top: parent.top
+    anchors.left: parent.left
+
+  Panel
+    id: mainTabContent
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    padding: 3
+    border-width: 1
+    border-color: #000000
+    margin-bottom: 20
+
+    VerticalScrollBar
+      id: itemsPanelListScrollBar
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      anchors.right: parent.right
+      step: 28
+      pixels-scroll: true
+
+    ScrollablePanel
+      id: itemsPanel
+      anchors.left: parent.left
+      anchors.right: prev.left
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      vertical-scrollbar: itemsPanelListScrollBar
+      layout:
+        type: grid
+        cell-size: 36 36
+        flow: true
+        auto-spacing: true
+
+  Panel
+    id: findSupply
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    width: 164
+    height: 25
+    Label
+      !text: tr('Find') .. ':'
+      anchors.top: parent.top
+      anchors.left: parent.left
+      width: 30
+      font: verdana-11px-rounded
+      text-offset: 0 2
+
+    TextEdit
+      id: searchEdit
+      anchors.verticalCenter: prev.verticalCenter
+      anchors.left: prev.right
+      margin-left: 3
+      width: 113
+      @onTextChange: renderItems()
+
+  Button
+    id: closeButton
+    !text: tr('Close')
+    anchors.top: mainTabContent.bottom
+    anchors.horizontalCenter: mainTabContent.horizontalCenter
+    margin-top: 5
+    width: 110
+    @onClick: onSupplyStashClose()
+
+StashItemBox < UICheckBox
+  id: itemBox
+  border-width: 1
+  border-color: #000000
+  color: #aaaaaa
+  text-align: center
+
+  Item
+    id: item
+    phantom: true
+    virtual: true
+    text-offset: 0 22
+    text-align: right
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin: 1
+
+  $checked:
+    border-color: #ffffff
+
+  $hover !checked:
+    border-color: #aaaaaa
+
+  $disabled:
+    image-color: #ffffff88
+    color: #aaaaaa88
+
+StashSelectAmount < MainWindow
+  id: stashSelectAmount
+  !text: tr('Stash Withdraw')
+  size: 196 90
+
+  Item
+    id: item
+    anchors.left: parent.left
+    anchors.top: parent.top
+    margin-top: 2
+    margin-left: -4
+    focusable: false
+    virtual: true
+
+  HorizontalScrollBar
+    id: countScrollBar
+    anchors.left: prev.right
+    anchors.right: parent.right
+    anchors.top: prev.top
+    margin-left: 10
+    margin-top: -2
+    focusable: false
+
+  Button
+    id: buttonCancel
+    !text: tr('Cancel')
+    height: 20
+    anchors.left: countScrollBar.horizontalCenter
+    anchors.right: countScrollBar.right
+    anchors.top: countScrollBar.bottom
+    margin-top: 7
+    focusable: false
+
+  Button
+    id: buttonOk
+    !text: tr('Ok')
+    height: 20
+    anchors.right: countScrollBar.horizontalCenter
+    anchors.left: countScrollBar.left
+    anchors.top: countScrollBar.bottom
+    margin-top: 7
+    margin-right: 6
+    focusable: false

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -715,4 +715,12 @@ namespace Otc
         OFFER_STATE_ACCEPTED = 3,
         OFFER_STATE_ACCEPTEDEX = 255
     };
+
+    enum Supply_Stash_Actions_t : uint8_t
+    {
+        SUPPLY_STASH_ACTION_STOW_ITEM = 0,
+        SUPPLY_STASH_ACTION_STOW_CONTAINER = 1,
+        SUPPLY_STASH_ACTION_STOW_STACK = 2,
+        SUPPLY_STASH_ACTION_WITHDRAW = 3
+    };
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1684,3 +1684,10 @@ void Game::closeImbuingWindow()
         return;
     m_protocolGame->sendCloseImbuingWindow();
 }
+
+void Game::stashWithdraw(uint16_t itemId, uint32_t count, uint8_t stackpos)
+{
+    if (!canPerformGameAction())
+        return;
+    m_protocolGame->sendStashWithdraw(itemId, count, stackpos);
+}

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -378,6 +378,8 @@ public:
     void enableTileThingLuaCallback(bool value) { m_tileThingsLuaCallback = value; }
     bool isTileThingLuaCallbackEnabled() { return m_tileThingsLuaCallback; }
 
+    void stashWithdraw(uint16_t itemId, uint32_t count, uint8_t stackpos);
+
 protected:
     void enableBotCall() { m_denyBotCall = false; }
     void disableBotCall() { m_denyBotCall = true; }

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -359,6 +359,7 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_game", "enableTileThingLuaCallback", &Game::enableTileThingLuaCallback, &g_game);
     g_lua.bindSingletonFunction("g_game", "isTileThingLuaCallbackEnabled", &Game::isTileThingLuaCallbackEnabled, &g_game);
     g_lua.bindSingletonFunction("g_game", "isEnabledBotProtection", &Game::isEnabledBotProtection, &g_game);
+    g_lua.bindSingletonFunction("g_game", "stashWithdraw", &Game::stashWithdraw, &g_game);
 
     g_lua.registerSingletonClass("g_gameConfig");
     g_lua.bindSingletonFunction("g_gameConfig", "loadFonts", &GameConfig::loadFonts, &g_gameConfig);
@@ -643,6 +644,8 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<ThingType>("hasExpireStop", &ThingType::hasExpireStop);
     g_lua.bindClassMemberFunction<ThingType>("isPodium", &ThingType::isPodium);
     g_lua.bindClassMemberFunction<ThingType>("getDefaultAction", &ThingType::getDefaultAction);
+    g_lua.bindClassMemberFunction<ThingType>("getName", &ThingType::getName);
+    g_lua.bindClassMemberFunction<ThingType>("getDescription", &ThingType::getDescription);
 #ifdef FRAMEWORK_EDITOR
     g_lua.bindClassMemberFunction<ThingType>("exportImage", &ThingType::exportImage);
 #endif

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -218,6 +218,7 @@ namespace Proto
         ClientLeaveGame = 20,
         ClientPing = 29,
         ClientPingBack = 30,
+        ClientUseStash = 40,
 
         // all in game opcodes must be equal or greater than 50
         ClientFirstGameOpcode = 50,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -129,6 +129,7 @@ public:
     void sendApplyImbuement(uint8_t slot, uint32_t imbuementId, bool protectionCharm);
     void sendClearImbuement(uint8_t slot);
     void sendCloseImbuingWindow();
+    void sendStashWithdraw(uint16_t itemId, uint32_t count, uint8_t stackpos);
 
     // otclient only
     void sendChangeMapAwareRange(int xrange, int yrange);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3162,11 +3162,14 @@ void ProtocolGame::parseLootContainers(const InputMessagePtr& msg)
 void ProtocolGame::parseSupplyStash(const InputMessagePtr& msg)
 {
     const uint16_t size = msg->getU16();
+    std::vector<std::vector<uint32_t>> stashItems;
     for (int_fast32_t i = 0; i < size; ++i) {
-        msg->getU16(); // item id
-        msg->getU32(); // unknown
+        uint16_t itemId = msg->getU16();
+        uint32_t amount = msg->getU32();
+        stashItems.push_back({ itemId, amount });
     }
     msg->getU16(); // available slots?
+    g_lua.callGlobalField("g_game", "onSupplyStashEnter", stashItems);
 }
 
 void ProtocolGame::parseSpecialContainer(const InputMessagePtr& msg)

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -1114,3 +1114,14 @@ void ProtocolGame::sendCloseImbuingWindow()
     msg->addU8(Proto::ClientCloseImbuingWindow);
     send(msg);
 }
+
+void ProtocolGame::sendStashWithdraw(uint16_t itemId, uint32_t count, uint8_t stackpos)
+{
+    const auto& msg = std::make_shared<OutputMessage>();
+    msg->addU8(Proto::ClientUseStash);
+    msg->addU8(Otc::Supply_Stash_Actions_t::SUPPLY_STASH_ACTION_WITHDRAW);
+    msg->addU16(itemId);
+    msg->addU32(count);
+    msg->addU8(stackpos);
+    send(msg);
+}

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -43,6 +43,8 @@ void ThingType::unserializeAppearance(uint16_t clientId, ThingCategory category,
     m_null = false;
     m_id = clientId;
     m_category = category;
+    m_name = appearance.name();
+    m_description = appearance.description();
 
     const appearances::AppearanceFlags& flags = appearance.flags();
 
@@ -196,7 +198,7 @@ void ThingType::unserializeAppearance(uint16_t clientId, ThingCategory category,
         m_market.category = static_cast<ITEM_CATEGORY>(flags.market().category());
         m_market.tradeAs = flags.market().trade_as_object_id();
         m_market.showAs = flags.market().show_as_object_id();
-        m_market.name = flags.market().name();
+        m_market.name = m_name;
 
         for (const int32_t voc : flags.market().restrict_to_profession()) {
             m_market.restrictVocation |= voc;

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -393,6 +393,9 @@ public:
     int getExactHeight();
     TexturePtr getTexture(int animationPhase);
 
+    std::string getName() { return m_name; }
+    std::string getDescription() { return m_description; }
+
 private:
     static ThingFlagAttr thingAttrToThingFlagAttr(ThingAttr attr);
     static Size getBestTextureDimension(int w, int h, int count);
@@ -462,4 +465,7 @@ private:
     std::atomic_bool m_loading;
 
     Timer m_lastTimeUsage;
+
+    std::string m_name;
+    std::string m_description;
 };


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Unimplemented stash window. When requested, it does not open.

### **Expected**

Implemented stash window. When required, it opens and allows you to view the stored items, filter by item name, and extract them.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)
  - [x] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Test A
(IMPORTANT: it seems that due to a particularity of the server it is necessary to always enter the sqm next to the depot. In other words, if you login while in the sqm, walk out and then into the sqm again to be able to extract items from the stash. in GOD ghost mode it also seems to prevent the process).

Open the depot. Place some stackables by dragging them to the stash icon. Click on the stash icon. A window containing the stash items should open. In the upper space of the window, search for the name of an item that is or is not in the stash. Check if the items shown match your search. Click on an item to extract it. A small window should appear to select the quantity. Select the quantity, click "Ok" and check that it has been debited from the stash window and is in your inventory.
Repeat the previous procedures, but checking if the "Close" button in the stash window and if the "Cancel" button in the small quantity selection window are closing their respective containers.


**Test Configuration**:

  - Server Version: Canary 3.1.2
  - Client: 3.x
  - Operating System: Win 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
