### PR TITLE
feat: Creature Information by UIWidget

### DIFF
--- a/data/setup.otml
+++ b/data/setup.otml
@@ -17,6 +17,7 @@ game
     transparent-floor-view-range: 2
 
   creature
+    draw-information-by-widget-beta: true
     force-new-walking-formula: true
     shield-blink-ticks: 500
     volatile-square-duration: 1000

--- a/modules/client_options/general.otui
+++ b/modules/client_options/general.otui
@@ -42,6 +42,8 @@ Panel
     anchors.right: parent.right
     anchors.top: prev.bottom
     margin-top: 12
+    !enabled: g_gameConfig.isDrawingInformationByWidget() == false
+
 
   OptionScrollbar
     id: creatureInformationScale
@@ -51,6 +53,7 @@ Panel
     margin-top: 3
     minimum: 1
     maximum: 9
+    !enabled: g_gameConfig.isDrawingInformationByWidget() == false
 
   Label
     id: staticTextScaleLabel

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -46,8 +46,8 @@ local defaultOptions = {
     creatureInformationScale = 0,
     staticTextScale = 0,
     animatedTextScale = 0,
-    setEffectAlphaScroll = 100 ,
-    setMissileAlphaScroll = 100 ,
+    setEffectAlphaScroll = 100,
+    setMissileAlphaScroll = 100,
 }
 
 local optionsWindow
@@ -315,10 +315,22 @@ function setOption(key, value, force)
         g_map.setFloatingEffect(value)
     elseif key == 'displayNames' then
         gameMapPanel:setDrawNames(value)
+
+        if g_gameConfig.isDrawingInformationByWidget() then
+            modules.game_creatureinformation.toggleInformation()
+        end
     elseif key == 'displayHealth' then
         gameMapPanel:setDrawHealthBars(value)
+
+        if g_gameConfig.isDrawingInformationByWidget() then
+            modules.game_creatureinformation.toggleInformation()
+        end
     elseif key == 'displayMana' then
         gameMapPanel:setDrawManaBar(value)
+
+        if g_gameConfig.isDrawingInformationByWidget() then
+            modules.game_creatureinformation.toggleInformation()
+        end
     elseif key == 'displayText' then
         g_app.setDrawTexts(value)
     elseif key == 'dontStretchShrink' then
@@ -354,12 +366,11 @@ function setOption(key, value, force)
         local fadeMode = value == 1
         graphicsPanel:getChildById('floorFading'):setEnabled(fadeMode)
         graphicsPanel:getChildById('floorFadingLabel'):setEnabled(fadeMode)
-        
     elseif key == 'setEffectAlphaScroll' then
-        g_client.setEffectAlpha(value/100)
+        g_client.setEffectAlpha(value / 100)
         generalPanel:getChildById('setEffectAlphaLabel'):setText(tr('Opacity Effect: %s%%', value))
     elseif key == 'setMissileAlphaScroll' then
-        g_client.setMissileAlpha(value/100)
+        g_client.setMissileAlpha(value / 100)
         generalPanel:getChildById('setMissileAlphaLabel'):setText(tr('Opacity Missile: %s%%', value))
     end
 

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -5,8 +5,10 @@ IconInformation < UIWidget
 
 UIWidget
   id: creatureInformation
-  size: 32 32
-
+  $size: 32 32
+  !margin-left: math.floor(-32/ 1.5)
+  !margin-top: math.floor(-32 / 2)
+  
   UILabel
     id: name
     anchors.top: parent.top
@@ -18,6 +20,7 @@ UIWidget
     id: lifeBar
     width: 40
     height: 4
+    image-draw-order: 2
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.HorizontalCenter: parent.HorizontalCenter
@@ -29,6 +32,7 @@ UIWidget
     width: 40
     height: 4
     margin-top: 2
+    image-draw-order: 2
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.HorizontalCenter: parent.HorizontalCenter

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -1,0 +1,33 @@
+IconInformation < UIWidget
+  anchors.top: prev.top
+  anchors.left: prev.right
+  margin-left: 2
+
+UIWidget
+  size: 32 32
+
+  UILabel
+    id: name
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.HorizontalCenter: parent.HorizontalCenter
+    !font: g_gameConfig.getCreatureNameFontName()
+
+  ProgressBar
+    id: lifeBar
+    width: 30
+    height: 2
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.HorizontalCenter: parent.HorizontalCenter
+
+  ProgressBar
+    id: manaBar
+    visible: false
+    background-color: blue
+    width: 30
+    height: 2
+    margin-top: 2
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.HorizontalCenter: parent.HorizontalCenter

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -32,3 +32,9 @@ UIWidget
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.HorizontalCenter: parent.HorizontalCenter
+
+  UIWidget
+    id: icons
+    size: 128 32
+    anchors.top: lifeBar.bottom
+    anchors.left: lifeBar.right

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -5,12 +5,13 @@ IconInformation < UIWidget
 
 UIWidget
   id: creatureInformation
-  $size: 32 32
+  size: 32 32
   !margin-left: math.floor(-32/ 1.5)
   !margin-top: math.floor(-32 / 2)
 
   UILabel
     id: name
+    text-auto-resize: true
     anchors.top: parent.top
     anchors.left: parent.left
     anchors.HorizontalCenter: parent.HorizontalCenter

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -4,6 +4,7 @@ IconInformation < UIWidget
   margin-left: 2
 
 UIWidget
+  id: creatureInformation
   size: 32 32
 
   UILabel
@@ -15,8 +16,8 @@ UIWidget
 
   ProgressBar
     id: lifeBar
-    width: 30
-    height: 2
+    width: 40
+    height: 4
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.HorizontalCenter: parent.HorizontalCenter
@@ -25,8 +26,8 @@ UIWidget
     id: manaBar
     visible: false
     background-color: blue
-    width: 30
-    height: 2
+    width: 40
+    height: 4
     margin-top: 2
     anchors.top: prev.bottom
     anchors.left: parent.left

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -36,5 +36,6 @@ UIWidget
   UIWidget
     id: icons
     size: 128 32
+    visible: false
     anchors.top: lifeBar.bottom
     anchors.left: lifeBar.right

--- a/modules/game_creatureinformation/creatureInformation.otui
+++ b/modules/game_creatureinformation/creatureInformation.otui
@@ -1,14 +1,14 @@
 IconInformation < UIWidget
   anchors.top: prev.top
   anchors.left: prev.right
-  margin-left: 2
+  margin-left: 3
 
 UIWidget
   id: creatureInformation
   $size: 32 32
   !margin-left: math.floor(-32/ 1.5)
   !margin-top: math.floor(-32 / 2)
