### PR TITLE
fix: spacing for align bottom vertical layouts

### DIFF
--- a/src/framework/ui/uiverticallayout.cpp
+++ b/src/framework/ui/uiverticallayout.cpp
@@ -77,7 +77,7 @@ bool UIVerticalLayout::internalUpdate()
             changed = true;
 
         gap = (m_alignBottom) ? -widget->getMarginTop() : (widget->getHeight() + widget->getMarginBottom());
-        gap += m_spacing;
+        gap += m_alignBottom ? -m_spacing : m_spacing;
         pos.y += gap;
         preferredHeight += gap;
     };


### PR DESCRIPTION
# Description

Spacing is wrongly added for align-bottom vertical layouts

## Behavior

### **Actual**

It works in reverse, deduces the spacing instead of adding

### **Expected**

Should add spacing between elements

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
