### PR TITLE
Update Effects.cpp for consistent behavior when rendering special patterns

### DIFF
--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -54,12 +54,16 @@ void Effect::draw(const Point& dest, bool drawThings, LightView* lightView)
         animationPhase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / ticks), getAnimationPhases() - 1);
     }
 
-    int xPattern = m_numPatternX;
-    int yPattern = m_numPatternY;
-    if (g_game.getFeature(Otc::GameMapOldEffectRendering)) {
-        const int offsetX = m_position.x - g_map.getCentralPosition().x;
-        const int offsetY = m_position.y - g_map.getCentralPosition().y;
+    const int offsetX = m_position.x - g_map.getCentralPosition().x;
+    const int offsetY = m_position.y - g_map.getCentralPosition().y;
 
+    int xPattern = unsigned(offsetX) % getNumPatternX();
+    xPattern = 1 - xPattern - getNumPatternX();
+    if (xPattern < 0) xPattern += getNumPatternX();
+
+    int yPattern = unsigned(offsetY) % getNumPatternY();
+
+    if (g_game.getFeature(Otc::GameMapOldEffectRendering)) {
         xPattern = offsetX % getNumPatternX();
         if (xPattern < 0)
             xPattern += getNumPatternX();


### PR DESCRIPTION
# Description

The current rendering behavior of spell effects with patternX = 2 and patternY = 2 exhibits inconsistency, as demonstrated in the provided videos.

## Behavior

### **Actual**

As an example, I've modified the "Eternal Winter" spell area to the following:
```
local area = {
	{0, 0, 0, 1, 0, 0, 0},
	{0, 0, 1, 1, 1, 0, 0},
	{0, 1, 1, 1, 1, 1, 0},
	{1, 1, 1, 2, 1, 1, 1},
	{0, 1, 1, 1, 1, 1, 0},
	{0, 0, 1, 1, 1, 0, 0},
	{0, 0, 0, 1, 0, 0, 0},
}
```
The spell produced the following behavior:

https://github.com/mehah/otclient/assets/68310301/15b811ee-3a62-4566-8c3e-b039f2d89dac

The animation renders correctly on certain sqms but not others, exhibiting inconsistent behavior.

### **Expected**

This pull request aims to rectify the issue by adjusting the effect rendering pattern formula to consistently align with the desired combat area, regardless of the pattern the object possesses.


https://github.com/mehah/otclient/assets/68310301/fad404f9-9ea6-4f9d-b1fc-4d34b58ab049


## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How to test and reproduce 

1. Create or modify a spell and use the CONST_ME_ICETORNADO, CONST_ME_BIGCLOUDS, or any effect whose pattern is not x = 1, y = 1.
2. Open the client and try the spell
3. Move one sqm and try it again (The rendering will be broken every other sqm)
4. Apply the changes on this PR
5. Try it again (The rendering is consistent)
6. Try effects that have another pattern setup and verify that the change didn't break them.

**Test Configuration**:

  - Server Version: TFS 1.4.2
  - Client: Mehah otclient (master)
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
