### PR TITLE
perf: event onPropertyChange is disabled by default

### DIFF
--- a/src/client/uiitem.cpp
+++ b/src/client/uiitem.cpp
@@ -23,7 +23,7 @@
 #include "uiitem.h"
 #include <framework/graphics/fontmanager.h>
 
-UIItem::UIItem() { setProp(PropDraggable, true); }
+UIItem::UIItem() { setProp(PropDraggable, true, false); }
 
 void UIItem::drawSelf(DrawPoolType drawPane)
 {

--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -31,7 +31,7 @@
 
 UIMap::UIMap()
 {
-    setProp(PropDraggable, true);
+    setProp(PropDraggable, true, false);
     m_keepAspectRatio = true;
     m_limitVisibleRange = false;
     m_maxZoomIn = 3;

--- a/src/framework/luaengine/luaobject.h
+++ b/src/framework/luaengine/luaobject.h
@@ -165,7 +165,7 @@ int LuaObject::luaCallLuaField(const std::string_view field, const T&... args)
     try {
         self = asLuaObject();
     } catch (...) {
-        g_logger.fine(stdext::format(
+        g_logger.warning(stdext::format(
             "(%s):luaCallLuaField: Calling lua during object construction is not allowed.", getClassName()));
         return 0;
     }

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1483,14 +1483,16 @@ UIWidgetPtr UIWidget::backwardsGetWidgetById(const std::string_view id)
 
 void UIWidget::setProp(FlagProp prop, bool v, bool callEvent)
 {
-    bool lastProp = hasProp(prop);
-    if (v) m_flagsProp |= prop; else m_flagsProp &= ~prop;
-
     // Note: Be aware that setProp is called many times, there will be a cost,
     // so only call this event if it is really necessary.
     // callEvent = false by default
-    if (callEvent && lastProp != v)
-        callLuaField("onPropertyChange", prop, v);
+    if (callEvent) {
+        const bool lastProp = hasProp(prop);
+        if (lastProp != v)
+            callLuaField("onPropertyChange", prop, v, lastProp);
+    }
+
+    if (v) m_flagsProp |= prop; else m_flagsProp &= ~prop;
 }
 
 bool UIWidget::setState(Fw::WidgetState state, bool on)

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -35,10 +35,10 @@
 
 UIWidget::UIWidget()
 {
-    setProp(PropEnabled, true);
-    setProp(PropVisible, true);
-    setProp(PropFocusable, true);
-    setProp(PropFirstOnStyle, true);
+    setProp(PropEnabled, true, false);
+    setProp(PropVisible, true, false);
+    setProp(PropFocusable, true, false);
+    setProp(PropFirstOnStyle, true, false);
 
     m_clickTimer.stop();
 
@@ -868,7 +868,6 @@ void UIWidget::internalDestroy()
     releaseLuaFieldsTable();
 
     g_ui.onWidgetDestroy(static_self_cast<UIWidget>());
-
 }
 
 void UIWidget::destroy()
@@ -1482,12 +1481,15 @@ UIWidgetPtr UIWidget::backwardsGetWidgetById(const std::string_view id)
     return widget;
 }
 
-void UIWidget::setProp(FlagProp prop, bool v)
+void UIWidget::setProp(FlagProp prop, bool v, bool callEvent)
 {
     bool lastProp = hasProp(prop);
     if (v) m_flagsProp |= prop; else m_flagsProp &= ~prop;
 
-    if (lastProp != v)
+    // Note: Be aware that setProp is called many times, there will be a cost,
+    // so only call this event if it is really necessary.
+    // callEvent = false by default
+    if (callEvent && lastProp != v)
         callLuaField("onPropertyChange", prop, v);
 }
 

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -201,7 +201,7 @@ public:
     void setShader(const std::string_view name);
     bool hasShader() { return m_shader != nullptr; }
 
-    void setProp(FlagProp prop, bool v);
+    void setProp(FlagProp prop, bool v, bool callEvent = false);
     bool hasProp(FlagProp prop) { return (m_flagsProp & prop); }
 
     void disableUpdateTemporarily();


### PR DESCRIPTION
Be aware that setProp is called many times, there will be a cost, so only call this event if it is really necessary.
Performance depreciation reported by: @oskar1121 (thx)