-  
+
   UILabel
     id: name
     anchors.top: parent.top

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -1,0 +1,127 @@
+controller = Controller:new()
+
+if not g_gameConfig.isDrawingInformationByWidget() then
+    return
+end
+
+g_logger.warning("Creature Information By Widget is enabled. (performance may be depreciated)");
+
+local COVERED_COLOR = '#606060'
+local NPC_COLOR = '#66CCFF'
+
+local function onCreate(creature)
+    local widget = g_ui.loadUI('creatureinformation')
+
+    widget:setMarginLeft(-widget:getWidth() / 1.5)
+    widget:setMarginTop(-widget:getHeight() / 2)
+
+    local nameSize = widget.name:getTextSize();
+
+    if creature:isLocalPlayer() then
+        widget.manaBar:setVisible(true)
+    end
+
+    creature:setWidgetInformation(widget)
+end
+
+local function onHealthPercentChange(creature, healthPercent, oldHealthPercent)
+    local widget = creature:getWidgetInformation()
+    local color = nil
+
+    if healthPercent > 92 then
+        color = '#00BC00';
+    elseif healthPercent > 60 then
+        color = '#50A150';
+    elseif healthPercent > 30 then
+        color = '#A1A100';
+    elseif healthPercent > 8 then
+        color = '#BF0A0A';
+    elseif healthPercent > 3 then
+        color = '#910F0F';
+    else
+        color = '#850C0F'
+    end
+
+    widget.name:setColor(color)
+    widget.lifeBar:setPercent(healthPercent)
+    widget.lifeBar:setBackgroundColor(color)
+end
+
+local function onManaChange(player, mana, maxMana, oldMana, oldMaxMana)
+    local widget = player:getWidgetInformation()
+    if player:getMaxMana() > 1 then
+        widget.manaBar:setPercent((mana / maxMana) * 100)
+    else
+        widget.manaBar:setPercent(1)
+    end
+end
+
+local function onChangeName(creature, name, oldName)
+    local infoWidget = creature:getWidgetInformation()
+
+    infoWidget.name:setText(name)
+
+    if g_game.getFeature(GameBlueNpcNameColor) and creature:isNpc() and creature:isFullHealth() then
+        infoWidget.name:setColor(NPC_COLOR)
+    else
+        --widget.name:setColor(NPC_COLOR)
+    end
+end
+
+local function setIcon(creature, id, getIconPath)
+    local path, blink = getIconPath(id)
+
+    local infoWidget = creature:getWidgetInformation()
+    local icon = g_ui.createWidget('IconInformation', infoWidget)
+    icon:setImageSource(path)
+end
+
+local function onTypeChange(creature, id)
+    setIcon(creature, id, getTypeImagePath)
+end
+
+local function onIconChange(creature, id)
+    setIcon(creature, id, getIconImagePath)
+end
+
+local function onSkullChange(creature, id)
+    setIcon(creature, id, getSkullImagePath)
+end
+
+local function onShieldChange(creature, id)
+    setIcon(creature, id, getShieldImagePathAndBlink)
+end
+
+local function onEmblemChange(creature, id)
+    setIcon(creature, id, getEmblemImagePath)
+end
+
+controller = Controller:new()
+
+function controller:onGameStart()
+    local player = g_game.getLocalPlayer()
+    onCreate(player)
+    onHealthPercentChange(player, player:getHealthPercent(), player:getHealthPercent())
+    onChangeName(player, player:getName())
+    onManaChange(player, player:getMana(), player:getMaxMana(), player:getMana(), player:getMaxMana())
+    onTypeChange(player, 3)
+    onIconChange(player, 1)
+    onSkullChange(player, 1)
+    onShieldChange(player, 1)
+    onEmblemChange(player, 1)
+end
+
+controller:addEvent(LocalPlayer, {
+    onManaChange = onManaChange
+})
+
+controller:addEvent(Creature, {
+    onCreate = onCreate,
+    onHealthPercentChange = onHealthPercentChange,
+    onChangeName = onChangeName,
+    onTypeChange = onTypeChange,
+    onIconChange = onIconChange,
+    onSkullChange = onSkullChange,
+    onShieldChange = onShieldChange,
+    onEmblemChange = onEmblemChange,
+})

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -11,6 +11,11 @@ local NPC_COLOR = '#66CCFF'
 
 local function onCreate(creature)
     local widget = g_ui.loadUI('creatureinformation')
+
+    -- Fix rendering order
+    widget.lifeBar:setImageDrawOrder(2)
+    widget.manaBar:setImageDrawOrder(2)
+
     widget:setMarginLeft(-widget:getWidth() / 1.5)
     widget:setMarginTop(-widget:getHeight() / 2)
 

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -15,15 +15,13 @@ local NPC_COLOR = '#66CCFF'
 local function onCreate(creature)
     local widget = g_ui.loadUI('creatureinformation')
 
+    widget.manaBar:setVisible(creature:isLocalPlayer())
+
     if debug then
         widget:setBorderColor('red')
         widget:setBorderWidth(2)
         widget.icons:setBorderColor('yellow')
         widget.icons:setBorderWidth(2)
-    end
-
-    if creature:isLocalPlayer() then
-        widget.manaBar:setVisible(true)
     end
 
     creature:setWidgetInformation(widget)
@@ -77,7 +75,7 @@ local function onCovered(creature, isCovered, oldIsCovered)
         infoWidget.name:setColor(COVERED_COLOR)
         infoWidget.lifeBar:setBackgroundColor(COVERED_COLOR)
     else
-        onHealthPercentChange(creature, creature:getHealthPercent(), creature:getHealthPercent())
+        onHealthPercentChange(creature, creature:getHealthPercent())
     end
 end
 
@@ -129,7 +127,7 @@ local creatureEvents = {
     onTypeChange = function(creature, id) setIcon(creature, id, getTypeImagePath, 'type') end,
     onIconChange = function(creature, id) setIcon(creature, id, getIconImagePath, 'icon') end,
     onSkullChange = function(creature, id) setIcon(creature, id, getSkullImagePath, 'skull') end,
-    onShieldChange = function(creature, id) setIcon(creature, id, getSkullImagePath, 'skull') end,
+    onShieldChange = function(creature, id) setIcon(creature, id, getShieldImagePathAndBlink, 'shield') end,
     onEmblemChange = function(creature, id) setIcon(creature, id, getEmblemImagePath, 'emblem') end,
 };
 

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -71,8 +71,16 @@ local function onChangeName(creature, name, oldName)
 
     if g_game.getFeature(GameBlueNpcNameColor) and creature:isNpc() and creature:isFullHealth() then
         infoWidget.name:setColor(NPC_COLOR)
+    end
+end
+
+local function onCovered(creature, isCovered, oldIsCovered)
+    local infoWidget = creature:getWidgetInformation()
+    if isCovered then
+        infoWidget.name:setColor(COVERED_COLOR)
+        infoWidget.lifeBar:setBackgroundColor(COVERED_COLOR)
     else
-        --widget.name:setColor(NPC_COLOR)
+        onHealthPercentChange(creature, creature:getHealthPercent(), creature:getHealthPercent())
     end
 end
 
