### PR TITLE
Fix black and red squares behaviors

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -860,7 +860,7 @@ void Creature::setShieldTexture(const std::string& filename, bool blink)
 void Creature::addTimedSquare(uint8_t color)
 {
     m_showTimedSquare = true;
-    m_timedSquareColor = Color::from8bit(color);
+    m_timedSquareColor = Color::from8bit(color != 0 ? color : 1);
 
     // schedule removal
     const auto self = static_self_cast<Creature>();

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3041,7 +3041,7 @@ void ProtocolGame::parseCreaturesMark(const InputMessagePtr& msg)
     const uint8_t len = g_game.getClientVersion() >= 1035 ? 1 : msg->getU8();
     for (auto i = 0; i < len; ++i) {
         const uint32_t creatureId = msg->getU32();
-        const bool isPermanent = static_cast<bool>(msg->getU8());
+        const bool isPermanent = false;
         const uint8_t markType = msg->getU8();
 
         const auto& creature = g_map.getCreatureById(creatureId);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -859,7 +859,7 @@ void ProtocolGame::parseStoreTransactionHistory(const InputMessagePtr& msg) cons
             msg->getU32();
             const uint32_t time = msg->getU32();
             msg->getU8();
-            const uint32_t amount = (UINT32_MAX -msg->getU32());
+            const uint32_t amount = (UINT32_MAX - msg->getU32());
             msg->getU8();
             const auto& productName = msg->getString();
             msg->getU8();
@@ -1436,7 +1436,7 @@ void ProtocolGame::parseContainerRemoveItem(const InputMessagePtr& msg)
     g_game.processContainerRemoveItem(containerId, slot, lastItem);
 }
 
-void ProtocolGame::parseBosstiaryInfo(const InputMessagePtr& msg) 
+void ProtocolGame::parseBosstiaryInfo(const InputMessagePtr& msg)
 {
     const uint16_t bosstiaryRaceLast = msg->getU16();
     std::vector<BosstiaryData> bossData;
@@ -2648,7 +2648,7 @@ void ProtocolGame::parseOpenOutfitWindow(const InputMessagePtr& msg) const
             const auto& shaderName = msg->getString();
             shaderList.emplace_back(shaderId, shaderName);
         }
-   }
+    }
 
     g_game.processOpenOutfitWindow(currentOutfit, outfitList, mountList, wingList, auraList, effectList, shaderList);
 }
@@ -2806,7 +2806,7 @@ void ProtocolGame::parseBestiaryMonsterData(const InputMessagePtr& msg)
     if (data.currentLevel > 1) {
         data.charmValue = msg->getU16();
         data.attackMode = msg->getU8();
-        msg->getU8(); 
+        msg->getU8();
         data.maxHealth = msg->getU32();
         data.experience = msg->getU32();
         data.speed = msg->getU16();
@@ -2844,7 +2844,7 @@ void ProtocolGame::parseBestiaryCharmsData(const InputMessagePtr& msg)
     BestiaryCharmsData charmData;
     charmData.points = msg->getU32();
 
-    const uint8_t charmsAmount = msg->getU8();  
+    const uint8_t charmsAmount = msg->getU8();
     for (auto i = 0; i < charmsAmount; ++i) {
         CharmData charm;
         charm.id = msg->getU8();
@@ -2861,17 +2861,17 @@ void ProtocolGame::parseBestiaryCharmsData(const InputMessagePtr& msg)
             const bool asigned = static_cast<bool>(msg->getU8());
             if (asigned) {
                 charm.asignedStatus = asigned;
-                charm.raceId = msg->getU16(); 
-                charm.removeRuneCost = msg->getU32(); 
+                charm.raceId = msg->getU16();
+                charm.removeRuneCost = msg->getU32();
             }
         } else {
-            msg->getU8(); 
+            msg->getU8();
         }
 
         charmData.charms.emplace_back(charm);
     }
 
