### PR TITLE
improve: smart event controller

### DIFF
--- a/modules/game_attachedeffects/attachedeffects.lua
+++ b/modules/game_attachedeffects/attachedeffects.lua
@@ -1,21 +1,3 @@
-controller = Controller:new()
-
--- uncomment this line to apply an effect on the local player, just for testing purposes.
---[[function controller:onGameStart()
-    g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(1))
-    g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(2))
-    g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(3))
-    g_game.getLocalPlayer():getTile():attachEffect(g_attachedEffects.getById(1))
-end
-
-function controller:onGameEnd()
-    g_game.getLocalPlayer():clearAttachedEffects()
-end]]
-
-function controller:onTerminate()
-    g_attachedEffects.clear()
-end
-
 local function onAttach(effect, owner)
     local category, thingId = AttachedEffectManager.getDataThing(owner)
     local config = AttachedEffectManager.getConfig(effect:getId(), category, thingId)
@@ -44,16 +26,36 @@ local function onOutfitChange(creature, outfit, oldOutfit)
     end
 end
 
-controller:attachExternalEvent(EventController:new(LocalPlayer, {
-    onOutfitChange = onOutfitChange
-}))
-controller:attachExternalEvent(EventController:new(Creature, {
-    onOutfitChange = onOutfitChange
-}))
-controller:attachExternalEvent(EventController:new(AttachedEffect, {
-    onAttach = onAttach,
-    onDetach = onDetach
-}))
+controller = Controller:new()
+
+function controller:onGameStart()
+    controller:registerEvents(LocalPlayer, {
+        onOutfitChange = onOutfitChange
+    })
+
+    controller:registerEvents(Creature, {
+        onOutfitChange = onOutfitChange
+    })
+
+    controller:registerEvents(AttachedEffect, {
+        onAttach = onAttach,
+        onDetach = onDetach
+    })
+
+    -- uncomment this line to apply an effect on the local player, just for testing purposes.
+    --[[g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(1))
+    g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(2))
+    g_game.getLocalPlayer():attachEffect(g_attachedEffects.getById(3))
+    g_game.getLocalPlayer():getTile():attachEffect(g_attachedEffects.getById(1))]]
+end
+
+function controller:onGameEnd()
+    -- g_game.getLocalPlayer():clearAttachedEffects()
+end
+
+function controller:onTerminate()
+    g_attachedEffects.clear()
+end
 
 -- @ note: sorry, I couldn't find any other way to do it
 function getCategory(id)
@@ -72,7 +74,6 @@ function getName(id)
     else
         return "None"
     end
-
 end
 
 function thingId(id)
@@ -82,4 +83,5 @@ function thingId(id)
         return "None"
     end
 end
+
 -- @

--- a/modules/game_creatureinformation/creatureinformation.lua
+++ b/modules/game_creatureinformation/creatureinformation.lua
@@ -180,12 +180,11 @@ function toggleInformation()
     end
 end
 
-controller = Controller:new()
-controller:addEvent(Creature, creatureEvents)
-controller:addEvent(LocalPlayer, { onManaChange = onManaChange })
+function controller:onGameStart()
+    controller:registerEvents(Creature, creatureEvents)
+    controller:registerEvents(LocalPlayer, { onManaChange = onManaChange })
 
-if devMode then
-    function controller:onGameStart()
+    if devMode then
         local spectators = modules.game_interface.getMapPanel():getSpectators()
         for _, creature in ipairs(spectators) do
             onCreate(creature)

--- a/modules/game_healthinfo/healthinfo.lua
+++ b/modules/game_healthinfo/healthinfo.lua
@@ -17,11 +17,6 @@ end
 healthManaController = Controller:new()
 healthManaController:setUI('healthinfo', modules.game_interface.getMainRightPanel())
 
-local healthManaControllerEvents = healthManaController:addEvent(LocalPlayer, {
-    onHealthChange = healthManaEvent,
-    onManaChange = healthManaEvent
-})
-
 function healthManaController:onInit()
 end
 
@@ -29,12 +24,10 @@ function healthManaController:onTerminate()
 end
 
 function healthManaController:onGameStart()
-    healthManaControllerEvents:connect()
-    healthManaControllerEvents:execute('onHealthChange')
-    healthManaControllerEvents:execute('onManaChange')
+    healthManaController:registerEvents(LocalPlayer, {
+        onHealthChange = healthManaEvent,
+        onManaChange = healthManaEvent
+    }):execute()
 end
 
-function healthManaController:onGameEnd()
-    healthManaControllerEvents:disconnect()
-end
 -- @ End of Health/Mana

