### PR TITLE
fix: 443 port should be used for server URLs with prefix https

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -357,7 +357,7 @@ function EnterGame.tryHttpLogin(clientVersion, httpLogin)
   local url = G.host
 
   if G.port == nil then
-    isHttps, _ = string.find(host, "https")
+    isHttps, _ = string.find(G.host, "https")
     if isHttps ~= nil then
       G.port = 443
     else     -- http


### PR DESCRIPTION
# Description
Seems like right now there is a bug - even for server urls with prefix HTTPS port 80 is used. This commit fixes this problem

## Behavior

### **Actual**

![image](https://github.com/mehah/otclient/assets/33435745/f9299855-1f83-4142-a12e-e45855142fda)


![image](https://github.com/mehah/otclient/assets/33435745/947c77e3-7ce4-4d06-b7bf-fe87a0b4eff5)


### **Expected**

![image](https://github.com/mehah/otclient/assets/33435745/df153be9-d02a-45a6-860d-fcf596620bc5)
![image](https://github.com/mehah/otclient/assets/33435745/ae59ae8d-d7e8-4fc4-ae0d-443b6af815f4)


## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested


**Test Configuration**:

  - Server Version: 1332
  - Client: 1332
  - Operating System: Windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
