### PR TITLE
fix: Combat effects aren’t visible

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -222,7 +222,7 @@ void Tile::addThing(const ThingPtr& thing, int stackPos)
             if (!prevEffect->canDraw())
                 continue;
 
-            if (mustOptimize && newEffect->getSize() > prevEffect->getSize()) {
+            if (mustOptimize && newEffect->getSize() >= prevEffect->getSize()) {
                 prevEffect->canDraw(false);
             } else if (mustOptimize || newEffect->getId() == prevEffect->getId()) {
                 if (!newEffect->waitFor(prevEffect))


### PR DESCRIPTION
# Description

look dragon

![image](https://github.com/user-attachments/assets/1548ec58-d01f-440d-93c6-d940c78401ee)

![image](https://github.com/user-attachments/assets/62b80782-ca17-43e0-8cc2-d9259ae9ee32)


prevEffect id 42 size: [2 x 2]

![image](https://github.com/user-attachments/assets/db49ee34-c911-4bcc-93b3-48273a86f191)

newEffect id 44 size: [2 x 2] 

![image](https://github.com/user-attachments/assets/af95f0f3-0b65-485d-8c8b-a9cdde41630e)


## Behavior

### **Actual**
![image](https://github.com/user-attachments/assets/e5b2cc32-2c82-473e-8790-b992e05b88d1)



### **Expected**
![image](https://github.com/user-attachments/assets/b8d32c0a-b2e2-4065-8a1f-68430412dcb1)



## Fixes

Discord , soyfabi

## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

use rune : 

2274 - avalanche
2268 - SD

**Test Configuration**:

  - Server Version: 1098
  - Client: pr
  - Operating System: win 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


server:
```cpp
...
void Game::combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColor_t& color, uint8_t& effect)
{
...
		case COMBAT_ICEDAMAGE: {
			color = TEXTCOLOR_TEAL;
			effect = CONST_ME_ICEATTACK;
			break;
		}
```