@@ -142,6 +150,7 @@ controller:addEvent(LocalPlayer, {
 controller:addEvent(Creature, {
     onCreate = onCreate,
     onOutfitChange = onOutfitChange,
+    onCovered = onCovered,
     onHealthPercentChange = onHealthPercentChange,
     onChangeName = onChangeName,
     onTypeChange = onTypeChange,

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -11,7 +11,6 @@ local NPC_COLOR = '#66CCFF'
 
 local function onCreate(creature)
     local widget = g_ui.loadUI('creatureinformation')
-
     widget:setMarginLeft(-widget:getWidth() / 1.5)
     widget:setMarginTop(-widget:getHeight() / 2)
 
@@ -73,6 +72,7 @@ local function setIcon(creature, id, getIconPath)
 
     local infoWidget = creature:getWidgetInformation()
     local icon = g_ui.createWidget('IconInformation', infoWidget)
+    icon:setId('icon' .. infoWidget:getChildCount())
     icon:setImageSource(path)
 end
 
@@ -99,7 +99,7 @@ end
 controller = Controller:new()
 
 function controller:onGameStart()
-    local player = g_game.getLocalPlayer()
+    --[[local player = g_game.getLocalPlayer()
     onCreate(player)
     onHealthPercentChange(player, player:getHealthPercent(), player:getHealthPercent())
     onChangeName(player, player:getName())
@@ -108,7 +108,7 @@ function controller:onGameStart()
     onIconChange(player, 1)
     onSkullChange(player, 1)
     onShieldChange(player, 1)
-    onEmblemChange(player, 1)
+    onEmblemChange(player, 1)]]
 end
 
 controller:addEvent(LocalPlayer, {

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -6,7 +6,7 @@ end
 
 g_logger.warning("Creature Information By Widget is enabled. (performance may be depreciated)");
 
-local debug = false
+local debug = true
 local COVERED_COLOR = '#606060'
 local NPC_COLOR = '#66CCFF'
 
@@ -16,6 +16,8 @@ local function onCreate(creature)
     if debug then
         widget:setBorderColor('red')
         widget:setBorderWidth(2)
+        widget.icons:setBorderColor('yellow')
+        widget.icons:setBorderWidth(2)
     end
 
     -- Fix rendering order
@@ -99,33 +101,47 @@ local function onOutfitChange(creature, outfit, oldOutfit)
     infoWidget:setMarginTop(-cropSize)
 end
 
-local function setIcon(creature, id, getIconPath)
-    local path, blink = getIconPath(id)
-
+local function setIcon(creature, id, getIconPath, typeIcon)
     local infoWidget = creature:getWidgetInformation()
-    local icon = g_ui.createWidget('IconInformation', infoWidget)
-    icon:setId('icon' .. infoWidget:getChildCount())
+    local oldIcon = infoWidget.icons[typeIcon]
+    if oldIcon then
+        oldIcon:destroy()
+    end
+
+    local path, blink = getIconPath(id)
+    if path == nil then
+        return
+    end
+
+    local hasChildren = infoWidget.icons:hasChildren()
+    local icon = g_ui.createWidget('IconInformation', infoWidget.icons)
+    icon:setId(typeIcon)
     icon:setImageSource(path)
+
+    if not hasChildren then
+        icon:addAnchor(AnchorTop, 'parent', AnchorTop)
+        icon:addAnchor(AnchorLeft, 'parent', AnchorLeft)
+    end
 end
 
 local function onTypeChange(creature, id)
-    setIcon(creature, id, getTypeImagePath)
+    setIcon(creature, id, getTypeImagePath, 'type')
 end
 
 local function onIconChange(creature, id)
-    setIcon(creature, id, getIconImagePath)
+    setIcon(creature, id, getIconImagePath, 'icon')
 end
 
 local function onSkullChange(creature, id)
-    setIcon(creature, id, getSkullImagePath)
+    setIcon(creature, id, getSkullImagePath, 'skull')
 end
 
 local function onShieldChange(creature, id)
-    setIcon(creature, id, getShieldImagePathAndBlink)
+    setIcon(creature, id, getShieldImagePathAndBlink, 'shield')
 end
 
 local function onEmblemChange(creature, id)
-    setIcon(creature, id, getEmblemImagePath)
+    setIcon(creature, id, getEmblemImagePath, 'emblem')
 end
 
 controller = Controller:new()

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -90,11 +90,33 @@ local function onOutfitChange(creature, outfit, oldOutfit)
     end
 end
 
+local function blinkIcon(icon, ticks)
+    if icon:isDestroyed() then
+        return
+    end
+
+    icon:setVisible(not icon:isVisible())
+
+    scheduleEvent(function()
+        blinkIcon(icon, ticks)
+    end, ticks)
+end
+
 local function setIcon(creature, id, getIconPath, typeIcon)
+    local setParentAnchor = function(w)
+        w:addAnchor(AnchorTop, 'parent', AnchorTop)
+        w:addAnchor(AnchorLeft, 'parent', AnchorLeft)
+    end
+
     local infoWidget = creature:getWidgetInformation()
     local oldIcon = infoWidget.icons[typeIcon]
     if oldIcon then
+        local index = oldIcon:getChildIndex()
         oldIcon:destroy()
+
+        if index == 1 and infoWidget.icons:hasChildren() then
+            setParentAnchor(infoWidget.icons:getChildByIndex(index))
+        end
     end
 
     local hasChildren = infoWidget.icons:hasChildren()
@@ -112,9 +134,12 @@ local function setIcon(creature, id, getIconPath, typeIcon)
     icon:setImageSource(path)
 
     if not hasChildren then
-        icon:addAnchor(AnchorTop, 'parent', AnchorTop)
-        icon:addAnchor(AnchorLeft, 'parent', AnchorLeft)
+        setParentAnchor(icon)
         infoWidget.icons:setVisible(true)
+    end
+
+    if blink then
+        blinkIcon(icon, g_gameConfig.getShieldBlinkTicks())
     end
 end
 

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -6,11 +6,17 @@ end
 
 g_logger.warning("Creature Information By Widget is enabled. (performance may be depreciated)");
 
+local debug = false
 local COVERED_COLOR = '#606060'
 local NPC_COLOR = '#66CCFF'
 
 local function onCreate(creature)
     local widget = g_ui.loadUI('creatureinformation')
+
+    if debug then
+        widget:setBorderColor('red')
+        widget:setBorderWidth(2)
+    end
 
     -- Fix rendering order
     widget.lifeBar:setImageDrawOrder(2)
@@ -18,8 +24,6 @@ local function onCreate(creature)
 
     widget:setMarginLeft(-widget:getWidth() / 1.5)
     widget:setMarginTop(-widget:getHeight() / 2)
-
-    local nameSize = widget.name:getTextSize();
 
     if creature:isLocalPlayer() then
         widget.manaBar:setVisible(true)
@@ -72,6 +76,21 @@ local function onChangeName(creature, name, oldName)
     end
 end
 
+local function onOutfitChange(creature, outfit, oldOutfit)
+    local infoWidget = creature:getWidgetInformation()
+    if not infoWidget then
+        return
+    end
+
+    local cropSize = 0
+
+    if g_gameConfig.isAdjustCreatureInformationBasedCropSize() then
+        cropSize = creature:getExactSize()
+    end
+
+    infoWidget:setMarginTop(-cropSize)
+end
+
 local function setIcon(creature, id, getIconPath)
     local path, blink = getIconPath(id)
 
@@ -122,6 +141,7 @@ controller:addEvent(LocalPlayer, {
 
 controller:addEvent(Creature, {
     onCreate = onCreate,
+    onOutfitChange = onOutfitChange,
     onHealthPercentChange = onHealthPercentChange,
     onChangeName = onChangeName,
     onTypeChange = onTypeChange,

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -92,13 +92,9 @@ local function onOutfitChange(creature, outfit, oldOutfit)
         return
     end
 
-    local cropSize = 0
-
     if g_gameConfig.isAdjustCreatureInformationBasedCropSize() then
-        cropSize = creature:getExactSize()
+        infoWidget:setMarginTop(-creature:getExactSize())
     end
-
-    infoWidget:setMarginTop(-cropSize)
 end
 
 local function setIcon(creature, id, getIconPath, typeIcon)
@@ -108,12 +104,16 @@ local function setIcon(creature, id, getIconPath, typeIcon)
         oldIcon:destroy()
     end
 
+    local hasChildren = infoWidget.icons:hasChildren()
+
     local path, blink = getIconPath(id)
     if path == nil then
+        if not hasChildren then
+            infoWidget.icons:setVisible(false)
+        end
         return
     end
 
-    local hasChildren = infoWidget.icons:hasChildren()
     local icon = g_ui.createWidget('IconInformation', infoWidget.icons)
     icon:setId(typeIcon)
     icon:setImageSource(path)
@@ -121,6 +121,7 @@ local function setIcon(creature, id, getIconPath, typeIcon)
     if not hasChildren then
         icon:addAnchor(AnchorTop, 'parent', AnchorTop)
         icon:addAnchor(AnchorLeft, 'parent', AnchorLeft)
+        infoWidget.icons:setVisible(true)
     end
 end
 

--- a/modules/game_creatureinformation/creatureinformation.otmod
+++ b/modules/game_creatureinformation/creatureinformation.otmod
@@ -1,0 +1,9 @@
+Module
+  name: game_creatureinformation
+  description:
+  author: Mehah
+  website:
+  scripts: [creatureinformation]
+  sandboxed: true
+  @onLoad: controller:init()
+  @onUnload: controller:terminate()

--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -37,5 +37,6 @@ Module
     - game_shaders
     - game_attachedeffects
     - game_stash
+    - game_creatureinformation
   @onLoad: init()
   @onUnload: terminate()

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -228,9 +228,9 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, boo
             auto extraTextSize = m_text->getTextSize();
             Rect extraTextRect = Rect(p.x - extraTextSize.width() / 2.0, p.y + 15, extraTextSize);
             m_text->drawText(extraTextRect.center(), extraTextRect);
-    }
+        }
 #endif
-}
+    }
 
     if (m_skull != Otc::SkullNone && m_skullTexture)
         g_drawPool.addTexturedPos(m_skullTexture, backgroundRect.x() + 13.5 + 12, backgroundRect.y() + 5);
@@ -1106,7 +1106,7 @@ void Creature::setWidgetInformation(const UIWidgetPtr& info) {
     if (m_widgetInformation == info)
         return;
 
-    if (m_widgetInformation) {
+    if (m_widgetInformation && !m_widgetInformation->isDestroyed()) {
         m_widgetInformation->destroy();
         g_map.removeAttachedWidgetFromObject(m_widgetInformation);
     }

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -132,7 +132,7 @@ void Creature::draw(const Rect& destRect, uint8_t size)
     } g_drawPool.releaseFrameBuffer(destRect);
 }
 
-void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, bool isCovered, int drawFlags)
+void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, int drawFlags)
 {
     static const Color
         DEFAULT_COLOR(96, 96, 96),
@@ -142,13 +142,6 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, boo
         return;
 
     if (g_gameConfig.isDrawingInformationByWidget()) {
-        // retirar do drawInformation
-        if (isCovered != m_isCovered) {
-            const auto oldCovered = m_isCovered;
-            m_isCovered = isCovered;
-            callLuaField("onCovered", isCovered, oldCovered);
-        }
-
         if (m_widgetInformation)
             m_widgetInformation->draw(mapRect.rect, DrawPoolType::FOREGROUND);
         return;
@@ -168,7 +161,7 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, boo
 
     auto fillColor = DEFAULT_COLOR;
 
-    if (!isCovered) {
+    if (!isCovered()) {
         if (g_game.getFeature(Otc::GameBlueNpcNameColor) && isNpc() && isFullHealth())
             fillColor = NPC_COLOR;
         else fillColor = m_informationColor;
@@ -1134,6 +1127,15 @@ void Creature::setName(const std::string_view name) {
     const auto& oldName = m_name.getText();
     m_name.setText(name);
     callLuaField("onChangeName", name, oldName);
+}
+
+void Creature::setCovered(bool covered) {
+    if (m_isCovered == covered)
+        return;
+
+    const auto oldCovered = m_isCovered;
+    m_isCovered = covered;
+    callLuaField("onCovered", covered, oldCovered);
 }
 
 #ifndef BOT_PROTECTION

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -817,11 +817,11 @@ void Creature::setBaseSpeed(uint16_t baseSpeed)
     callLuaField("onBaseSpeedChange", baseSpeed, oldBaseSpeed);
 }
 
-void Creature::setType(uint8_t type) { callLuaField("onTypeChange", m_type = type); }
-void Creature::setIcon(uint8_t icon) { callLuaField("onIconChange", m_icon = icon); }
-void Creature::setSkull(uint8_t skull) { callLuaField("onSkullChange", m_skull = skull); }
-void Creature::setShield(uint8_t shield) { callLuaField("onShieldChange", m_shield = shield); }
-void Creature::setEmblem(uint8_t emblem) { callLuaField("onEmblemChange", m_emblem = emblem); }
+void Creature::setType(uint8_t v) { if (m_type != v) callLuaField("onTypeChange", m_type = v); }
+void Creature::setIcon(uint8_t v) { if (m_icon != v) callLuaField("onIconChange", m_icon = v); }
+void Creature::setSkull(uint8_t v) { if (m_skull != v) callLuaField("onSkullChange", m_skull = v); }
+void Creature::setShield(uint8_t v) { if (m_shield != v) callLuaField("onShieldChange", m_shield = v); }
+void Creature::setEmblem(uint8_t v) { if (m_emblem != v) callLuaField("onEmblemChange", m_emblem = v); }
 
 void Creature::setTypeTexture(const std::string& filename) { m_typeTexture = g_textures.getTexture(filename); }
 void Creature::setIconTexture(const std::string& filename) { m_iconTexture = g_textures.getTexture(filename); }

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -1135,7 +1135,10 @@ void Creature::setCovered(bool covered) {
 
     const auto oldCovered = m_isCovered;
     m_isCovered = covered;
-    callLuaField("onCovered", covered, oldCovered);
+
+    g_dispatcher.addEvent([self = static_self_cast<Creature>(), covered, oldCovered] {
+        self->callLuaField("onCovered", covered, oldCovered);
+    });
 }
 
 #ifndef BOT_PROTECTION

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -132,7 +132,7 @@ void Creature::draw(const Rect& destRect, uint8_t size)
     } g_drawPool.releaseFrameBuffer(destRect);
 }
 
-void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, bool useGray, int drawFlags)
+void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, bool isCovered, int drawFlags)
 {
     static const Color
         DEFAULT_COLOR(96, 96, 96),
@@ -142,6 +142,13 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, boo
         return;
 
     if (g_gameConfig.isDrawingInformationByWidget()) {
+        // retirar do drawInformation
+        if (isCovered != m_isCovered) {
+            const auto oldCovered = m_isCovered;
+            m_isCovered = isCovered;
+            callLuaField("onCovered", isCovered, oldCovered);
+        }
+
         if (m_widgetInformation)
             m_widgetInformation->draw(mapRect.rect, DrawPoolType::FOREGROUND);
         return;
@@ -161,7 +168,7 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, boo
 
     auto fillColor = DEFAULT_COLOR;
 
-    if (!useGray) {
+    if (!isCovered) {
         if (g_game.getFeature(Otc::GameBlueNpcNameColor) && isNpc() && isFullHealth())
             fillColor = NPC_COLOR;
         else fillColor = m_informationColor;

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -152,6 +152,7 @@ public:
     bool isFullHealth() { return m_healthPercent == 100; }
     bool canBeSeen() { return !isInvisible() || isPlayer(); }
     bool isCreature() override { return true; }
+    bool isCovered() { return m_isCovered; }
 
     bool isDisabledWalkAnimation() { return m_disableWalkAnimation > 0; }
     void setDisableWalkAnimation(bool v) {
@@ -254,6 +255,7 @@ private:
     bool m_drawOutfitColor{ true };
     bool m_showShieldTexture{ true };
     bool m_typing{ false };
+    bool m_isCovered{ false };
 
     uint8_t m_disableWalkAnimation{ 0 };
 

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -58,7 +58,7 @@ public:
     void draw(const Rect& destRect, uint8_t size);
 
     void internalDraw(Point dest, LightView* lightView = nullptr, const Color& color = Color::white);
-    void drawInformation(const MapPosInfo& mapRect, const Point& dest, bool useGray, int drawFlags);
+    void drawInformation(const MapPosInfo& mapRect, const Point& dest, int drawFlags);
 
     void setId(uint32_t id) override { m_id = id; }
     void setMasterId(uint32_t id) { m_masterId = id; }
@@ -153,6 +153,8 @@ public:
     bool canBeSeen() { return !isInvisible() || isPlayer(); }
     bool isCreature() override { return true; }
     bool isCovered() { return m_isCovered; }
+
+    void setCovered(bool covered);
 
     bool isDisabledWalkAnimation() { return m_disableWalkAnimation > 0; }
     void setDisableWalkAnimation(bool v) {

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -45,8 +45,11 @@ public:
     static double speedC;
 
     Creature();
+    ~Creature();
 
     static bool hasSpeedFormula();
+
+    void onCreate();
 
     void onAppear() override;
     void onDisappear() override;
@@ -59,7 +62,7 @@ public:
 
     void setId(uint32_t id) override { m_id = id; }
     void setMasterId(uint32_t id) { m_masterId = id; }
-    void setName(const std::string_view name) { m_name.setText(name); }
+    void setName(const std::string_view name);
     void setHealthPercent(uint8_t healthPercent);
     void setDirection(Otc::Direction direction);
     void setOutfit(const Outfit& outfit);
@@ -146,7 +149,7 @@ public:
     bool isRemoved() { return m_removed; }
     bool isInvisible() { return m_outfit.isEffect() && m_outfit.getAuxId() == 13; }
     bool isDead() { return m_healthPercent <= 0; }
-    bool isFullHealth() const { return m_healthPercent == 100; }
+    bool isFullHealth() { return m_healthPercent == 100; }
     bool canBeSeen() { return !isInvisible() || isPlayer(); }
     bool isCreature() override { return true; }
 
@@ -163,6 +166,9 @@ public:
     bool getTyping() { return m_typing; }
     void setTypingIconTexture(const std::string& filename);
     void setBounce(uint8_t minHeight, uint8_t height, uint16_t speed) { m_bounce = { minHeight, height , speed }; }
+
+    void setWidgetInformation(const UIWidgetPtr& info);
+    UIWidgetPtr getWidgetInformation() { return m_widgetInformation; }
 
 #ifndef BOT_PROTECTION
     void setText(const std::string& text, const Color& color);
@@ -294,6 +300,8 @@ private:
     std::function<void()> m_mountShaderAction{ nullptr };
 
     ThingType* m_mountType{ nullptr };
+
+    UIWidgetPtr m_widgetInformation;
 
 #ifndef BOT_PROTECTION
     StaticTextPtr m_text;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -507,6 +507,7 @@ void Game::loginWorld(const std::string_view account, const std::string_view pas
     resetGameStates();
 
     m_localPlayer = std::make_shared<LocalPlayer>();
+    m_localPlayer->onCreate();
     m_localPlayer->setName(characterName);
 
     m_protocolGame = std::make_shared<ProtocolGame>();

--- a/src/client/gameconfig.cpp
+++ b/src/client/gameconfig.cpp
@@ -143,6 +143,8 @@ void GameConfig::loadCreatureNode(const OTMLNodePtr& mainNode) {
             m_adjustCreatureInformationBasedCropSize = node->value<bool>();
         else if (node->tag() == "diagonal-walk-speed")
             m_creatureDiagonalWalkSpeed = node->value<double>();
+        else if (node->tag() == "draw-information-by-widget-beta")
+            m_drawInformationByWidget = node->value<bool>();
     }
 }
 

--- a/src/client/gameconfig.h
+++ b/src/client/gameconfig.h
@@ -49,6 +49,7 @@ public:
     uint8_t getTileMaxThings() const { return m_tileMaxThings; }
     uint8_t getTileTransparentFloorViewRange() const { return m_tileTransparentFloorViewRange; }
 
+    bool isDrawingInformationByWidget() { return m_drawInformationByWidget; }
     bool isForcingNewWalkingFormula() const { return m_forceNewWalkingFormula; }
     bool isAdjustCreatureInformationBasedCropSize() const { return m_adjustCreatureInformationBasedCropSize; }
     uint16_t getShieldBlinkTicks() const { return m_shieldBlinkTicks; }
@@ -69,6 +70,11 @@ public:
     BitmapFontPtr getAnimatedTextFont()  const { return m_animatedTextFont; }
     BitmapFontPtr getStaticTextFont()  const { return m_staticTextFont; }
     BitmapFontPtr getWidgetTextFont()  const { return m_widgetTextFont; }
+
+    std::string getCreatureNameFontName() { return m_creatureNameFont->getName(); }
+    std::string getAnimatedTextFontName() { return m_animatedTextFont->getName(); }
+    std::string getStaticTextFontName() { return m_staticTextFont->getName(); }
+    std::string getWidgetTextFontName() { return m_widgetTextFont->getName(); }
 
     void loadFonts();
 
@@ -100,6 +106,7 @@ private:
     uint8_t m_tileTransparentFloorViewRange{ 2 };
 
     // Creature
+    bool m_drawInformationByWidget{ false };
     bool m_forceNewWalkingFormula{ true };
     bool m_adjustCreatureInformationBasedCropSize{ false };
     uint16_t m_shieldBlinkTicks{ 500 };

--- a/src/client/gameconfig.h
+++ b/src/client/gameconfig.h
@@ -52,7 +52,7 @@ public:
     bool isDrawingInformationByWidget() { return m_drawInformationByWidget; }
     bool isForcingNewWalkingFormula() const { return m_forceNewWalkingFormula; }
     bool isAdjustCreatureInformationBasedCropSize() { return m_adjustCreatureInformationBasedCropSize; }
-    uint16_t getShieldBlinkTicks() const { return m_shieldBlinkTicks; }
+    uint16_t getShieldBlinkTicks() { return m_shieldBlinkTicks; }
     uint16_t getVolatileSquareDuration() const { return m_volatileSquareDuration; }
 
     uint16_t getInvisibleTicksPerFrame() const { return m_invisibleTicksPerFrame; }

--- a/src/client/gameconfig.h
+++ b/src/client/gameconfig.h
@@ -51,7 +51,7 @@ public:
 
     bool isDrawingInformationByWidget() { return m_drawInformationByWidget; }
     bool isForcingNewWalkingFormula() const { return m_forceNewWalkingFormula; }
-    bool isAdjustCreatureInformationBasedCropSize() const { return m_adjustCreatureInformationBasedCropSize; }
+    bool isAdjustCreatureInformationBasedCropSize() { return m_adjustCreatureInformationBasedCropSize; }
     uint16_t getShieldBlinkTicks() const { return m_shieldBlinkTicks; }
     uint16_t getVolatileSquareDuration() const { return m_volatileSquareDuration; }
 

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -367,6 +367,7 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_gameConfig", "isDrawingInformationByWidget", &GameConfig::isDrawingInformationByWidget, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "isAdjustCreatureInformationBasedCropSize", &GameConfig::isAdjustCreatureInformationBasedCropSize, &g_gameConfig);
 
+    g_lua.bindSingletonFunction("g_gameConfig", "getShieldBlinkTicks", &GameConfig::getShieldBlinkTicks, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getCreatureNameFontName", &GameConfig::getCreatureNameFontName, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getAnimatedTextFontName", &GameConfig::getAnimatedTextFontName, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getStaticTextFontName", &GameConfig::getStaticTextFontName, &g_gameConfig);

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -575,6 +575,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Creature>("getWidgetInformation", &Creature::getWidgetInformation);
     g_lua.bindClassMemberFunction<Creature>("setWidgetInformation", &Creature::setWidgetInformation);
     g_lua.bindClassMemberFunction<Creature>("isFullHealth", &Creature::isFullHealth);
+    g_lua.bindClassMemberFunction<Creature>("isCovered", &Creature::isCovered);
 
 #ifndef BOT_PROTECTION
     g_lua.bindClassMemberFunction<Creature>("setText", &Creature::setText);

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -364,6 +364,12 @@ void Client::registerLuaFunctions()
     g_lua.registerSingletonClass("g_gameConfig");
     g_lua.bindSingletonFunction("g_gameConfig", "loadFonts", &GameConfig::loadFonts, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getSpriteSize", &GameConfig::getSpriteSize, &g_gameConfig);
+    g_lua.bindSingletonFunction("g_gameConfig", "isDrawingInformationByWidget", &GameConfig::isDrawingInformationByWidget, &g_gameConfig);
+
+    g_lua.bindSingletonFunction("g_gameConfig", "getCreatureNameFontName", &GameConfig::getCreatureNameFontName, &g_gameConfig);
+    g_lua.bindSingletonFunction("g_gameConfig", "getAnimatedTextFontName", &GameConfig::getAnimatedTextFontName, &g_gameConfig);
+    g_lua.bindSingletonFunction("g_gameConfig", "getStaticTextFontName", &GameConfig::getStaticTextFontName, &g_gameConfig);
+    g_lua.bindSingletonFunction("g_gameConfig", "getWidgetTextFontName", &GameConfig::getWidgetTextFontName, &g_gameConfig);
 
     g_lua.registerSingletonClass("g_client");
     g_lua.bindSingletonFunction("g_client", "setEffectAlpha", &Client::setEffectAlpha, &g_client);
@@ -462,6 +468,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Thing>("getClassification", &Thing::getClassification);
     g_lua.bindClassMemberFunction<Thing>("setHighlight", &Thing::lua_setHighlight);
     g_lua.bindClassMemberFunction<Thing>("isHighlighted", &Thing::isHighlighted);
+    g_lua.bindClassMemberFunction<Thing>("getExactSize", &Thing::getExactSize);
 
 #ifdef FRAMEWORK_EDITOR
     g_lua.registerClass<House>();
@@ -564,6 +571,9 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Creature>("getTyping", &Creature::getTyping);
     g_lua.bindClassMemberFunction<Creature>("sendTyping", &Creature::sendTyping);
     g_lua.bindClassMemberFunction<Creature>("setTypingIconTexture", &Creature::setTypingIconTexture);
+    g_lua.bindClassMemberFunction<Creature>("getWidgetInformation", &Creature::getWidgetInformation);
+    g_lua.bindClassMemberFunction<Creature>("setWidgetInformation", &Creature::setWidgetInformation);
+    g_lua.bindClassMemberFunction<Creature>("isFullHealth", &Creature::isFullHealth);
 
 #ifndef BOT_PROTECTION
     g_lua.bindClassMemberFunction<Creature>("setText", &Creature::setText);
@@ -842,6 +852,8 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Tile>("select", &Tile::select);
     g_lua.bindClassMemberFunction<Tile>("unselect", &Tile::unselect);
     g_lua.bindClassMemberFunction<Tile>("isSelected", &Tile::isSelected);
+    g_lua.bindClassMemberFunction<Tile>("isCovered", &Tile::isCovered);
+    g_lua.bindClassMemberFunction<Tile>("isCompletelyCovered", &Tile::isCompletelyCovered);
 
 #ifndef BOT_PROTECTION
     g_lua.bindClassMemberFunction<Tile>("setText", &Tile::setText);

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -365,6 +365,7 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_gameConfig", "loadFonts", &GameConfig::loadFonts, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getSpriteSize", &GameConfig::getSpriteSize, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "isDrawingInformationByWidget", &GameConfig::isDrawingInformationByWidget, &g_gameConfig);
+    g_lua.bindSingletonFunction("g_gameConfig", "isAdjustCreatureInformationBasedCropSize", &GameConfig::isAdjustCreatureInformationBasedCropSize, &g_gameConfig);
 
     g_lua.bindSingletonFunction("g_gameConfig", "getCreatureNameFontName", &GameConfig::getCreatureNameFontName, &g_gameConfig);
     g_lua.bindSingletonFunction("g_gameConfig", "getAnimatedTextFontName", &GameConfig::getAnimatedTextFontName, &g_gameConfig);

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -119,6 +119,9 @@ void Map::clean()
 
 void Map::cleanDynamicThings()
 {
+    for (const auto& mapview : m_mapViews)
+        mapview->followCreature(nullptr);
+
     for (const auto& [widget, object] : m_attachedObjectWidgetMap)
         widget->destroy();
 
@@ -1204,6 +1207,7 @@ void Map::updateAttachedWidgets(const MapViewPtr& mapView)
         const auto& widgetRect = widget->getRect();
         const auto& newWidgetRect = Rect(p, widgetRect.width(), widgetRect.height());
 
+        widget->disableUpdateTemporarily();
         widget->setRect(newWidgetRect);
     }
 }

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -128,6 +128,7 @@ void Map::cleanDynamicThings()
         m_floors[i].missiles.clear();
 
     cleanTexts();
+    m_attachedObjectWidgetMap.clear();
 }
 
 void Map::addThing(const ThingPtr& thing, const Position& pos, int16_t stackPos)
@@ -1183,7 +1184,7 @@ void Map::updateAttachedWidgets(const MapViewPtr& mapView)
             const auto displacementY = g_game.getFeature(Otc::GameNegativeOffset) ? 0 : creature->getDisplacementY();
 
             const auto& jumpOffset = creature->getJumpOffset() * g_drawPool.getScaleFactor();
-            const auto& creatureOffset = Point(16 - displacementX, -displacementY - 2) + creature->getWalkOffset();
+            const auto& creatureOffset = Point(16 - displacementX, -displacementY - 2) + creature->getDrawOffset();
             p += creatureOffset * g_drawPool.getScaleFactor() - Point(std::round(jumpOffset.x), std::round(jumpOffset.y));
         }
 

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -119,6 +119,11 @@ void Map::clean()
 
 void Map::cleanDynamicThings()
 {
+    for (const auto& [widget, object] : m_attachedObjectWidgetMap)
+        widget->destroy();
+
+    m_attachedObjectWidgetMap.clear();
+
     for (const auto& [uid, creature] : m_knownCreatures) {
         removeThing(creature);
     }
@@ -128,7 +133,6 @@ void Map::cleanDynamicThings()
         m_floors[i].missiles.clear();
 
     cleanTexts();
-    m_attachedObjectWidgetMap.clear();
 }
 
 void Map::addThing(const ThingPtr& thing, const Position& pos, int16_t stackPos)

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -114,22 +114,6 @@ void MapView::preLoad() {
     }
 
     g_map.updateAttachedWidgets(static_self_cast<MapView>());
-
-    Position _camera = m_posInfo.camera;
-    const bool alwaysTransparent = m_floorViewMode == ALWAYS_WITH_TRANSPARENCY && _camera.coveredUp(m_posInfo.camera.z - m_floorMin);
-    for (const auto& [uid, creature] : g_map.getCreatures()) {
-        const auto& tile = creature->getTile();
-        if (!tile || !m_posInfo.isInRange(creature->getPosition()))
-            continue;
-
-        bool isCovered = tile->isCovered(alwaysTransparent ? m_floorMin : m_cachedFirstVisibleFloor);
-        if (alwaysTransparent && isCovered) {
-            const bool inRange = creature->getPosition().isInRange(m_posInfo.camera, g_gameConfig.getTileTransparentFloorViewRange(), g_gameConfig.getTileTransparentFloorViewRange(), true);
-            isCovered = !inRange;
-        }
-
-        creature->setCovered(isCovered);
-    }
 }
 
 void MapView::draw(const Rect& rect)
@@ -224,10 +208,20 @@ void MapView::drawCreatureInformation() {
     if (m_drawHealthBars) { flags |= Otc::DrawBars; }
     if (m_drawManaBar) { flags |= Otc::DrawManaBar; }
 
+    Position _camera = m_posInfo.camera;
+    const bool alwaysTransparent = m_floorViewMode == ALWAYS_WITH_TRANSPARENCY && _camera.coveredUp(m_posInfo.camera.z - m_floorMin);
     for (const auto& [uid, creature] : g_map.getCreatures()) {
         const auto& tile = creature->getTile();
         if (!tile || !m_posInfo.isInRange(creature->getPosition()))
             continue;
+
+        bool isCovered = tile->isCovered(alwaysTransparent ? m_floorMin : m_cachedFirstVisibleFloor);
+        if (alwaysTransparent && isCovered) {
+            const bool inRange = creature->getPosition().isInRange(m_posInfo.camera, g_gameConfig.getTileTransparentFloorViewRange(), g_gameConfig.getTileTransparentFloorViewRange(), true);
+            isCovered = !inRange;
+        }
+
+        creature->setCovered(isCovered);
 
         creature->drawInformation(m_posInfo, transformPositionTo2D(creature->getPosition()), flags);
     }
@@ -392,7 +386,7 @@ void MapView::updateVisibleTiles()
     m_updateVisibleTiles = false;
     m_resetCoveredCache = false;
     updateHighlightTile(m_mousePosition);
-    }
+}
 
 void MapView::updateRect(const Rect& rect) {
     if (m_posInfo.rect != rect || m_updateMapPosInfo) {

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2753,24 +2753,29 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type) cons
                     // fixes a bug server side bug where GameInit is not sent and local player id is unknown
                     (creatureType == Proto::CreatureTypePlayer && !m_localPlayer->getId() && name == m_localPlayer->getName())) {
                     creature = m_localPlayer;
-                } else switch (creatureType) {
-                    case Proto::CreatureTypePlayer:
-                        creature = std::make_shared<Player>();
-                        break;
+                } else {
+                    switch (creatureType) {
+                        case Proto::CreatureTypePlayer:
+                            creature = std::make_shared<Player>();
+                            break;
 
-                    case Proto::CreatureTypeNpc:
-                        creature = std::make_shared<Npc>();
-                        break;
+                        case Proto::CreatureTypeNpc:
+                            creature = std::make_shared<Npc>();
+                            break;
 
-                    case Proto::CreatureTypeHidden:
-                    case Proto::CreatureTypeMonster:
-                    case Proto::CreatureTypeSummonOwn:
-                    case Proto::CreatureTypeSummonOther:
-                        creature = std::make_shared<Monster>();
-                        break;
+                        case Proto::CreatureTypeHidden:
+                        case Proto::CreatureTypeMonster:
+                        case Proto::CreatureTypeSummonOwn:
+                        case Proto::CreatureTypeSummonOther:
+                            creature = std::make_shared<Monster>();
+                            break;
 
-                    default:
-                        g_logger.traceError("creature type is invalid");
+                        default:
+                            g_logger.traceError("creature type is invalid");
+                    }
+
+                    if (creature)
+                        creature->onCreate();
                 }
             }
 

--- a/src/client/statictext.h
+++ b/src/client/statictext.h
@@ -39,7 +39,7 @@ public:
     bool hasText() { return m_cachedText.hasText(); }
 
     Otc::MessageMode getMessageMode() const { return m_mode; }
-    std::string getFirstMessage() { return m_messages[0].first; }
+    std::string getFirstMessage() { return m_messages.empty() ? "" : m_messages[0].first; }
 
     bool isYell() const { return m_mode == Otc::MessageYell || m_mode == Otc::MessageMonsterYell || m_mode == Otc::MessageBarkLoud; }
 

--- a/src/framework/graphics/drawpoolmanager.cpp
+++ b/src/framework/graphics/drawpoolmanager.cpp
@@ -81,9 +81,9 @@ void DrawPoolManager::drawObject(const DrawPool::DrawObject& obj)
     g_painter->drawCoords(coords, obj.drawMode);
 }
 
-void DrawPoolManager::addTexturedCoordsBuffer(const TexturePtr& texture, const CoordsBufferPtr& coords, const Color& color) const
+void DrawPoolManager::addTexturedCoordsBuffer(const TexturePtr& texture, const CoordsBufferPtr& coords, const Color& color, const DrawConductor& condutor) const
 {
-    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{}, DrawMode::TRIANGLE_STRIP, DEFAULT_DRAW_CONDUCTOR, coords);
+    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{}, DrawMode::TRIANGLE_STRIP, condutor, coords);
 }
 
 void DrawPoolManager::addTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color, const DrawConductor& condutor) const
