### PR TITLE
fix: onLook is selecting incorrect floor as (first) reference

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -572,6 +572,27 @@ bool Tile::isCovered(int8_t firstFloor)
     return (m_isCovered & idState) == idState;
 }
 
+bool Tile::isClickable()
+{
+    bool hasGround = false;
+    bool hasOnBottom = false;
+    bool hasIgnoreLook = false;
+    for (const auto& thing : m_things) {
+        if (thing->isGround())
+            hasGround = true;
+        else if (thing->isOnBottom())
+            hasOnBottom = true;
+
+        if (thing->isIgnoreLook())
+            hasIgnoreLook = true;
+
+        if ((hasGround || hasOnBottom) && !hasIgnoreLook)
+            return true;
+    }
+
+    return false;
+}
+
 void Tile::onAddInMapView()
 {
     m_drawTopAndCreature = true;

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -133,7 +133,7 @@ public:
     int getThingCount() { return m_things.size() + m_effects.size(); }
 
     bool isWalkable(bool ignoreCreatures = false);
-    bool isClickable() { return (hasGround() || hasBottomItem()) && !hasIgnoreLook(); }
+    bool isClickable();
     bool isPathable() { return (m_thingTypeFlag & TileThingType::NOT_PATHABLE) == 0; }
     bool isFullGround() { return m_thingTypeFlag & TileThingType::FULL_GROUND; }
     bool isFullyOpaque() { return m_thingTypeFlag & TileThingType::IS_OPAQUE; }


### PR DESCRIPTION
Fix for #607 

Thanks to [dev-blackstone](https://github.com/dev-blackstone)
