### PR TITLE
fix: long messages was lasting more than 25 seconds on screen

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -119,7 +119,7 @@ function terminate()
 end
 
 function calculateVisibleTime(text)
-    return math.max(#text * 100, 4000)
+    return math.max(#text * 50, 4000)
 end
 
 function displayMessage(mode, text)


### PR DESCRIPTION
- Long messages in RL tibia, longs 15 seconds in max, this will fix it