--- a/modules/game_inventory/inventory.lua
+++ b/modules/game_inventory/inventory.lua
@@ -31,7 +31,7 @@ local function combatEvent()
     elseif g_game.getFightMode() == FightDefensive then
         selectCombat('defense', true)
     end
-   
+
     selectPvp(g_game.getPVPMode() == PVPRedFist, true)
 end
 
@@ -101,7 +101,6 @@ local function onSoulChange(localPlayer, soul)
     if ui.soulAndCapacity and ui.soulAndCapacity.soul then
         ui.soulAndCapacity.soul:setText(soul)
     end
-
 end
 
 local function onFreeCapacityChange(player, freeCapacity)
@@ -153,7 +152,6 @@ local function refreshInventory_panel()
             inventoryEvent(player, i, nil)
         end
     end
-
 end
 
 local function refreshInventorySizes()
@@ -191,21 +189,6 @@ end
 inventoryController = Controller:new()
 inventoryController:setUI('inventory', modules.game_interface.getMainRightPanel())
 
-local inventoryControllerEvents = inventoryController:addEvent(LocalPlayer, {
-    onInventoryChange = inventoryEvent,
-    onSoulChange = onSoulChange,
-    onFreeCapacityChange = onFreeCapacityChange
-})
-
-local inventoryControllerEvents_game = inventoryController:addEvent(g_game, {
-    onWalk = walkEvent,
-    onAutoWalk = walkEvent,
-    onFightModeChange = combatEvent,
-    onChaseModeChange = combatEvent,
-    onSafeFightChange = combatEvent,
-    onPVPModeChange = combatEvent
-})
-
 function inventoryController:onInit()
     refreshInventory_panel()
     local ui = getInventoryUi()
@@ -219,24 +202,21 @@ function inventoryController:onInit()
     })
 end
 
-function inventoryController:onTerminate()
-    inventoryControllerEvents:disconnect()
-    inventoryControllerEvents_game:disconnect()
-end
-
 function inventoryController:onGameStart()
-    inventoryControllerEvents:connect()
-    inventoryControllerEvents:execute('onInventoryChange')
-    inventoryControllerEvents:execute('onSoulChange')
-    inventoryControllerEvents:execute('onFreeCapacityChange')
+    inventoryController:registerEvents(LocalPlayer, {
+        onInventoryChange = inventoryEvent,
+        onSoulChange = onSoulChange,
+        onFreeCapacityChange = onFreeCapacityChange
+    }):execute()
 
-    inventoryControllerEvents_game:connect()
-    inventoryControllerEvents_game:execute('onWalk')
-    inventoryControllerEvents_game:execute('onAutoWalk')
-    inventoryControllerEvents_game:execute('onFightModeChange')
-    inventoryControllerEvents_game:execute('onChaseModeChange')
-    inventoryControllerEvents_game:execute('onSafeFightChange')
-    inventoryControllerEvents_game:execute('onPVPModeChange')
+    inventoryController:registerEvents(g_game, {
+        onWalk = walkEvent,
+        onAutoWalk = walkEvent,
+        onFightModeChange = combatEvent,
+        onChaseModeChange = combatEvent,
+        onSafeFightChange = combatEvent,
+        onPVPModeChange = combatEvent
+    }):execute()
 
     inventoryShrink = g_settings.getBoolean('mainpanel_shrink_inventory')
     refreshInventorySizes()
@@ -248,11 +228,6 @@ function inventoryController:onGameStart()
         inventoryController.ui.onPanel.blessings:hide()
         inventoryController.ui.onPanel.expert:hide()
     end
-end
-
-function inventoryController:onGameEnd()
-    inventoryControllerEvents:disconnect()
-    inventoryControllerEvents_game:disconnect()
 end
 
 function selectPosture(key, ignoreUpdate)
@@ -308,7 +283,7 @@ function selectPvp(pvp, ignoreUpdate)
         end
     else
         ui.pvp:setImageClip(ui.pvp.imageClipUncheckedX .. ' ' .. ui.pvp.imageClipUncheckedY .. ' ' ..
-                                ui.pvp.imageClipWidth .. ' 20')
+            ui.pvp.imageClipWidth .. ' 20')
         if not ignoreUpdate then
             g_game.setPVPMode(PVPWhiteHand)
         end
@@ -322,7 +297,6 @@ function changeInventorySize()
     modules.game_mainpanel.reloadMainPanelSizes()
     local player = g_game.getLocalPlayer()
     if player and g_game.isOnline() then
-
         onFreeCapacityChange(player, player:getFreeCapacity())
         onSoulChange(player, player:getSoul())
     end

