### PR TITLE
fix: early return on dimensions or placement == hide

### DIFF
--- a/modules/game_interface/widgets/statsbar.lua
+++ b/modules/game_interface/widgets/statsbar.lua
@@ -196,7 +196,7 @@ function StatsBar.getCurrentStatsBarWithPosition()
     -- It's made this way so we can call the current stats bar without having to use a switch statement.
     -- And if it's necessary to add more stats bars like "largeOnLeft" it will be easier to add them
     -- Without changing this code.
-    if currentStats.dimension == 'hide' and currentStats.placement == 'hide' then
+    if currentStats.dimension == 'hide' or currentStats.placement == 'hide' then
         return nil
     end
     -- -- Get full position as a single string. 
@@ -222,7 +222,7 @@ end
 function StatsBar.getCurrentStatsBar()
     -- This method will return the statsbar based on its placement.
     -- i.e statsBarTop // statsBarBottom
-    if currentStats.dimension == 'hide' and currentStats.placement == 'hide' then
+    if currentStats.dimension == 'hide' or currentStats.placement == 'hide' then
         return nil
     end
     -- -- Get full placement. 
@@ -475,7 +475,13 @@ local function onStatsMousePress(tab, mousePos, mouseButton)
 end
 
 function StatsBar.reloadCurrentTab()
+    if currentStats.dimension == "hide" then
+        return
+    end
+
     local dimension = currentStats.dimension:gsub("^%l", string.upper)
+    
+
     if statsBarsDimensions[dimension] then
         return constructStatsBar(dimension, currentStats.placement)
     else 

--- a/modules/game_interface/widgets/statsbar.lua
+++ b/modules/game_interface/widgets/statsbar.lua
@@ -480,7 +480,6 @@ function StatsBar.reloadCurrentTab()
     end
 
     local dimension = currentStats.dimension:gsub("^%l", string.upper)
-    
 
     if statsBarsDimensions[dimension] then
         return constructStatsBar(dimension, currentStats.placement)


### PR DESCRIPTION
# Description

When stats bar dimensions or placement were equals hide it would print that the bar was not found.

## Behavior

### **Actual**

![image](https://github.com/mehah/otclient/assets/16403023/ef1685c1-8f1b-4a13-82a1-efa9d25eb3e9)


### **Expected**

It shouldn't print that the bar was not found if dimensions or placements were equals hide.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Login, change stats bar to hide in menu or options, relog. It shouldn't warn that the stats bar weren't found.
  - [x] Login, change stats bar to anything but hide, relog, it shouldn't warn that the stats bar weren't found.

**Test Configuration**:

  - Server Version: Canary 13.32
  - Client: OTC Redemption
  - Operating System: Windows