@@ -99,24 +99,24 @@ void DrawPoolManager::addTexturedRect(const Rect& dest, const TexturePtr& textur
     }, DrawMode::TRIANGLE_STRIP, condutor);
 }
 
-void DrawPoolManager::addUpsideDownTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color) const
+void DrawPoolManager::addUpsideDownTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color, const DrawConductor& condutor) const
 {
     if (dest.isEmpty() || src.isEmpty()) {
         getCurrentPool()->resetOnlyOnceParameters();
         return;
     }
 
-    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ DrawPool::DrawMethodType::UPSIDEDOWN_RECT, dest, src }, DrawMode::TRIANGLE_STRIP);
+    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ DrawPool::DrawMethodType::UPSIDEDOWN_RECT, dest, src }, DrawMode::TRIANGLE_STRIP, condutor);
 }
 
-void DrawPoolManager::addTexturedRepeatedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color) const
+void DrawPoolManager::addTexturedRepeatedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color, const DrawConductor& condutor) const
 {
     if (dest.isEmpty() || src.isEmpty()) {
         getCurrentPool()->resetOnlyOnceParameters();
         return;
     }
 
-    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ DrawPool::DrawMethodType::REPEATED_RECT, dest, src });
+    getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ DrawPool::DrawMethodType::REPEATED_RECT, dest, src }, DrawMode::TRIANGLES, condutor);
 }
 
 void DrawPoolManager::addFilledRect(const Rect& dest, const Color& color, const DrawConductor& condutor) const