--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -43,9 +43,7 @@ end
 mapController = Controller:new()
 mapController:setUI('minimap', modules.game_interface.getMainRightPanel())
 
-local mapControllerEvents = mapController:addEvent(LocalPlayer, {
-    onPositionChange = onPositionChange
-})
+
 
 function onChangeWorldTime(hour, minute)
     currentDayTime = {
@@ -96,9 +94,6 @@ function onChangeWorldTime(hour, minute)
 end
 
 function mapController:onInit()
-    mapControllerEvents:connect()
-    mapControllerEvents:execute('onPositionChange')
-
     self.ui.minimapBorder.minimap:getChildById('floorUpButton'):hide()
     self.ui.minimapBorder.minimap:getChildById('floorDownButton'):hide()
     self.ui.minimapBorder.minimap:getChildById('zoomInButton'):hide()
@@ -111,6 +106,10 @@ function mapController:onInit()
 end
 
 function mapController:onGameStart()
+    mapController:registerEvents(LocalPlayer, {
+        onPositionChange = onPositionChange
+    }):execute()
+
     -- Load Map
     g_minimap.clean()
 
@@ -144,7 +143,6 @@ function mapController:onGameEnd()
 end
 
 function mapController:onTerminate()
-    mapControllerEvents:disconnect()
     disconnect(g_game, {
         onChangeWorldTime = onChangeWorldTime
     })
@@ -245,4 +243,5 @@ end
 function getMiniMapUi()
     return mapController.ui.minimapBorder.minimap
 end
+
 -- @ End of Minimap

--- a/modules/gamelib/controller.lua
+++ b/modules/gamelib/controller.lua
@@ -12,14 +12,14 @@ local function onGameStart(self)
         self.currentTypeEvent = TypeEvent.GAME_INIT
         addEvent(function()
             self:__onGameStart()
-        end)
-    end
 
-    local eventList = self.events[TypeEvent.GAME_INIT]
-    if eventList ~= nil then
-        for actor, events in pairs(eventList) do
-            connect(actor, events)
-        end
+            local eventList = self.events[TypeEvent.GAME_INIT]
+            if eventList ~= nil then
+                for _, event in pairs(eventList) do
+                    event:connect()
+                end
+            end
+        end)
     end
 end
 
@@ -30,9 +30,11 @@ local function onGameEnd(self)
 
     local eventList = self.events[TypeEvent.GAME_INIT]
     if eventList ~= nil then
-        for actor, events in pairs(eventList) do
-            disconnect(actor, events)
+        for _, event in pairs(eventList) do
+            event:disconnect()
         end
+
+        self.events[TypeEvent.GAME_INIT] = nil
     end
 
     if self.dataUI ~= nil and self.dataUI.onGameStart then
@@ -45,7 +47,6 @@ Controller = {
     name = nil,
     events = nil,
     ui = nil,
-    externalEvents = nil,
     keyboardEvents = nil,
     attrs = nil,
     opcodes = nil,
@@ -57,7 +58,6 @@ function Controller:new()
         name = g_modules.getCurrentModule():getName(),
         currentTypeEvent = TypeEvent.MODULE_INIT,
         events = {},
-        externalEvents = {},
         keyboardEvents = {},
         attrs = {},
         opcodes = {}
@@ -81,6 +81,7 @@ function Controller:init()
     self.onGameStart = function()
         onGameStart(self)
     end
+
     connect(g_game, {
         onGameStart = self.onGameStart
     })
@@ -98,12 +99,10 @@ function Controller:init()
         onGameEnd = self.onGameEnd
     })
 
-    self:connectExternalEvents()
-
     local eventList = self.events[TypeEvent.MODULE_INIT]
-    if eventList ~= nil then
-        for actor, events in pairs(eventList) do
-            connect(actor, events)
+    if eventList then
+        for _, event in pairs(eventList) do
+            event:connect()
         end
     end
 end
@@ -143,12 +142,11 @@ function Controller:terminate()
         ProtocolGame.unregisterExtendedOpcode(opcode)
     end
 
-    self:disconnectExternalEvents()
-
-    local eventList = self.events[TypeEvent.MODULE_INIT]
-    if eventList ~= nil then
-        for actor, events in pairs(eventList) do
-            disconnect(actor, events)
+    for type, events in pairs(self.events) do
+        if events ~= nil then
+            for _, event in pairs(events) do
+                event:disconnect()
+            end
         end
     end
 
@@ -162,75 +160,25 @@ function Controller:terminate()
     self.keyboardEvents = nil
     self.attrs = nil
     self.opcodes = nil
