### PR TITLE
fix: save hotkeys after re-opening the client

### DIFF
--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -59,7 +59,7 @@ boundCombosCallback = {}
 hotkeysList = {}
 disableHotkeysCount = 0
 lastHotkeyTime = g_clock.millis()
-local hotkeysWindowButton = nil 
+local hotkeysWindowButton = nil
 
 -- public functions
 function init()
@@ -202,16 +202,21 @@ function cancel()
 end
 
 function load(forceDefaults)
+    local serverHost = nil
     hotkeysManagerLoaded = false
 
     local hotkeySettings = g_settings.getNode('game_hotkeys')
     local hotkeys = {}
 
+
     if not table.empty(hotkeySettings) then
         hotkeys = hotkeySettings
     end
     if perServer and not table.empty(hotkeys) then
-        hotkeys = hotkeys[G.host]
+        if G.host ~= nil then
+            serverHost = string.gsub(G.host, "^https?://", "")
+            hotkeys = hotkeys[serverHost]
+        end
     end
     if perCharacter and not table.empty(hotkeys) then
         hotkeys = hotkeys[g_game.getCharacterName()]
@@ -257,14 +262,15 @@ function reload()
 end
 
 function save()
+    local serverHost = string.gsub(G.host, "^https?://", "")
     local hotkeySettings = g_settings.getNode('game_hotkeys') or {}
     local hotkeys = hotkeySettings
 
     if perServer then
-        if not hotkeys[G.host] then
-            hotkeys[G.host] = {}
+        if not hotkeys[serverHost] then
+            hotkeys[serverHost] = {}
         end
-        hotkeys = hotkeys[G.host]
+        hotkeys = hotkeys[serverHost]
     end
 
     if perCharacter then


### PR DESCRIPTION
# Description
As mentioned in this issue https://github.com/mehah/otclient/issues/830 ot client cant save hotkeys after re-opening the client.

## Behavior

### **Actual**

Hotkeys cant be loaded after closing/opening the client.

### **Expected**

Keep hotkeys after closing and oppening the client.

## Fixes

When we use and http or https server for login, the method g_settings.getNode() -> OTMLNodePtr Config::getNode in file src\framework\core\config.cpp cant parse "http://" "https://" correctly.

## Type of change

Removing http:// or https:// from Host in load() and save() methods at file "modules\game_hotkeys\hotkeys_manager.lua"

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: Canary 1332
  - Client: Meha/otclient branch main
  - Operating System: Windows X64

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
