### PR TITLE
feat: menu hide action bar and hide spell cooldown group

### DIFF
--- a/modules/client_options/data_options.lua
+++ b/modules/client_options/data_options.lua
@@ -308,6 +308,18 @@ return {
             modules.game_interface.getRightExtraPanel():setOn(value)
         end
     },
+    showActionbar                    = {
+        value = false,
+        action = function(value, options, controller, panels, extraWidgets)
+            modules.game_actionbar.setActionBarVisible(value)
+        end
+    },
+    showSpellGroupCooldowns           = {
+        value = true,
+        action = function(value, options, controller, panels, extraWidgets)
+            modules.game_cooldown.setSpellGroupCooldownsVisible(value)
+        end
+    },
     dontStretchShrink                 = {
         value = false,
         action = function(value, options, controller, panels, extraWidgets)

--- a/modules/client_options/general.otui
+++ b/modules/client_options/general.otui
@@ -49,6 +49,28 @@ Panel
     anchors.top: prev.bottom
     margin-top: 7
     height: 22
+
+    OptionCheckBox
+      id: showActionbar
+      !text: tr('Show action bar')
+
+  SmallReversedQtPanel
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 7
+    height: 22
+
+    OptionCheckBox
+      id: showSpellGroupCooldowns
+      !text: tr('Show spell group cooldowns')
+
+  SmallReversedQtPanel
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 7
+    height: 22
   
     OptionCheckBox
       id: openMaximized

--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -913,6 +913,16 @@ function loadActionBar()
     setupHotkeys()
 end
 
+function setActionBarVisible(visible)
+    if visible then
+        actionBar:setHeight(34)
+        actionBar:show()
+    else
+        actionBar:setHeight(0)
+        actionBar:hide()
+    end
+end
+
 function round(n)
     return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
 end

--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -23,10 +23,12 @@ function init()
     cooldownButton = modules.game_mainpanel.addToggleButton('cooldownButton', tr('Cooldowns'),
         '/images/options/cooldowns', toggle, false, 5)
 
-    if g_settings.get('cooldownWindow') then
+    if modules.client_options.getOption('showSpellGroupCooldowns') then
         cooldownButton:setOn(true)
+        modules.client_options.setOption('showSpellGroupCooldowns', true)
     else
         cooldownButton:setOn(false)
+        modules.client_options.setOption('showSpellGroupCooldowns', false)
     end
 
     cooldownButton:hide()
@@ -58,8 +60,6 @@ function terminate()
         onSpellGroupCooldown = onSpellGroupCooldown,
         onSpellCooldown = onSpellCooldown
     })
-
-    g_settings.set('cooldownWindow', cooldownWindow:isVisible())
 
     cooldownWindow:destroy()
     cooldownButton:destroy()
@@ -106,40 +106,34 @@ end
 
 function onMiniWindowOpen()
     cooldownButton:setOn(true)
+    modules.client_options.setOption('showSpellGroupCooldowns', true)
 end
 
 function onMiniWindowClose()
     cooldownButton:setOn(false)
+    modules.client_options.setOption('showSpellGroupCooldowns', false)
 end
 
 function toggle()
     local console = modules.game_console.consolePanel
     if cooldownButton:isOn() then
-        setSpellGroupCooldownsVisible(false)
+        modules.client_options.setOption('showSpellGroupCooldowns', false)
         cooldownButton:setOn(false)
-        if console then
-            console:addAnchor(AnchorTop, modules.game_actionbar.getPanelActionbar():getId(), AnchorBottom)
-        end
     else
-        setSpellGroupCooldownsVisible(true)
+        modules.client_options.setOption('showSpellGroupCooldowns', true)
         cooldownButton:setOn(true)
-
-        if console then
-            console:addAnchor(AnchorTop, cooldownWindow:getId(), AnchorBottom)
-        end
-
     end
 end
 
 function online()
-
     if g_game.getFeature(GameSpellList) then
         cooldownButton:show()
         cooldownButton:setOn(true)
+        modules.client_options.setOption('showSpellGroupCooldowns', true)
     else
         cooldownButton:hide()
         cooldownButton:setOn(false)
-        setSpellGroupCooldownsVisible(false)
+        modules.client_options.setOption('showSpellGroupCooldowns', false)
     end
 
     if not lastPlayer or lastPlayer ~= g_game.getCharacterName() then
@@ -283,10 +277,10 @@ function setSpellGroupCooldownsVisible(visible)
     if visible then
         cooldownWindow:setHeight(30)
         cooldownWindow:show()