-    self.externalEvents = nil
     self.keyboardAnchor = nil
     self.__onGameStart = nil
     self.__onGameEnd = nil
 end
 
-function Controller:addEvent(actor, events)
-    local evt = EventController:new(actor, events)
-    table.insert(self.externalEvents, evt)
-    return evt
-end
-
-function Controller:attachExternalEvent(event)
-    table.insert(self.externalEvents, event)
-end
-
-function Controller:connectExternalEvents()
-    for i, event in pairs(self.externalEvents) do
-        event:connect()
-    end
-end
-
-function Controller:disconnectExternalEvents()
-    for i, event in pairs(self.externalEvents) do
-        event:disconnect()
-    end
-end
-
+--[[
+    If you register an event within onInit() or in the general scope of the script,
+    the event will be automatically connected at startup and disconnected when it is destroyed.
+    If it is within onGameStart(), the events will be connected when starting the game map and when exiting it.
+]]
 function Controller:registerEvents(actor, events)
     if self.events[self.currentTypeEvent] == nil then
         self.events[self.currentTypeEvent] = {}
     end
 
-    self.events[self.currentTypeEvent][actor] = events
-end
+    local evt = EventController:new(actor, events)
+    table.insert(self.events[self.currentTypeEvent], evt)
 
-function Controller:connectEvents(actor, events)
-    if type(actor) == 'table' then
-        for _, target in pairs(actor) do
-            self:connectEvents(target, events)
-        end
-        return
-    end
-
-    if not events then
-        events = self.events[actor]
-    else
-        self.events[actor] = events
-    end
-
-    assert(events ~= nil, 'Events are empty')
-    connect(actor, events)
-end
-
-function Controller:disconnectEvents(actor, destroy)
-    if type(actor) == 'table' then
-        for _, target in pairs(actor) do
-            self:disconnectEvents(target, destroy)
-        end
-        return
-    end
-
-    local events = self.events[actor]
-    if events then
-        disconnect(actor, events)
-        if destroy ~= false then
-            self.events[actor] = nil
-        end
-    end
+    return evt
 end
 
 function Controller:registerExtendedOpcode(opcode, fnc)

--- a/modules/gamelib/controller.lua
+++ b/modules/gamelib/controller.lua
@@ -166,9 +166,9 @@ function Controller:terminate()
 end
 
 --[[
-    If you register an event within onInit() or in the general scope of the script,
-    the event will be automatically connected at startup and disconnected when it is destroyed.
-    If it is within onGameStart(), the events will be connected when starting the game map and when exiting it.
+    If you register an event in onInit() or in the general scope of the script,
+    the event will be automatically registered at startup and disconnected when the module is destroyed.
+    If it is inside onGameStart(), the events will be connected when entering the game map and disconnected when leaving and also when the module is destroyed.
 ]]
 function Controller:registerEvents(actor, events)
     if self.events[self.currentTypeEvent] == nil then
@@ -217,7 +217,6 @@ function Controller:bindKeyUp(...)
         args = args
     })
 
-    print(args[1], args[2], args[3])
     g_keyboard.bindKeyUp(args[1], args[2], args[3])
 end
 

--- a/modules/gamelib/eventcontroller.lua
+++ b/modules/gamelib/eventcontroller.lua
@@ -4,6 +4,16 @@ EventController = {
 }
 
 function EventController:new(actor, events)
+    if actor == nil then
+        error('Actor is null.')
+        return
+    end
+
+    if events == nil then
+        error('Events is null.')
+        return
+    end
+
     local obj = {
         actor = actor,
         events = events,
@@ -19,6 +29,7 @@ function EventController:connect()
         return
     end
     self.connected = true
+
     connect(self.actor, self.events)
 end
 
@@ -31,5 +42,13 @@ function EventController:disconnect()
 end
 
 function EventController:execute(name, ...)
+    if name == nil then
+        for name, act in pairs(self.events) do
+            print(name)
+            act()
+        end
+        return
+    end
+
     self.events[name](...)
 end

--- a/modules/gamelib/eventcontroller.lua
+++ b/modules/gamelib/eventcontroller.lua
@@ -44,7 +44,6 @@ end
 function EventController:execute(name, ...)
     if name == nil then
         for name, act in pairs(self.events) do
-            print(name)
             act()
         end
         return


### PR DESCRIPTION
If you register an event in onInit() or in the general scope of the script,
the event will be automatically registered at startup and disconnected when the module is destroyed.
If it is inside onGameStart(), the events will be connected when entering the game map and disconnected when leaving and also when the module is destroyed.