@@ -129,7 +129,7 @@ void DrawPoolManager::addFilledRect(const Rect& dest, const Color& color, const 
     getCurrentPool()->add(color, nullptr, DrawPool::DrawMethod{ DrawPool::DrawMethodType::RECT, dest }, DrawMode::TRIANGLES, condutor);
 }
 
-void DrawPoolManager::addFilledTriangle(const Point& a, const Point& b, const Point& c, const Color& color) const
+void DrawPoolManager::addFilledTriangle(const Point& a, const Point& b, const Point& c, const Color& color, const DrawConductor& condutor) const
 {
     if (a == b || a == c || b == c) {
         getCurrentPool()->resetOnlyOnceParameters();
@@ -141,10 +141,10 @@ void DrawPoolManager::addFilledTriangle(const Point& a, const Point& b, const Po
             .a = a,
             .b = b,
             .c = c
-     });
+     }, DrawMode::TRIANGLES, condutor);
 }
 
-void DrawPoolManager::addBoundingRect(const Rect& dest, const Color& color, uint16_t innerLineWidth) const
+void DrawPoolManager::addBoundingRect(const Rect& dest, const Color& color, uint16_t innerLineWidth, const DrawConductor& condutor) const
 {
     if (dest.isEmpty() || innerLineWidth == 0) {
         getCurrentPool()->resetOnlyOnceParameters();
@@ -155,7 +155,7 @@ void DrawPoolManager::addBoundingRect(const Rect& dest, const Color& color, uint
         .type = DrawPool::DrawMethodType::BOUNDING_RECT,
         .dest = dest,
         .intValue = innerLineWidth
-    });
+    }, DrawMode::TRIANGLES, condutor);
 }
 
 void DrawPoolManager::preDraw(const DrawPoolType type, const std::function<void()>& f, const Rect& dest, const Rect& src, const Color& colorClear)

