### PR TITLE
fix: Enter Game window when setUniqueServer is activated

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -577,6 +577,9 @@ function EnterGame.setUniqueServer(host, port, protocol, windowWidth, windowHeig
   local clientLabel = enterGame:getChildById('clientLabel')
   clientLabel:setVisible(false)
   clientLabel:setHeight(0)
+  local httpLoginBox = enterGame:getChildById('httpLoginBox')
+  httpLoginBox:setVisible(false)
+  httpLoginBox:setHeight(0)
 
   local serverListButton = enterGame:getChildById('serverListButton')
   serverListButton:setVisible(false)


### PR DESCRIPTION
The PR #647 bugged the enter game window, I've fixed

Before fix:
![1](https://github.com/mehah/otclient/assets/7372287/05ca3ce3-e70d-463d-bfe4-cebbb60ba567)

After fix:
![2](https://github.com/mehah/otclient/assets/7372287/8d3b4f7d-52cf-42d8-8529-857539edf573)
