### PR TITLE
Add config option to show status messages of other players/monsters in server log

### DIFF
--- a/modules/client_options/console.otui
+++ b/modules/client_options/console.otui
@@ -12,6 +12,10 @@ Panel
     !text: tr('Show status messages in console')
 
   OptionCheckBox
+    id: showOthersStatusMessagesInConsole
+    !text: tr('Show others\' status messages in console')
+
+  OptionCheckBox
     id: showTimestampsInConsole
     !text: tr('Show timestamps in console')
 

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -14,6 +14,7 @@ local defaultOptions = {
     showTimestampsInConsole = true,
     showLevelsInConsole = true,
     showPrivateMessagesInConsole = true,
+    showOthersStatusMessagesInConsole = false,
     showPrivateMessagesOnScreen = true,
     showLeftPanel = true,
     showRightExtraPanel = false,

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -41,6 +41,11 @@ MessageSettings = {
         screenTarget = 'statusLabel',
         consoleOption = 'showStatusMessagesInConsole'
     },
+    othersStatus = {
+        color = TextColors.white,
+        consoleTab = 'Server Log',
+        consoleOption = 'showOthersStatusMessagesInConsole'
+    },
     statusSmall = {
         color = TextColors.white,
         screenTarget = 'statusLabel'
@@ -74,10 +79,10 @@ MessageTypes = {
     [MessageModes.Heal] = MessageSettings.status,
     [MessageModes.Exp] = MessageSettings.status,
 
-    [MessageModes.DamageOthers] = MessageSettings.none,
-    [MessageModes.HealOthers] = MessageSettings.none,
-    [MessageModes.ExpOthers] = MessageSettings.none,
-    [MessageModes.Potion] = MessageSettings.none,
+    [MessageModes.DamageOthers] = MessageSettings.othersStatus,
+    [MessageModes.HealOthers] = MessageSettings.othersStatus,
+    [MessageModes.ExpOthers] = MessageSettings.othersStatus,
+    [MessageModes.Potion] = MessageSettings.othersStatus,
 
     [MessageModes.TradeNpc] = MessageSettings.centerWhite,
     [MessageModes.Guild] = MessageSettings.centerWhite,


### PR DESCRIPTION
# Description

Adds a config option to show status messages not related to your experience, healing or damage (e.g. `An orc wizard loses 37 hitpoints due to an attack by Player2`) in the server log.

Setting it to false by default.

## Behavior

### **Actual**

These messages are not handled by otclient.

### **Expected**

I'd expect to be able to configure it, like the Tibia client:

![image](https://github.com/mehah/otclient/assets/22473765/36d016fe-f6dc-4e90-87e1-d4fa59d2b5c6)

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Can be tested with any protocol version above 10.41, which first introduced the `MessageDamageOthers`, `MessageHealOthers` and `MessageExpOthers` message types.

**Test Configuration**:

  - Server Version: 10.7
  - Client: Latest
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
