### PR TITLE
fix: Prevent crashes caused by client_entergame and other minor bugs.

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -267,7 +267,11 @@ function EnterGame.setPassword(password)
 end
 
 function EnterGame.setHttpLogin(httpLogin)
-  enterGame:getChildById('httpLoginBox'):setChecked(#httpLogin > 0)
+    if type(httpLogin) == "boolean" then
+        enterGame:getChildById('httpLoginBox'):setChecked(httpLogin)
+    else
+        enterGame:getChildById('httpLoginBox'):setChecked(#httpLogin > 0)
+    end
 end
 
 function EnterGame.clearAccountFields()

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -498,7 +498,13 @@ function EnterGame.doLogin()
     protocolLogin.onCharacterList = onCharacterList
     protocolLogin.onUpdateNeeded = onUpdateNeeded
 
-    loadBox = displayCancelBox(tr('Please wait'), tr('Connecting to login server...'))
+    if not host then
+        loadBox = displayCancelBox(tr('Please wait'), tr('ERROR , try adding \n- ip/login.php \n- Enable HTTP login'))
+    else
+        loadBox = displayCancelBox(tr('Please wait'), tr('Connecting to login server...\nServer: [%s]',
+            host .. ":" .. tostring(G.port) .. path))
+    end
+    
     connect(loadBox, {
       onCancel = function(msgbox)
         loadBox = nil

--- a/modules/client_entergame/entergame.otui
+++ b/modules/client_entergame/entergame.otui
@@ -1,7 +1,6 @@
 EnterGameWindow < MainWindow
   !text: tr('Enter Game')
   size: 236 316
-  draggable: false
 
 EnterGameButton < Button
   width: 64


### PR DESCRIPTION
### 1.- fix: crash game_entergame if httpLoginBox is boolean
produced in #647

I think `httpLogin ` is always boolean, but I haven't studied pr 647 enough.
```
    if type(httpLogin) == "boolean" then
        enterGame:getChildById('httpLoginBox'):setChecked(httpLogin)
    else
        enterGame:getChildById('httpLoginBox'):setChecked(#httpLogin > 0)
    end
```

Error:
```
ERROR: Lua exception: /client_entergame/entergame.lua:270: attempt to get length of local 'httpLogin' (a boolean value)
stack traceback:
	[C]: in function '__len'
	/client_entergame/entergame.lua:270: in function 'setHttpLogin'
	/client_serverlist/serverlist.lua:44: in function 'select'
	/client_serverlist/serverlist.lua:81: in function </client_serverlist/serverlist.lua:80>
ERROR: protected lua call failed: LUA ERROR:
/client_entergame/entergame.lua:270: attempt to get length of local 'httpLogin' (a boolean value)
stack traceback:
	[C]: in function '__len'
	/client_entergame/entergame.lua:270: in function 'setHttpLogin'
	/client_serverlist/serverlist.lua:44: in function 'select'
	/client_serverlist/serverlist.lua:81: in function </client_serverlist/serverlist.lua:80>
ERROR: Lua exception: 
ERROR: protected lua call failed: LUA ERROR:

ERROR: Lua exception: 
ERROR: protected lua call failed: LUA ERROR:

ERROR: Lua exception: 
ERROR: protected lua call failed: LUA ERROR:
```
https://github.com/mehah/otclient/assets/114332266/3bd9e704-ad64-4a49-a7b5-3d7a27cbdbbf

### 2.- fix: game_entergame if host nil windows is hidden

https://github.com/mehah/otclient/assets/114332266/dc8d1b72-a4d7-4e2f-af36-d478dbe31ca6

fix:
![image](https://github.com/mehah/otclient/assets/114332266/d5617a83-3d4f-4c17-b4c5-fa286b843936)



### 3.- temp fix: game_entergame windows is not centered

https://github.com/mehah/otclient/assets/114332266/5374b552-4db8-4c0a-a0c8-846b7732df82

```
the original bug is in
EnterGame.toggleAuthenticatorToken
EnterGame.toggleStayLoggedBox

I don't have how to test I don't use token
```


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 860 | 1320
  - Operating System: windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