--- a/src/framework/graphics/drawpoolmanager.h
+++ b/src/framework/graphics/drawpoolmanager.h
@@ -46,12 +46,12 @@ public:
     { addTexturedRect(dest, texture, Rect(Point(), texture->getSize()), color); }
 
     void addTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
-    void addTexturedCoordsBuffer(const TexturePtr& texture, const CoordsBufferPtr& coords, const Color& color = Color::white) const;
-    void addUpsideDownTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white) const;
-    void addTexturedRepeatedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white) const;
+    void addTexturedCoordsBuffer(const TexturePtr& texture, const CoordsBufferPtr& coords, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
+    void addUpsideDownTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
+    void addTexturedRepeatedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
     void addFilledRect(const Rect& dest, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
-    void addFilledTriangle(const Point& a, const Point& b, const Point& c, const Color& color = Color::white) const;
-    void addBoundingRect(const Rect& dest, const Color& color = Color::white, uint16_t innerLineWidth = 1) const;
+    void addFilledTriangle(const Point& a, const Point& b, const Point& c, const Color& color = Color::white, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
+    void addBoundingRect(const Rect& dest, const Color& color = Color::white, uint16_t innerLineWidth = 1, const DrawConductor& condutor = DEFAULT_DRAW_CONDUCTOR) const;
     void addAction(const std::function<void()>& action) const { getCurrentPool()->addAction(action); }
 
     void bindFrameBuffer(const Size& size, const Color& color = Color::white) const { getCurrentPool()->bindFrameBuffer(size, color); }

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -329,7 +329,7 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_app", "setCreatureInformationScale", &GraphicalApplication::setCreatureInformationScale, &g_app);
     g_lua.bindSingletonFunction("g_app", "setAnimatedTextScale", &GraphicalApplication::setAnimatedTextScale, &g_app);
     g_lua.bindSingletonFunction("g_app", "setStaticTextScale", &GraphicalApplication::setStaticTextScale, &g_app);
-    
+
     // PlatformWindow
     g_lua.registerSingletonClass("g_window");
     g_lua.bindSingletonFunction("g_window", "move", &PlatformWindow::move, &g_window);
@@ -742,6 +742,12 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIWidget>("getTextSize", &UIWidget::getTextSize);
     g_lua.bindClassMemberFunction<UIWidget>("hasShader", &UIWidget::hasShader);
     g_lua.bindClassMemberFunction<UIWidget>("disableUpdateTemporarily", &UIWidget::disableUpdateTemporarily);
+
+    g_lua.bindClassMemberFunction<UIWidget>("setBackgroundDrawOrder", &UIWidget::setBackgroundDrawOrder);
+    g_lua.bindClassMemberFunction<UIWidget>("setImageDrawOrder", &UIWidget::setImageDrawOrder);
+    g_lua.bindClassMemberFunction<UIWidget>("setIconDrawOrder", &UIWidget::setIconDrawOrder);
+    g_lua.bindClassMemberFunction<UIWidget>("setTextDrawOrder", &UIWidget::setTextDrawOrder);
+    g_lua.bindClassMemberFunction<UIWidget>("setBorderDrawOrder", &UIWidget::setBorderDrawOrder);
 
     // UILayout
     g_lua.registerClass<UILayout>();

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1997,8 +1997,10 @@ void UIWidget::disableUpdateTemporarily() {
     setProp(PropDisableUpdateTemporarily, true);
     m_layout->disableUpdates();
     g_dispatcher.deferEvent([self = static_self_cast<UIWidget>()] {
-        self->m_layout->enableUpdates();
-        self->m_layout->update();
+        if (self->m_layout) {
+            self->m_layout->enableUpdates();
+            self->m_layout->update();
+        }
         self->setProp(PropDisableUpdateTemporarily, false);
     });
 }

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -32,6 +32,7 @@
 #include <framework/otml/otmlnode.h>
 
 #include "framework/graphics/texture.h"
+#include "framework/graphics/drawpool.h"
 
 template<typename T = int>
 struct EdgeGroup
@@ -208,9 +209,21 @@ public:
     void addOnDestroyCallback(const std::string& id, const std::function<void()>&& callback);
     void removeOnDestroyCallback(const std::string&);
 
+    void setBackgroundDrawOrder(uint8_t order) { m_backgroundDrawConductor.order = order; }
+    void setImageDrawOrder(uint8_t order) { m_imageDrawConductor.order = order; }
+    void setIconDrawOrder(uint8_t order) { m_iconDrawConductor.order = order; }
+    void setTextDrawOrder(uint8_t order) { m_textDrawConductor.order = order; }
+    void setBorderDrawOrder(uint8_t order) { m_borderDrawConductor.order = order; }
+
 private:
     uint32_t m_flagsProp{ 0 };
     PainterShaderProgramPtr m_shader;
+
+    DrawConductor m_backgroundDrawConductor;
+    DrawConductor m_imageDrawConductor;
+    DrawConductor m_iconDrawConductor;
+    DrawConductor m_textDrawConductor;
+    DrawConductor m_borderDrawConductor;
 
     // state managment
 protected:

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -209,11 +209,11 @@ public:
     void addOnDestroyCallback(const std::string& id, const std::function<void()>&& callback);
     void removeOnDestroyCallback(const std::string&);
 
-    void setBackgroundDrawOrder(uint8_t order) { m_backgroundDrawConductor.order = order; }
-    void setImageDrawOrder(uint8_t order) { m_imageDrawConductor.order = order; }
-    void setIconDrawOrder(uint8_t order) { m_iconDrawConductor.order = order; }
-    void setTextDrawOrder(uint8_t order) { m_textDrawConductor.order = order; }
-    void setBorderDrawOrder(uint8_t order) { m_borderDrawConductor.order = order; }
+    void setBackgroundDrawOrder(uint8_t order) { m_backgroundDrawConductor.order = std::min<uint8_t>(order, DrawOrder::LAST - 1); }
+    void setImageDrawOrder(uint8_t order) { m_imageDrawConductor.order = std::min<uint8_t>(order, DrawOrder::LAST - 1); }
+    void setIconDrawOrder(uint8_t order) { m_iconDrawConductor.order = std::min<uint8_t>(order, DrawOrder::LAST - 1); }
+    void setTextDrawOrder(uint8_t order) { m_textDrawConductor.order = std::min<uint8_t>(order, DrawOrder::LAST - 1); }
+    void setBorderDrawOrder(uint8_t order) { m_borderDrawConductor.order = std::min<uint8_t>(order, DrawOrder::LAST - 1); }
 
 private:
     uint32_t m_flagsProp{ 0 };

--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -69,7 +69,17 @@ void UIWidget::parseBaseStyle(const OTMLNodePtr& styleNode)
     }
     // load styles used by all widgets
     for (const auto& node : styleNode->children()) {
-        if (node->tag() == "color")
+        if (node->tag() == "background-draw-order")
+            setBackgroundDrawOrder(node->value<int>());
+        else if (node->tag() == "border-draw-order")
+            setBorderDrawOrder(node->value<int>());
+        else if (node->tag() == "icon-draw-order")
+            setIconDrawOrder(node->value<int>());
+        else if (node->tag() == "image-draw-order")
+            setImageDrawOrder(node->value<int>());
+        else if (node->tag() == "text-draw-order")
+            setTextDrawOrder(node->value<int>());
+        else if (node->tag() == "color")
             setColor(node->value<Color>());
         else if (node->tag() == "shader")
             setShader(node->value());

--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -350,7 +350,7 @@ void UIWidget::drawBackground(const Rect& screenCoords) const
         drawRect.translate(m_backgroundRect.topLeft());
         if (m_backgroundRect.isValid())
             drawRect.resize(m_backgroundRect.size());
-        g_drawPool.addFilledRect(drawRect, m_backgroundColor);
+        g_drawPool.addFilledRect(drawRect, m_backgroundColor, m_backgroundDrawConductor);
     }
 }
 
@@ -359,22 +359,22 @@ void UIWidget::drawBorder(const Rect& screenCoords) const
     // top
     if (m_borderWidth.top > 0) {
         const Rect borderRect(screenCoords.topLeft(), screenCoords.width(), m_borderWidth.top);
-        g_drawPool.addFilledRect(borderRect, m_borderColor.top);
+        g_drawPool.addFilledRect(borderRect, m_borderColor.top, m_borderDrawConductor);
     }
     // right
     if (m_borderWidth.right > 0) {
         const Rect borderRect(screenCoords.topRight() - Point(m_borderWidth.right - 1, 0), m_borderWidth.right, screenCoords.height());
-        g_drawPool.addFilledRect(borderRect, m_borderColor.right);
+        g_drawPool.addFilledRect(borderRect, m_borderColor.right, m_borderDrawConductor);
     }
     // bottom
     if (m_borderWidth.bottom > 0) {
         const Rect borderRect(screenCoords.bottomLeft() - Point(0, m_borderWidth.bottom - 1), screenCoords.width(), m_borderWidth.bottom);
-        g_drawPool.addFilledRect(borderRect, m_borderColor.bottom);
+        g_drawPool.addFilledRect(borderRect, m_borderColor.bottom, m_borderDrawConductor);
     }
     // left
     if (m_borderWidth.left > 0) {
         const Rect borderRect(screenCoords.topLeft(), m_borderWidth.left, screenCoords.height());
-        g_drawPool.addFilledRect(borderRect, m_borderColor.left);
+        g_drawPool.addFilledRect(borderRect, m_borderColor.left, m_borderDrawConductor);
     }
 }
 
