### PR TITLE
fix: #867

### DIFF
--- a/modules/game_features/features.lua
+++ b/modules/game_features/features.lua
@@ -5,6 +5,7 @@ controller:registerEvents(g_game, {
         -- g_game.enableFeature(GameSmoothWalkElevation)
         -- g_game.enableFeature(GameNegativeOffset)
         -- g_game.enableFeature(GameWingsAurasEffectsShader)
+        -- g_game.enableFeature(GameAllowCustomBotScripts)
         
         g_game.enableFeature(GameFormatCreatureName)
 

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -200,6 +200,7 @@ GameNegativeOffset = 116
 GameItemTooltipV8 = 117 
 GameWingsAurasEffectsShader = 118
 GameForgeConvergence = 119
+GameAllowCustomBotScripts = 120
 
 TextColors = {
     red = '#f55e5e',    -- '#c83200'

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -548,6 +548,7 @@ namespace Otc
         GameItemTooltipV8 = 117,
         GameWingsAurasEffectsShader = 118,
         GameForgeConvergence = 119,
+        GameAllowCustomBotScripts = 120,
         LastGameFeature
     };
 

--- a/src/client/spritemanager.cpp
+++ b/src/client/spritemanager.cpp
@@ -51,7 +51,7 @@ void SpriteManager::load() {
     if (g_app.isLoadingAsyncTexture()) {
         for (auto& file : m_spritesFiles)
             file = std::make_unique<FileStream_m>(g_resources.openFile(m_lastFileName));
-    } else (m_spritesFiles[0] = std::make_unique<FileStream_m>(g_resources.openFile(m_lastFileName)))->file->cache();
+    } else (m_spritesFiles[0] = std::make_unique<FileStream_m>(g_resources.openFile(m_lastFileName)))->file->cache(true);
 }
 
 bool SpriteManager::loadSpr(std::string file)
@@ -62,10 +62,6 @@ bool SpriteManager::loadSpr(std::string file)
     try {
         m_lastFileName = g_resources.guessFilePath(file, "spr");
         load();
-
-        if (g_app.isEncrypted()) {
-            ResourceManager::decrypt(getSpriteFile()->m_data.data(), getSpriteFile()->m_data.size());
-        }
 
         m_signature = getSpriteFile()->getU32();
         m_spritesCount = g_game.getFeature(Otc::GameSpritesU32) ? getSpriteFile()->getU32() : getSpriteFile()->getU16();

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -82,11 +82,7 @@ bool ThingTypeManager::loadDat(std::string file)
         file = g_resources.guessFilePath(file, "dat");
 
         const auto& fin = g_resources.openFile(file);
-        fin->cache();
-
-#if ENABLE_ENCRYPTION == 1
-        ResourceManager::decrypt(fin->m_data.data(), fin->m_data.size());
-#endif
+        fin->cache(true);
 
         m_datSignature = fin->getU32();
         m_contentRevision = static_cast<uint16_t>(m_datSignature);

--- a/src/framework/config.h
+++ b/src/framework/config.h
@@ -36,6 +36,7 @@
 #define ENABLE_ENCRYPTION_BUILDER 0
 // for security reasons make sure you are using password with at last 100+ characters
 #define ENCRYPTION_PASSWORD "SET_YOUR_PASSWORD_HERE"
+#define ENCRYPTION_HEADER "SET_YOUR_HEADER_HERE"
 
 // DISCORD RPC (https://discord.com/developers/applications)
 // Note: Only for VSSolution, doesn't work with CMAKE

--- a/src/framework/core/filestream.h
+++ b/src/framework/core/filestream.h
@@ -37,7 +37,7 @@ public:
     FileStream(std::string name, const std::string_view buffer);
     ~FileStream();
 
-    void cache();
+    void cache(bool useEnc = false);
     void close();
     void flush();
     void write(const void* buffer, uint32_t count);

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -209,7 +209,7 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
 {
     const std::string fullPath = resolvePath(fileName);
 
-    if (fullPath.find(getByteStrings(0)) != std::string::npos) {
+    if (fullPath.find(g_resources.getByteStrings(0)) != std::string::npos) {
         auto dfile = g_http.getFile(fullPath.substr(10));
         if (dfile)
             return std::string(dfile->response.begin(), dfile->response.end());
@@ -232,7 +232,7 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
 
 #if ENABLE_ENCRYPTION == 1
     if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
-        if (fullPath.find(getByteStrings(1)) != std::string::npos && !hasHeader) {
+        if (fullPath.find(g_resources.getByteStrings(1)) != std::string::npos && !hasHeader) {
             return buffer;
         }
     }

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -767,6 +767,7 @@ std::string ResourceManager::decodificateStrings(const std::vector<unsigned char
     return result;
 }
 
+// used to obfuscate vulnerable strings (provisional)
 std::string ResourceManager::getByteStrings(size_t line) {
     std::vector<std::vector<unsigned char>> strTable = {
         {0x85, 0xCE, 0xC5, 0xDD, 0xC4, 0xC6, 0xC5, 0xCB, 0xCE, 0xD9},  // "/downloads"

--- a/src/framework/core/resourcemanager.h
+++ b/src/framework/core/resourcemanager.h
@@ -93,6 +93,8 @@ public:
     bool launchCorrect(std::vector<std::string>& args);
     std::string createArchive(const std::unordered_map<std::string, std::string>& files);
     std::unordered_map<std::string, std::string> decompressArchive(std::string dataOrPath);
+    std::string decodificateStrings(const std::vector<unsigned char>& bytes);
+    std::string getByteStrings(size_t line);
 
     std::string getBinaryPath() { return m_binaryPath.string(); }
 


### PR DESCRIPTION
I added a "header" so we can identify whether the file is encrypted or not, so that the bot can be treated separately...
I don't know if it's the best way, but from my tests it solves the problem mentioned.

Now it is possible to define the "header you want" in [config.h](https://github.com/mehah/otclient/blob/main/src/framework/config.h#L39), the most recommended would be random characters (letters and numbers) so that they are "disguised" in the encrypted files.