### PR TITLE
fix: game_outfit Adjust outfit size and prevent "ERROR: invalid thing type"

### DIFF
--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -96,9 +96,6 @@ local function showSelectionList(data, tempValue, tempField, onSelectCallback)
         local button = g_ui.createWidget("SelectionButton", window.selectionList)
         button:setId("0")
 
-        button.outfit:setOutfit({
-            type = 0
-        })
         button.name:setText("None")
         if tempValue == 0 then
             focused = 0
@@ -846,7 +843,9 @@ function showOutfits()
         
         local thingType = g_things.getThingType(outfit.type, ThingCategoryCreature)
         button.outfit:setPadding(-8)
-        button.outfit:setCreatureSize(thingType:getRealSize() + 32)
+        if thingType:getRealSize() > 0 then
+            button.outfit:setCreatureSize(thingType:getRealSize() + 32)
+        end
         --button.outfit:setBorderColor('red')
         --button.outfit:setBorderWidth(2)
 
@@ -897,7 +896,9 @@ function showMounts()
 
         local thingType = g_things.getThingType(mountData[1], ThingCategoryCreature)
         button.outfit:setPadding(-8)
-        button.outfit:setCreatureSize(thingType:getRealSize() + 32)
+        if thingType:getRealSize() > 0 then
+            button.outfit:setCreatureSize(thingType:getRealSize() + 32)
+        end
 
         button.name:setText(mountData[2])
         if tempOutfit.mount == mountData[1] then
@@ -1056,9 +1057,7 @@ function showTitle()
         local button = g_ui.createWidget("SelectionButton", window.selectionList)
         button:setId("0")
 
-        button.outfit:setOutfit({
-            type = 0
-        })
+
         button.name:setText("None")
         if tempOutfit.tile == 0 then
             focused = 0


### PR DESCRIPTION
# Description


in some versions thingType:getRealSize() is 0, causing this error: 
(maybe there is **another function similar to getRealSize**, but I didn't find the function.)


## Behavior

### **Actual**

![mainrepo](https://github.com/user-attachments/assets/34e3938d-7d3b-464d-a8d4-32635a686c21)

### **Expected**
![despuss](https://github.com/user-attachments/assets/0fee0b24-470a-43b0-900d-dbedd65d63ff)



## Fixes
prevent this spam in terminal. caused by this(before it did not give an error)

```lua
button.outfit:setOutfit({
  type = 0
})
```

> ERROR: invalid thing type client id 307 in category 1
> ERROR: invalid thing type client id 307 in category 1
> ERROR: invalid thing type client id 0 in category 4

![image](https://github.com/user-attachments/assets/1a5c2643-d317-4715-b7ee-3aec6f59647e)
report by kizuno18

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)



**Test Configuration**:

  - Server Version: 13.40 , 7.72  8.6
  - Client: pr
  - Operating System: windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works

-----
note: there are several ways to reproduce this error. ERROR: invalid thing type client id

I believe it is necessary to improve the handling of this error to prevent spam and avoid performance issues.

before this error did not occur