### PR TITLE
fix: colorize text in UITextEdit

### DIFF
--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -76,14 +76,15 @@ void UITextEdit::drawSelf(DrawPoolType drawPane)
             m_placeholderFont->drawText(m_placeholder, m_drawArea, m_placeholderColor, m_placeholderAlign);
         }
     }
+
     if (m_color != Color::alpha) {
-        if (glyphsMustRecache) {
-            m_glyphsTextRectCache.clear();
-            for (int i = -1; ++i < textLength;)
-                m_glyphsTextRectCache.emplace_back(m_glyphsCoords[i].first, m_glyphsCoords[i].second);
+        if (m_drawTextColors.empty() || m_colorCoordsBuffer.empty()) {
+            g_drawPool.addTexturedCoordsBuffer(texture, m_coordsBuffer, m_color, m_textDrawConductor);
+        } else {
+            for (const auto& [color, coordsBuffer] : m_colorCoordsBuffer) {
+                g_drawPool.addTexturedCoordsBuffer(texture, coordsBuffer, color, m_textDrawConductor);
+            }
         }
-        for (const auto& [dest, src] : m_glyphsTextRectCache)
-            g_drawPool.addTexturedRect(dest, texture, src, m_color);
     }
 
     if (hasSelection()) {
@@ -258,12 +259,40 @@ void UITextEdit::update(bool focusCursor)
     } else { // AlignLeft
     }
 
+    std::map<uint32_t, CoordsBufferPtr> colorCoordsMap;
+    uint32_t curColorRgba;
+    int32_t nextColorIndex = 0;
+    int32_t colorIndex = -1;
+    CoordsBufferPtr coords;
+
+    const int textColorsSize = m_drawTextColors.size();
+    m_colorCoordsBuffer.clear();
+    m_coordsBuffer->clear();
+
     for (int i = 0; i < textLength; ++i) {
+        if (i >= nextColorIndex) {
+            colorIndex = colorIndex + 1;
+            if (colorIndex < textColorsSize) {
+                curColorRgba = m_drawTextColors[colorIndex].second.rgba();
+            }
+            if (colorIndex + 1 < textColorsSize) {
+                nextColorIndex = m_drawTextColors[colorIndex + 1].first;
+            } else {
+                nextColorIndex = textLength;
+            }
+
+            if (colorCoordsMap.find(curColorRgba) == colorCoordsMap.end()) {
+                colorCoordsMap.insert(std::make_pair(curColorRgba, std::make_shared<CoordsBuffer>()));
+            }
+
+            coords = colorCoordsMap[curColorRgba];
+        }
+
         glyph = static_cast<uint8_t>(text[i]);
         m_glyphsCoords[i].first.clear();
 
         // skip invalid glyphs
-        if (glyph < 32 && glyph != static_cast<uint8_t>('\n'))
+        if (glyph < 32)
             continue;
 
         // calculate initial glyph rect and texture coords
@@ -324,6 +353,16 @@ void UITextEdit::update(bool focusCursor)
         // render glyph
         m_glyphsCoords[i].first = glyphScreenCoords;
         m_glyphsCoords[i].second = glyphTextureCoords;
+
+        if (textColorsSize > 0) {
+            coords->addRect(glyphScreenCoords, glyphTextureCoords);
+        } else {
+            m_coordsBuffer->addRect(glyphScreenCoords, glyphTextureCoords);
+        }
+    }
+
+    for (auto& [rgba, crds] : colorCoordsMap) {
+        m_colorCoordsBuffer.emplace_back(Color(rgba), crds);
     }
 
     if (fireAreaUpdate)
@@ -575,8 +614,11 @@ void UITextEdit::updateDisplayedText()
     else
         text = m_text;
 
-    if (isTextWrap() && m_rect.isValid())
+    m_drawTextColors = m_textColors;
+
+    if (isTextWrap() && m_rect.isValid()) {
         text = m_font->wrapText(text, getPaddingRect().width() - m_textOffset.x);
+    }
 
     m_displayedText = text;
 }

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -152,7 +152,6 @@ private:
 
     std::vector<std::pair<Rect, Rect>> m_glyphsCoords;
 
-    std::vector<std::pair<Rect, Rect>> m_glyphsTextRectCache;
     std::vector<std::pair<Rect, Rect>> m_glyphsSelectRectCache;
 
     std::string m_displayedText;

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -238,7 +238,6 @@ private:
     DrawConductor m_backgroundDrawConductor;
     DrawConductor m_imageDrawConductor;
     DrawConductor m_iconDrawConductor;
-    DrawConductor m_textDrawConductor;
     DrawConductor m_borderDrawConductor;
 
     // state managment
@@ -382,6 +381,8 @@ protected:
     float m_rotation{ 0.f };
     uint16_t m_autoRepeatDelay{ 500 };
     Point m_lastClickPosition;
+
+    DrawConductor m_textDrawConductor;
 
 public:
     void setX(int x) { move(x, getY()); }
@@ -573,8 +574,6 @@ private:
     Rect m_textCachedScreenCoords;
     std::vector<Point> m_glyphsPositionsCache;
     Size m_textSize;
-    CoordsBufferPtr m_coordsBuffer;
-    std::vector<std::pair<Color, CoordsBufferPtr>> m_colorCoordsBuffer;
 
 protected:
     virtual void updateText();
@@ -591,6 +590,9 @@ protected:
     BitmapFontPtr m_font;
     std::vector<std::pair<int, Color>> m_textColors;
     std::vector<std::pair<int, Color>> m_drawTextColors;
+
+    CoordsBufferPtr m_coordsBuffer;
+    std::vector<std::pair<Color, CoordsBufferPtr>> m_colorCoordsBuffer;
 
     float m_fontScale{ 1.f };
 


### PR DESCRIPTION
# Description

Added support for UITextEdit text colors

## Behavior

### **Actual**

UITextEdit doesnt support colors in text like UIWidget does

### **Expected**

It should support the colors too

## Fixes
#916 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
