### PR TITLE
feat: ToolstipsV8 for inventory items

### DIFF
--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -108,8 +108,29 @@ function UIItem:onHoverChange(hovered)
 
     if g_game.getFeature(GameItemTooltipV8) then
         local tooltip = nil
+        local function splitTextIntoLines(text, maxLineLength)
+            local words = {}
+            for word in text:gmatch("%S+") do
+                table.insert(words, word)
+            end
+        
+            local lines = {}
+            local currentLine = words[1]
+            for i = 2, #words do
+                if currentLine:len() + 1 + words[i]:len() > maxLineLength then
+                    table.insert(lines, currentLine)
+                    currentLine = words[i]
+                else
+                    currentLine = currentLine .. " " .. words[i]
+                end
+            end
+            table.insert(lines, currentLine)
+        
+            return table.concat(lines, "\n")
+        end
+
         if self:getItem() and self:getItem():getTooltip():len() > 0 then
-            tooltip = self:getItem():getTooltip()
+            tooltip = splitTextIntoLines(self:getItem():getTooltip(), 80) 
         end
         self:setTooltip(tooltip)
     end

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -105,6 +105,15 @@ function UIItem:onHoverChange(hovered)
             draggingWidget.hoveredWho = nil
         end
     end
+
+    if g_game.getFeature(GameItemTooltipV8) then
+        local tooltip = nil
+        if self:getItem() and self:getItem():getTooltip():len() > 0 then
+            tooltip = self:getItem():getTooltip()
+        end
+        self:setTooltip(tooltip)
+    end
+    
 end
 
 function UIItem:onMouseRelease(mousePosition, mouseButton)

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -107,7 +107,7 @@ function UIItem:onHoverChange(hovered)
     end
 
     if g_game.getFeature(GameItemTooltipV8) then
-        local tooltip = nil
+        local tooltip = ""
         local function splitTextIntoLines(text, maxLineLength)
             local words = {}
             for word in text:gmatch("%S+") do
@@ -131,8 +131,10 @@ function UIItem:onHoverChange(hovered)
 
         if self:getItem() and self:getItem():getTooltip():len() > 0 then
             tooltip = splitTextIntoLines(self:getItem():getTooltip(), 80) 
+            if tooltip then
+                self:setTooltip(tooltip)
+            end
         end
-        self:setTooltip(tooltip)
     end
     
 end

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -193,6 +193,7 @@ GameContainerFilter = 113
 GameEnterGameShowAppearance = 114
 GameSmoothWalkElevation = 115
 GameNegativeOffset = 116
+GameItemTooltipV8 = 117
 
 TextColors = {
     red = '#f55e5e',    -- '#c83200'

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -544,7 +544,8 @@ namespace Otc
         GameEnterGameShowAppearance = 114,
         GameSmoothWalkElevation = 115,
         GameNegativeOffset = 116,
-        LastGameFeature = 117
+        GameItemTooltipV8 = 117,
+        LastGameFeature = 118
     };
 
     enum MagicEffectsType_t : uint8_t

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -84,10 +84,12 @@ public:
     void setSubType(int subType) { m_countOrSubType = subType; updatePatterns(); }
     void setColor(const Color& c) { if (m_color != c) m_color = c; }
     void setPosition(const Position& position, uint8_t stackPos = 0, bool hasElevation = false) override;
+    void setTooltip(const std::string& str) { m_tooltip = str; }
 
     int getCountOrSubType() { return m_countOrSubType; }
     int getSubType();
     int getCount() { return isStackable() ? m_countOrSubType : 1; }
+    std::string getTooltip() { return m_tooltip; }
 
     bool isValid() { return getThingType() != nullptr; }
 
@@ -158,6 +160,7 @@ private:
     ticks_t m_lastPhase{ 0 };
 
     bool m_async{ true };
+    std::string m_tooltip;
 
 #ifdef FRAMEWORK_EDITOR
     uint16_t m_serverId{ 0 };

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -676,10 +676,13 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Item>("clone", &Item::clone);
 
     g_lua.bindClassMemberFunction<Item>("setCount", &Item::setCount);
+    g_lua.bindClassMemberFunction<Item>("setTooltip", &Item::setTooltip);
+
     g_lua.bindClassMemberFunction<Item>("getCount", &Item::getCount);
     g_lua.bindClassMemberFunction<Item>("getSubType", &Item::getSubType);
     g_lua.bindClassMemberFunction<Item>("getCountOrSubType", &Item::getCountOrSubType);
     g_lua.bindClassMemberFunction<Item>("getId", &Item::getId);
+    g_lua.bindClassMemberFunction<Item>("getTooltip", &Item::getTooltip);
 
     g_lua.bindClassMemberFunction<Item>("isStackable", &Item::isStackable);
     g_lua.bindClassMemberFunction<Item>("isMarketable", &Item::isMarketable);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3051,6 +3051,10 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id)
         item->setShader(msg->getString());
     }
 
+    if (g_game.getFeature(Otc::GameItemTooltipV8)) {
+        item->setTooltip(msg->getString());
+    }
+
     return item;
 }
 


### PR DESCRIPTION
Creditos : kondra , v8team

Many people asked for it on Discord. I'm not sure if it'll be approved, but it'll be helpful for more than one person.


![image](https://github.com/mehah/otclient/assets/114332266/ac9d9f4c-97d5-4c17-afe6-2e99e938e8ca)

server conections:

option 1: 1.5  8.6
https://github.com/moviebr/TFS-1.5-Downgrades/commit/d978ead7220cc50f3602f68dfe0233e7c4b2ba92

option 2: 1.3 ? 10.98
https://github.com/OTCv8/forgottenserver/commit/7f5b4fbc08711124dec86b0fcd7bfd78dd1165c4

optiones 3 : 0.4
cc:  @ thalesduarte help

option 4 : canary

option 5:  1.4.2 repo otland
https://github.com/kokekanon/1.4.2-delete/commit/7764f3703ffba18c6a21a14bce08ea2ac15b4bee

-------
```cpp

void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
.... 
	if (operatingSystem == CLIENTOS_OTCLIENT_WINDOWS) {
		isMehah = true;
	}
	
```


> [!IMPORTANT]
> Active features OTC
g_game.enableFeature(GameItemTooltipV8);


### PD: I'm not good at CPP.
 
![image](https://github.com/mehah/otclient/assets/114332266/125ebd5e-75f0-4963-89d9-da2b34dd9e90)

Issues addressed:
![image](https://github.com/mehah/otclient/assets/114332266/7f6acf01-a8fc-461c-b7f8-ef8fe7d6587c)

![image](https://github.com/mehah/otclient/assets/114332266/2f3c31f3-45f7-46c8-a203-97c5fc2d4492)

![image](https://github.com/mehah/otclient/assets/114332266/4dc0c36e-446b-4717-9c72-12513c61d356)

![image](https://github.com/mehah/otclient/assets/114332266/65c67a41-6725-4df4-a1bc-471ec704beec)




