### PR TITLE
fix: enable chat mode on/off

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -282,10 +282,8 @@ function toggleChat()
     consoleToggleChat.isChecked = not consoleToggleChat.isChecked
     if consoleToggleChat.isChecked then
         consoleToggleChat:setText(tr('Chat Off'))
-        consoleToggleChat.isChecked = true
     else
         consoleToggleChat:setText(tr('Chat On'))
-        consoleToggleChat.isChecked = false
     end
 end
 
@@ -372,6 +370,8 @@ function disableChatOnCall()
     if isChatEnabled() and not consoleToggleChat.isChecked then
         toggleChat()
     end
+
+    updateChatMode()
 end
 
 function isChatEnabled()
@@ -447,6 +447,7 @@ function load()
         else
             consoleToggleChat:setText(tr('Chat On'))
         end
+        updateChatMode()
     end
     loadCommunicationSettings()
 end

--- a/modules/game_console/console.otui
+++ b/modules/game_console/console.otui
@@ -254,4 +254,4 @@ Panel
         self.isChecked = true
         self:setText(tr('Chat Off'))
       end
-    @onCheckChange: updateChatMode()
+      updateChatMode()


### PR DESCRIPTION
# Description

When clicking on the button to change chat mode, it wasn't working.
Chat mode wasn't beind save by the settings.
On first login, you always had chat enable and had to press enter twice to make it work.
Esc didn't disable chat.

## Behavior

### **Actual**

When clicking on the button to change chat mode, it wasn't working.
Chat mode wasn't being save by the settings.
On first login, you always had chat enable and had to press enter twice to make it work.
Esc didn't disable chat.

### **Expected**

When clicking on the button to change chat mode it should change the text and disable/enable chat.
Chat mode should be saved on the settings
Esc disables chat.

## Fixes

No Issues on Github.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Open client, login, enable/disable chat. 
Close client, open client again, chat should be the same accordingly to the last settings.

**Test Configuration**:

  - Server Version: Canary 13.32
  - Client: OTC
  - Operating System: Windows 11 23H2 (22631.3737)

