### PR TITLE
fix: forge skills

### DIFF
--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -119,7 +119,12 @@ function setSkillValue(id, value)
     local skill = skillsWindow:recursiveGetChildById(id)
     if skill then
         local widget = skill:getChildById('value')
-        widget:setText(value)
+        if id == "skillId7" or id == "skillId9" or id == "skillId11" or id == "skillId13" or id == "skillId14" or id == "skillId15" or id == "skillId16" then
+            local value = value / 100
+            widget:setText(value .. "%")
+        else
+            widget:setText(value)
+        end
     end
 end
 
@@ -250,10 +255,22 @@ function refresh()
     local hasAdditionalSkills = g_game.getFeature(GameAdditionalSkills)
     for i = Skill.Fist, Skill.ManaLeechAmount do
         onSkillChange(player, i, player:getSkillLevel(i), player:getSkillLevelPercent(i))
-        onBaseSkillChange(player, i, player:getSkillBaseLevel(i))
 
         if i > Skill.Fishing then
-            toggleSkill('skillId' .. i, hasAdditionalSkills)
+            local ativedAdditionalSkills = hasAdditionalSkills
+            if ativedAdditionalSkills and g_game.getClientVersion() >= 1281 and (i == Skill.LifeLeechAmount or i == Skill.ManaLeechAmount) then
+                ativedAdditionalSkills = false
+            end
+
+            toggleSkill('skillId' .. i, ativedAdditionalSkills)
+        end
+    end
+
+    if g_game.getClientVersion() >= 1281 then
+        local lastSkill = g_game.getClientVersion() >= 1332 and Skill.Transcendence or Skill.Momentum
+        for i = Skill.Fatal, lastSkill do
+            onSkillChange(player, i, player:getSkillLevel(i), player:getSkillLevelPercent(i))
+            toggleSkill('skillId' .. i, player:getSkillLevel(i) > 0)
         end
     end
 
@@ -506,6 +523,10 @@ function onSkillChange(localPlayer, id, level, percent)
     setSkillPercent('skillId' .. id, percent, tr('You have %s percent to go', 100 - percent))
 
     onBaseSkillChange(localPlayer, id, localPlayer:getSkillBaseLevel(id))
+
+    if id > Skill.ManaLeechAmount then
+	    toggleSkill('skillId' .. id, level > 0)
+    end
 end
 
 function onBaseSkillChange(localPlayer, id, baseLevel)

--- a/modules/game_skills/skills.otui
+++ b/modules/game_skills/skills.otui
@@ -210,3 +210,27 @@ MiniWindow
       SkillNameLabel
         !text: tr('Mana Leech Amount')
       SkillValueLabel
+
+    SmallSkillButton
+      id: skillId13
+      SkillNameLabel
+        !text: tr('Fatal')
+      SkillValueLabel
+
+    SmallSkillButton
+      id: skillId14
+      SkillNameLabel
+        !text: tr('Dodge')
+      SkillValueLabel
+
+    SmallSkillButton
+      id: skillId15
+      SkillNameLabel
+        !text: tr('Momentum')
+      SkillValueLabel
+
+    SmallSkillButton
+      id: skillId16
+      SkillNameLabel
+        !text: tr('Transcendence')
+      SkillValueLabel

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -57,7 +57,11 @@ Skill = {
     LifeLeechChance = 9,
     LifeLeechAmount = 10,
     ManaLeechChance = 11,
-    ManaLeechAmount = 12
+    ManaLeechAmount = 12,
+    Fatal = 13,
+    Dodge = 14,
+    Momentum = 15,
+    Transcendence = 16
 }
 
 North = Directions.North


### PR DESCRIPTION
- fix error:
```

ERROR: Lua exception: /game_skills/skills.lua:104: attempt to index local 'skill' (a nil value)
stack traceback:
    [C]: in function '__index'
    /game_skills/skills.lua:104: in function 'setSkillBase'
    /game_skills/skills.lua:512: in function </game_skills/skills.lua:511>
ERROR: protected lua call failed: LUA ERROR:
/game_skills/skills.lua:104: attempt to index local 'skill' (a nil value)
stack traceback:
    [C]: in function '__index'
    /game_skills/skills.lua:104: in function 'setSkillBase'
    /game_skills/skills.lua:512: in function </game_skills/skills.lua:511>
```

- removed redundancy in onBaseSkillChange's refresh() function
![image](https://github.com/mehah/otclient/assets/6209529/16674d60-b8ad-47df-97f1-04b59cde8d16)
![image](https://github.com/mehah/otclient/assets/6209529/33838997-9547-4315-b113-24dbae7690a2)

- readjustment for forge skills only appear when they are greater than 0


https://github.com/mehah/otclient/assets/6209529/ce08716c-eea0-46d6-b895-930491991d69


