### PR TITLE
fix: quickloot in old protocol

### DIFF
--- a/modules/game_quickloot/quickloot.lua
+++ b/modules/game_quickloot/quickloot.lua
@@ -21,14 +21,6 @@ function quickLootController:onInit()
             {}
         }
     }
-    QuickLoot.mouseGrabberWidget = g_ui.createWidget("UIWidget")
-
-    QuickLoot.mouseGrabberWidget:setVisible(false)
-    QuickLoot.mouseGrabberWidget:setFocusable(false)
-
-    QuickLoot.mouseGrabberWidget.onMouseRelease = QuickLoot.onChooseItem
-    QuickLoot.lastSelectBag = nil
-    QuickLoot.ErrorWindow = nil
 
     quickLootController.ui:hide()
 
@@ -48,6 +40,19 @@ function quickLootController:onTerminate()
 end
 
 function quickLootController:onGameStart()
+    if not g_game.getFeature(GameThingQuickLoot) then
+        return
+    end
+
+    QuickLoot.mouseGrabberWidget = g_ui.createWidget("UIWidget")
+
+    QuickLoot.mouseGrabberWidget:setVisible(false)
+    QuickLoot.mouseGrabberWidget:setFocusable(false)
+
+    QuickLoot.mouseGrabberWidget.onMouseRelease = QuickLoot.onChooseItem
+    QuickLoot.lastSelectBag = nil
+    QuickLoot.ErrorWindow = nil
+
     quickLootController.ui.information.vipPanel.premium:setOn(not g_game.getLocalPlayer():isPremium())
     QuickLoot.load()
 
@@ -147,7 +152,15 @@ function QuickLoot.Define()
                 return g_logger.error("Error while reading containers settings file. " .. result)
             end
 
-            QuickLoot.data = result
+            if result == nil then
+                QuickLoot.data = {
+                    filter = 1,
+                    loots = {{}, {}}
+                }
+            else
+                QuickLoot.data = result
+            end
+
         else
             QuickLoot.data = {
                 filter = 1,


### PR DESCRIPTION
# Description
8.60 =
![image](https://github.com/user-attachments/assets/c6c262aa-9131-4867-b299-6bac87b4b0cf)

Ups:
missing    

```
 if not g_game.getFeature(GameThingQuickLoot) then
        return
    end

```
## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