-        cooldownButton:setOn(true)
     else
         cooldownWindow:hide()
         cooldownWindow:setHeight(10)
-        cooldownButton:setOn(false)
     end
+
+    cooldownButton:setOn(visible)
 end

--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -275,3 +275,13 @@ function onSpellGroupCooldown(groupId, duration)
         groupCooldown[groupId] = true
     end
 end
+
+function setSpellGroupCooldownsVisible(visible)
+    if visible then
+        cooldownWindow:setHeight(30)
+        cooldownWindow:show()
+    else
+        cooldownWindow:hide()
+        cooldownWindow:setHeight(10)
+    end
+end

--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -23,7 +23,11 @@ function init()
     cooldownButton = modules.game_mainpanel.addToggleButton('cooldownButton', tr('Cooldowns'),
         '/images/options/cooldowns', toggle, false, 5)
 
-    cooldownButton:setOn(true)
+    if g_settings.get('cooldownWindow') then
+        cooldownButton:setOn(true)
+    else
+        cooldownButton:setOn(false)
+    end
 
     cooldownButton:hide()
 
@@ -54,6 +58,8 @@ function terminate()
         onSpellGroupCooldown = onSpellGroupCooldown,
         onSpellCooldown = onSpellCooldown
     })
+
+    g_settings.set('cooldownWindow', cooldownWindow:isVisible())
 
     cooldownWindow:destroy()
     cooldownButton:destroy()
@@ -109,14 +115,13 @@ end
 function toggle()
     local console = modules.game_console.consolePanel
     if cooldownButton:isOn() then
-        cooldownWindow:hide()
+        setSpellGroupCooldownsVisible(false)
         cooldownButton:setOn(false)
-
         if console then
             console:addAnchor(AnchorTop, modules.game_actionbar.getPanelActionbar():getId(), AnchorBottom)
         end
     else
-        cooldownWindow:show()
+        setSpellGroupCooldownsVisible(true)
         cooldownButton:setOn(true)
 
         if console then
@@ -129,14 +134,12 @@ end
 function online()
 
     if g_game.getFeature(GameSpellList) then
-
         cooldownButton:show()
         cooldownButton:setOn(true)
     else
-
         cooldownButton:hide()
         cooldownButton:setOn(false)
-        cooldownWindow:hide()
+        setSpellGroupCooldownsVisible(false)
     end
 
     if not lastPlayer or lastPlayer ~= g_game.getCharacterName() then
@@ -280,8 +283,10 @@ function setSpellGroupCooldownsVisible(visible)
     if visible then
         cooldownWindow:setHeight(30)
         cooldownWindow:show()
+        cooldownButton:setOn(true)
     else
         cooldownWindow:hide()
         cooldownWindow:setHeight(10)
+        cooldownButton:setOn(false)
     end
 end


### PR DESCRIPTION
# Description

Some people might want to use the client in old style way, not using actionbars or spell cooldown group.
- [x] Added Show spells cooldowns group in the option menu
- [x] Added Show action bars in the option menu 
- [x] At first the hide cooldown group button near inventory doesn't hide properly.
![image](https://github.com/mehah/otclient/assets/16403023/0e6f1305-47b1-4917-b554-d9a1ae7cfe84)
- [x] Hide spells cooldown group button wasn't synchronized with the spells cooldown group option in the menu.

## Behavior

### **Actual**

There's no option to hide them.

## Fixes

No github issues.

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Open the client, go into menu options check/uncheck "show action bar" or "show spell group cooldowns"
The menu configuration:
![image](https://github.com/mehah/otclient/assets/16403023/703b7634-d152-4929-89dc-79db461e05a1)

Both unchecked:
![image](https://github.com/mehah/otclient/assets/16403023/3563346b-f42d-4f13-a8a7-9048bff15330)
Action bar checked:
![image](https://github.com/mehah/otclient/assets/16403023/96ff180f-5b97-4d3f-8de0-074d1f8d4a3a)
Spell group cooldowns checked:
![image](https://github.com/mehah/otclient/assets/16403023/66413cee-f4f6-4cc3-9cbd-944092cf6696)
Action bar and spell group cooldowns checked:
![image](https://github.com/mehah/otclient/assets/16403023/ea23e1e3-555a-411d-a1ea-2332cc4922c1)

**Test Configuration**:

  - Server Version: Canary 13.32
  - Client: OTC
  - Operating System:  Windows 11 23H2 (22631.3737)

