### PR TITLE
fix: market browsing broken in pre-12.51 protocols

### DIFF
--- a/modules/game_market/marketprotocol.lua
+++ b/modules/game_market/marketprotocol.lua
@@ -59,8 +59,8 @@ end
 function MarketProtocol.sendMarketBrowse(browseId, browseType)
     if g_game.getFeature(GamePlayerMarket) then
         local msg = OutputMessage.create()
+        msg:addU8(ClientOpcodes.ClientMarketBrowse)
         if g_game.getClientVersion() >= 1251 then
-            msg:addU8(ClientOpcodes.ClientMarketBrowse)
             msg:addU8(browseId)
             if browseType > 0 then
                 msg:addU16(browseType)


### PR DESCRIPTION
# Description

Since https://github.com/mehah/otclient/commit/30b67026d1cfc5fba8d0afedc5bfc32a395fcf3e any market browse messages by the client in protocols prior to 12.51 that have market enabled have been missing the header. This causes the server to interpret the item ID as the header, causing all kinds of wonky behavior depending on what the item ID is.

## Behavior

### **Actual**

If you attempt to browse a market item in a 9.x / 10.x / 11.x game server, the items info is not returned. Instead, depending on which item has been browsed, a variety of things can happen (you get disconnected, you walk in a direction, nothing at all).

### **Expected**

Attempting to browse a market item in  a 9.x / 10.x / 11.x game server should return the items information.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

  - Server Version: 10.7
  - Client: 10.7
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
