### PR TITLE
fix: bot item ondrop and analyzer loot channel

### DIFF
--- a/mods/game_bot/default_configs/vBot_4.8/vBot/analyzer.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/analyzer.lua
@@ -723,11 +723,10 @@ local expPerHour = function(calculation)
 end
 
 local function add(t, text, color, last)
-    table.insert(t, text)
-    table.insert(t, color)
+    local coloredText = "{" .. text .. ", " .. color .. "}"
+    table.insert(t, coloredText)
     if not last then
-        table.insert(t, ", ")
-        table.insert(t, "#FFFFFF")
+        table.insert(t, "{, , #FFFFFF}")
     end
 end
 
@@ -958,7 +957,8 @@ onTextMessage(function(mode, text)
     local panel = console.consoleTabBar:getTabPanel(tab)
     local consoleBuffer = panel:getChildById('consoleBuffer')
     local message = consoleBuffer:getLastChild()
-    message:setColoredText(t)
+    message:setColoredText(table.concat(t))
+
 end)
 
 local function niceFormat(v)

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -178,7 +178,6 @@ function UIItem:onMouseRelease(mousePosition, mouseButton)
 end
 
 function UIItem:canAcceptDrop(widget, mousePos)
-
     if not g_game.isEnabledBotProtection() then
         if not self.selectable and (self:isVirtual() or not self:isDraggable()) then
             return false
@@ -188,6 +187,7 @@ function UIItem:canAcceptDrop(widget, mousePos)
             return false
         end
     end
+
     if not widget or not widget.currentDragThing then
         return false
     end

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -43,6 +43,14 @@ function UIItem:onDrop(widget, mousePos)
     if not(toPos) and self:getParent() and self:getParent().slotPosition then
         toPos = self:getParent().slotPosition
     end
+
+    if not g_game.isEnabledBotProtection() and self.selectable then
+        if item:isPickupable() then
+          self:setItem(Item.create(item:getId(), item:getCountOrSubType()))
+          return true
+        end
+        return false
+      end
     if not itemPos or not toPos then
         local pressedWidget = g_ui.getPressedWidget()
         local rootWidget = g_ui.getRootWidget()
@@ -170,8 +178,15 @@ function UIItem:onMouseRelease(mousePosition, mouseButton)
 end
 
 function UIItem:canAcceptDrop(widget, mousePos)
-    if self:isVirtual() or not self:isDraggable() then
-        return false
+
+    if not g_game.isEnabledBotProtection() then
+        if not self.selectable and (self:isVirtual() or not self:isDraggable()) then
+            return false
+        end
+    else
+        if self:isVirtual() or not self:isDraggable() then
+            return false
+        end
     end
     if not widget or not widget.currentDragThing then
         return false

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -187,7 +187,6 @@ function UIItem:canAcceptDrop(widget, mousePos)
             return false
         end
     end
-
     if not widget or not widget.currentDragThing then
         return false
     end

--- a/modules/game_interface/widgets/uiitem.lua
+++ b/modules/game_interface/widgets/uiitem.lua
@@ -50,7 +50,7 @@ function UIItem:onDrop(widget, mousePos)
           return true
         end
         return false
-      end
+    end
     if not itemPos or not toPos then
         local pressedWidget = g_ui.getPressedWidget()
         local rootWidget = g_ui.getRootWidget()

--- a/src/client/uiitem.cpp
+++ b/src/client/uiitem.cpp
@@ -74,7 +74,7 @@ void UIItem::setItemId(int id)
         m_item->setId(id);
     else
         m_item = Item::create(id);
-#ifdef BOT_PROTECTION
+#ifndef BOT_PROTECTION
     callLuaField("onItemChange");
 #endif
 }
@@ -82,7 +82,7 @@ void UIItem::setItemId(int id)
 void UIItem::setItemCount(int count) 
 {
     if (m_item) m_item->setCount(count);
-#ifdef BOT_PROTECTION
+#ifndef BOT_PROTECTION
     callLuaField("onItemChange");
 #endif
 }
@@ -90,7 +90,7 @@ void UIItem::setItemCount(int count)
 void UIItem::setItemSubType(int subType)
 { 
     if (m_item) m_item->setSubType(subType); 
-#ifdef BOT_PROTECTION
+#ifndef BOT_PROTECTION
     callLuaField("onItemChange");
 #endif
 }
@@ -99,7 +99,7 @@ void UIItem::setItem(const ItemPtr& item)
 { 
     m_item = item; 
 
-#ifdef BOT_PROTECTION
+#ifndef BOT_PROTECTION
     callLuaField("onItemChange");
 #endif
 }


### PR DESCRIPTION
# Description

bug reported in discord by ‘soyfabi’.
1.- fix ondrop item in UI conteiner
2.- the setColouredText function is different in v8 than in redemption
![fix drop](https://github.com/user-attachments/assets/aef8b1ed-6d71-48ac-8fd5-dcf20205ef31)
![image](https://github.com/user-attachments/assets/b5c6bdb7-d4c8-4e93-920a-c9d6b84e1be4)

## Fixes

‘soyfabi’.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 860
  - Client: pr
  - Operating System: win 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
