### PR TITLE
fix: properly handle ctrl + backspace in UITextEdit

### DIFF
--- a/src/framework/const.h
+++ b/src/framework/const.h
@@ -147,6 +147,7 @@ namespace Fw
         KeyBar = 124,         // |
         KeyRightCurly = 125,  // }
         KeyTilde = 126,       // ~
+        KeyDel = 127,       // DEL (Ctrl + Backspace)
         KeyF1 = 128,
         KeyF2 = 129,
         KeyF3 = 130,

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -502,15 +502,24 @@ void UITextEdit::blinkCursor()
     repaint();
 }
 
+void UITextEdit::deleteSelection()
+{
+    if (!hasSelection()) {
+        return;
+    }
+
+    std::string tmp = m_text;
+    tmp.erase(m_selectionStart, m_selectionEnd - m_selectionStart);
+
+    setCursorPos(m_selectionStart);
+    clearSelection();
+    setText(tmp);
+}
+
 void UITextEdit::del(bool right)
 {
     if (hasSelection()) {
-        std::string tmp = m_text;
-        tmp.erase(m_selectionStart, m_selectionEnd - m_selectionStart);
-
-        setCursorPos(m_selectionStart);
-        clearSelection();
-        setText(tmp);
+        deleteSelection();
     } else
         removeCharacter(right);
 }
@@ -779,6 +788,7 @@ bool UITextEdit::onKeyPress(uint8_t keyCode, int keyboardModifiers, int autoRepe
             paste(g_window.getClipboardText());
             return true;
         }
+
         if (keyCode == Fw::KeyX && getProp(PropEditable) && getProp(PropSelectable)) {
             if (hasSelection()) {
                 cut();
@@ -792,6 +802,25 @@ bool UITextEdit::onKeyPress(uint8_t keyCode, int keyboardModifiers, int autoRepe
         } else if (keyCode == Fw::KeyA && getProp(PropSelectable)) {
             if (m_text.length() > 0) {
                 selectAll();
+                return true;
+            }
+        } else if (keyCode == Fw::KeyBackspace) {
+            if (hasSelection()) {
+                deleteSelection();
+            } else if (m_text.length() > 0) {
+                // delete last word
+                std::string tmp = m_text;
+                if (m_cursorPos == 0) {
+                    tmp.erase(tmp.begin());
+                } else {
+                    int pos = m_cursorPos;
+                    while (pos > 0 && tmp[pos - 1] == ' ')
+                        --pos;
+                    while (pos > 0 && tmp[pos - 1] != ' ')
+                        --pos;
+                    tmp.erase(tmp.begin() + pos, tmp.begin() + m_cursorPos);
+                }
+                setText(tmp);
                 return true;
             }
         }
@@ -838,6 +867,11 @@ bool UITextEdit::onKeyPress(uint8_t keyCode, int keyboardModifiers, int autoRepe
 
 bool UITextEdit::onKeyText(const std::string_view keyText)
 {
+    // ctrl + backspace inserts a special ASCII character
+    if (keyText.length() == 1 && keyText.front() == Fw::KeyDel) {
+        return false;
+    }
+
     if (getProp(PropEditable)) {
         appendText(keyText.data());
         return true;

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -63,6 +63,7 @@ public:
     void removeCharacter(bool right);
     void blinkCursor();
 
+    void deleteSelection();
     void del(bool right = false);
     void paste(const std::string_view text);
     std::string copy();


### PR DESCRIPTION
# Description

ctrl + backspace should remove last word until space is meet, you can check the behaviour in any code editor (vscode etc)

## Behavior
### **Actual**

doesn't do anything

### **Expected**

should remove last word

## Fixes

#869 

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