-    msg->getU8(); 
+    msg->getU8();
 
     const uint16_t finishedMonstersSize = msg->getU16();
     for (auto i = 0; i < finishedMonstersSize; ++i) {
@@ -3038,27 +3038,24 @@ void ProtocolGame::parseChangeMapAwareRange(const InputMessagePtr& msg)
 
 void ProtocolGame::parseCreaturesMark(const InputMessagePtr& msg)
 {
-    const uint8_t len = g_game.getClientVersion() >= 1035 ? 1 : msg->getU8();
-    for (auto i = 0; i < len; ++i) {
-        const uint32_t creatureId = msg->getU32();
-        const bool isPermanent = false;
-        const uint8_t markType = msg->getU8();
+    const uint32_t creatureId = msg->getU32();
+    const bool isPermanent = g_game.getClientVersion() >= 1076 ? msg->getU8() == 0 : false;
+    const uint8_t markType = msg->getU8();
 
-        const auto& creature = g_map.getCreatureById(creatureId);
-        if (!creature) {
-            g_logger.traceError(stdext::format("ProtocolGame::parseTrappers: could not get creature with id %d", creatureId));
-            continue;
-        }
+    const auto& creature = g_map.getCreatureById(creatureId);
+    if (!creature) {
+        g_logger.traceError(stdext::format("ProtocolGame::parseTrappers: could not get creature with id %d", creatureId));
+        return;
+    }
 
-        if (isPermanent) {
-            if (markType == 0xff) {
-                creature->hideStaticSquare();
-            } else {
-                creature->showStaticSquare(Color::from8bit(markType));
-            }
+    if (isPermanent) {
+        if (markType == 0xff) {
+            creature->hideStaticSquare();
         } else {
-            creature->addTimedSquare(markType);
+            creature->showStaticSquare(Color::from8bit(markType != 0 ? markType : 1));
         }
+    } else {
+        creature->addTimedSquare(markType);
     }
 }
 
@@ -3818,7 +3815,7 @@ void ProtocolGame::parsePartyAnalyzer(const InputMessagePtr& msg)
         msg->getU64(); // healing
     }
 
-    const bool hasNamesBool =static_cast<bool>( msg->getU8());
+    const bool hasNamesBool = static_cast<bool>(msg->getU8());
     if (hasNamesBool) {
         const uint8_t membersNameSize = msg->getU8();
         for (auto i = 0; i < membersNameSize; ++i) {
@@ -4152,10 +4149,10 @@ void ProtocolGame::parseCyclopediaCharacterInfo(const InputMessagePtr& msg)
         case Otc::CYCLOPEDIA_CHARACTERINFO_RECENTDEATHS:
         {
             CyclopediaCharacterRecentDeaths data;
-            msg->getU16();  
+            msg->getU16();
             msg->getU16();
 
-            const uint16_t entriesCount = msg->getU16();  
+            const uint16_t entriesCount = msg->getU16();
             for (auto i = 0; i < entriesCount; ++i) {
                 RecentDeathEntry entry;
                 entry.timestamp = msg->getU32();
@@ -4169,10 +4166,10 @@ void ProtocolGame::parseCyclopediaCharacterInfo(const InputMessagePtr& msg)
         case Otc::CYCLOPEDIA_CHARACTERINFO_RECENTPVPKILLS:
         {
             CyclopediaCharacterRecentPvPKills data;
-            msg->getU16();  
+            msg->getU16();
             msg->getU16();
 
-            const uint16_t entriesCount = msg->getU16();  
+            const uint16_t entriesCount = msg->getU16();
             for (auto i = 0; i < entriesCount; ++i) {
                 RecentPvPKillEntry entry;
                 entry.timestamp = msg->getU32();
@@ -4344,8 +4341,8 @@ void ProtocolGame::parseCyclopediaCharacterInfo(const InputMessagePtr& msg)
         }
         case Otc::CYCLOPEDIA_CHARACTERINFO_STORESUMMARY:
         {
-            const uint32_t xpBoostTime = msg->getU32();  
-            const uint32_t dailyRewardXpBoostTime = msg->getU32();  
+            const uint32_t xpBoostTime = msg->getU32();
+            const uint32_t dailyRewardXpBoostTime = msg->getU32();
 
             std::vector<std::tuple<std::string, uint8_t>> blessings;
             const uint8_t blessingCount = msg->getU8();
@@ -4403,7 +4400,7 @@ void ProtocolGame::parseCyclopediaCharacterInfo(const InputMessagePtr& msg)
                 const auto& badgeName = msg->getString();
                 badgesVector.emplace_back(badgeId, badgeName);
             }
-    
+
             g_game.processCyclopediaCharacterGeneralStatsBadge(showAccountInformation, playerOnline, playerPremium, loyaltyTitle, badgesVector);
             break;
         }
@@ -4764,7 +4761,7 @@ void ProtocolGame::parseImbuementWindow(const InputMessagePtr& msg)
         const uint8_t firstByte = msg->getU8();
         if (firstByte == 0x01) {
             Imbuement imbuement = getImbuementInfo(msg);
-            const uint32_t duration = msg->getU32(); 
+            const uint32_t duration = msg->getU32();
             const uint32_t removalCost = msg->getU32();
             activeSlots[i] = std::make_tuple(imbuement, duration, removalCost);
         }


### PR DESCRIPTION
# Description

Black squares are not showing around attacking creatures, and the red target square disappears when you are attacked.

### **Expected**

Black squares on attacking creatures and red square when you are attacking.

## Fixes

**Please help me understand this so we can code a proper solution.**
In ProtocolGame::parseCreaturesMark, if I set "isPermanent" to false, the squares issues seem to get solved:

![image](https://github.com/user-attachments/assets/016abafe-78b6-4b20-a398-a9551df86cdd)


https://github.com/user-attachments/assets/b5e41862-78ba-4828-9da1-b16083513695

Canary and TFS always sends 0x01 for "isPermanent":
[Server side reference](https://github.com/opentibiabr/canary/blob/f2f52cc2c55fa1db77dfb35e844f5b3546b63008/src/server/network/protocol/protocolgame.cpp#L3397)

Am I missing something? Should squares always be timedSquares?

Fixes #898 
