### PR TITLE
fix: action bar spells progress bars ignoring group cooldowns

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -972,7 +972,7 @@ function onSpellGroupCooldown(groupId, duration)
             end
         end
         if spell then
-            if table.contains(spell.group, groupId) then
+            if spell.group[groupId] ~= nil then
                 local continue = false
                 if not cooldown[spell.id] or cooldown[spell.id] and cooldown[spell.id] < duration then
                     local oldProgressBar = k:recursiveGetChildById('progress' .. spell.id)


### PR DESCRIPTION
# Description

Spell slots on the action bar only show progress bars for the spell's individual cooldown. The logic for doing so is there (& seems to work correctly), it's just the group check seems to be written for an older data structure of `spells.lua`.

## Behavior

### **Actual**

If you assign an attack spell to slot 1 (e.g. lightning strike) and another attack spell to slot 2 (e.g. fire wave), and then cast fire wave, no progress bar will be shown on spell slot 1.

### **Expected**

Since fire wave causes spell group 1 to go into cooldown for 2s, I expect slot 1 to show a progress bar for 2s.


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Tested the scenario above (two spells that share a single group cooldown)
  - [x] Tested that the highest cooldown amonst multiple cooldown groups is shown (e.g. ultimate flame strike & ultimate energy strike)

**Test Configuration**:

  - Server Version: 10.77
  - Client: Latest
  - Operating System: Window

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