@@ -397,7 +397,7 @@ void UIWidget::drawIcon(const Rect& screenCoords) const
             drawRect.alignIn(screenCoords, m_iconAlign);
     }
     drawRect.translate(m_iconOffset);
-    g_drawPool.addTexturedRect(drawRect, m_icon, m_iconClipRect, m_iconColor);
+    g_drawPool.addTexturedRect(drawRect, m_icon, m_iconClipRect, m_iconColor, m_iconDrawConductor);
 }
 
 void UIWidget::setIcon(const std::string& iconFile)

--- a/src/framework/ui/uiwidgetimage.cpp
+++ b/src/framework/ui/uiwidgetimage.cpp
@@ -40,14 +40,13 @@ void UIWidget::parseImageStyle(const OTMLNodePtr& styleNode)
             if (split.size() == 0) split.push_back("none");
             bool base64 = split.size() > 1 && split[0] == "base64";
             auto& value = split.size() > 1 ? split[1] : split[0];
-            
+
             if (value == "" || value == "none") {
                 setImageSource("", base64);
             } else {
                 setImageSource(stdext::resolve_path(value, node->source()), base64);
             }
-        }
-        else if (node->tag() == "image-offset-x")
+        } else if (node->tag() == "image-offset-x")
             setImageOffsetX(node->value<int>());
         else if (node->tag() == "image-offset-y")
             setImageOffsetY(node->value<int>());
