### PR TITLE
improve: HTTP login error handling to display login.php error messages

### DIFF
--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -116,7 +116,7 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
             if (result) {
                 status = result->status;
                 try {
-                    auto body = json::parse(result->body);
+                    const auto body = json::parse(result->body);
                     if (body.contains("errorMessage")) {
                         msg = body["errorMessage"];
                     } else {

--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -115,10 +115,19 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
             std::string msg = "";
             if (result) {
                 status = result->status;
-                msg = httplib::to_string(result.error());
+                try {
+                    auto body = json::parse(result->body);
+                    if (body.contains("errorMessage")) {
+                        msg = body["errorMessage"];
+                    } else {
+                        msg = "Unexpected JSON format.";
+                    }
+                } catch (const std::exception&) {
+                    msg = httplib::to_string(result.error());
+                }
             } else {
                 status = -1;
-                msg = "Unknown error";
+                msg = "Unknown error.\ncheck: \n-Enable Http login\n-Check Apache\n-Check login.php\n-check port 80/8080\n-Check Cloudflare";
             }
 
             g_dispatcher.addEvent([this, request_id, status, msg] {

--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -127,7 +127,7 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
                 }
             } else {
                 status = -1;
-                msg = "Unknown error.\ncheck: \n-Enable Http login\n-Check Apache\n-Check login.php\n-check port 80/8080\n-Check Cloudflare";
+                msg = "Unknown error.\nCheck: \n-Enable Http login\n-Check Apache\n-Check login.php\n-check port 80/8080\n-Check Cloudflare";
             }
 
             g_dispatcher.addEvent([this, request_id, status, msg] {


### PR DESCRIPTION
# Description

The objective of the PR is to visualize this(in versions using login.php):
![image](https://github.com/user-attachments/assets/96fd5377-4bb2-4534-bdee-19f24684776a)

test in 10.6.12-MariaDB and login.php of myacc 

13.40

# Explanation: 
![image](https://github.com/user-attachments/assets/5162ea02-d8b5-430a-9f6e-7451816f8e62)

**See the squares in the lower left corner**

https://github.com/user-attachments/assets/3878b73f-0ce7-435b-9ec2-2c416e42a6ee



![bandicam 2024-09-21 03-42-43-433 00_00_08_22 Imagen fija002](https://github.com/user-attachments/assets/819a2563-9491-455d-9215-d86ae1b34594)


## Fixes

someone asked me on discord
cpp not my area, I don't even use canary or tfs 13.10 xd . 

## Type of change



  - [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested

check video

**Test Configuration**:

  - Server Version: login.php from myacc
  - Client: 13.40
  - Operating System: win 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
