### PR TITLE
fix: center text message like Tibia

### DIFF
--- a/modules/game_textmessage/textmessage.otui
+++ b/modules/game_textmessage/textmessage.otui
@@ -16,7 +16,7 @@ Panel
     layout:
       type: verticalBox
       fit-children: true
-    width: 360
+    width: 255
     anchors.centerIn: parent
 
     TextMessageLabel


### PR DESCRIPTION
Before fix:
![1](https://github.com/mehah/otclient/assets/7372287/fd8a9dc3-aaa4-4fa0-bcaa-70b4acd90a9f)

RL Tibia:
![2](https://github.com/mehah/otclient/assets/7372287/875f895c-7077-463e-9010-1a3f15f07c95)

After fix:
![3](https://github.com/mehah/otclient/assets/7372287/387f4907-a2dc-4564-96b6-eabee170df34)