@@ -183,9 +182,9 @@ void UIWidget::drawImage(const Rect& screenCoords)
 
     for (const auto& [dest, src] : m_imageCoordsCache) {
         if (useRepeated)
-            g_drawPool.addTexturedRepeatedRect(dest, texture, src, m_imageColor);
+            g_drawPool.addTexturedRepeatedRect(dest, texture, src, m_imageColor, m_imageDrawConductor);
         else
-            g_drawPool.addTexturedRect(dest, texture, src, m_imageColor);
+            g_drawPool.addTexturedRect(dest, texture, src, m_imageColor, m_imageDrawConductor);
     }
 }
 
@@ -205,9 +204,9 @@ void UIWidget::setImageSource(const std::string_view source, bool base64)
         stream.write(decoded.c_str(), decoded.size());
         m_imageTexture = g_textures.loadTexture(stream);
     } else {
-	    m_imageTexture = g_textures.getTexture(m_imageSource = source, isImageSmooth());
+        m_imageTexture = g_textures.getTexture(m_imageSource = source, isImageSmooth());
     }
-    
+
     if (!m_imageTexture)
         return;
 

--- a/src/framework/ui/uiwidgettext.cpp
+++ b/src/framework/ui/uiwidgettext.cpp
@@ -39,8 +39,7 @@ void UIWidget::updateText()
     if (isTextWrap() && m_rect.isValid()) {
         m_drawTextColors = m_textColors;
         m_drawText = m_font->wrapText(m_text, getWidth() - m_textOffset.x);
-    }
-    else {
+    } else {
         m_drawText = m_text;
         m_drawTextColors = m_textColors;
     }
@@ -123,12 +122,11 @@ void UIWidget::drawText(const Rect& screenCoords)
 
     g_drawPool.scale(m_fontScale);
     if (m_drawTextColors.empty() || m_colorCoordsBuffer.empty()) {
-        g_drawPool.addTexturedCoordsBuffer(m_font->getTexture(), m_coordsBuffer, m_color);
-    }
-    else {
+        g_drawPool.addTexturedCoordsBuffer(m_font->getTexture(), m_coordsBuffer, m_color, m_textDrawConductor);
+    } else {
         auto texture = m_font->getTexture();
         for (const auto& [color, coordsBuffer] : m_colorCoordsBuffer) {
-            g_drawPool.addTexturedCoordsBuffer(texture, coordsBuffer, color);
+            g_drawPool.addTexturedCoordsBuffer(texture, coordsBuffer, color, m_textDrawConductor);
         }
     }
     g_drawPool.scale(1.f); // reset scale
@@ -149,7 +147,7 @@ void UIWidget::setText(const std::string_view text, bool dontFireLuaCall)
 
     if (m_text == _text && m_textColors.empty())
         return;
-    
+
     m_textColors.clear();
     m_drawTextColors.clear();
     m_colorCoordsBuffer.clear();
@@ -163,7 +161,6 @@ void UIWidget::setText(const std::string_view text, bool dontFireLuaCall)
     }
 }
 
-
 void UIWidget::setColoredText(const std::string_view coloredText, bool dontFireLuaCall)
 {
     m_textColors.clear();
@@ -174,12 +171,11 @@ void UIWidget::setColoredText(const std::string_view coloredText, bool dontFireL
     std::regex exp("\\{([^\\}]+),[ ]*([^\\}]+)\\}");
 
     std::string _text{ coloredText.data() };
-    
+
     Color baseColor = Color::white;
     std::smatch res;
     std::string text = "";
-    while (std::regex_search(_text, res, exp))
-    {
+    while (std::regex_search(_text, res, exp)) {
         std::string prefix = res.prefix().str();
         if (prefix.size() > 0) {
             m_textColors.push_back(std::make_pair(text.size(), baseColor));


### PR DESCRIPTION
It is now possible to customize creature information using the UIWidget.

To enable, just go to setup.otml and set true in draw-information-by-widget-beta

The files to customize the creature's information are found in 'module\game_creatureinformation'

Note: There is a performance degradation compared to programming directly with Draw Pool of around ~20% depending on the occasion.

https://github.com/mehah/otclient/assets/2267386/6eaee037-01e7-42a2-94db-26e74d578df0

