### PR TITLE
fix: limitsFloorView incorrect thing check when calculating visible floor

### DIFF
--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -710,16 +710,16 @@ uint8_t MapView::calcFirstVisibleFloor(bool checkLimitsFloorsView) const
                 firstFloor = std::max<uint8_t >(m_posInfo.camera.z - g_gameConfig.getMapAwareUndergroundFloorRange(), g_gameConfig.getMapUndergroundFloorRange());
 
             // loop in 3x3 tiles around the camera
-            for (int_fast32_t ix = -1; checkLimitsFloorsView && ix <= 1 && firstFloor < m_posInfo.camera.z; ++ix) {
-                for (int_fast32_t iy = -1; iy <= 1 && firstFloor < m_posInfo.camera.z; ++iy) {
+            for (int ix = -1; checkLimitsFloorsView && ix <= 1 && firstFloor < m_posInfo.camera.z; ++ix) {
+                for (int iy = -1; iy <= 1 && firstFloor < m_posInfo.camera.z; ++iy) {
                     const auto& pos = m_posInfo.camera.translated(ix, iy);
+                    const bool isLookPossible = g_map.isLookPossible(pos);
 
                     // process tiles that we can look through, e.g. windows, doors
-                    if ((ix == 0 && iy == 0) || ((std::abs(ix) != std::abs(iy)) && g_map.isLookPossible(pos))) {
+                    if ((ix == 0 && iy == 0) || ((std::abs(ix) != std::abs(iy)) && isLookPossible)) {
                         Position upperPos = pos;
                         Position coveredPos = pos;
 
-                        const bool isLookPossible = g_map.isLookPossible(pos);
                         while (coveredPos.coveredUp() && upperPos.up() && upperPos.z >= firstFloor) {
                             // check tiles physically above
                             if (const TilePtr& tile = g_map.getTile(upperPos)) {
@@ -754,7 +754,7 @@ uint8_t MapView::calcLastVisibleFloor() const
 {
     uint8_t z = g_gameConfig.getMapSeaFloor();
 
-    // this could happens if the player is not known yet
+    // this could happen if the player is not known yet
     if (m_posInfo.camera.isValid()) {
         // view only underground floors when below sea level
         if (m_posInfo.camera.z > g_gameConfig.getMapSeaFloor())

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -695,8 +695,18 @@ bool Tile::hasBlockingCreature() const
 bool Tile::limitsFloorsView(bool isFreeView)
 {
     // ground and walls limits the view
-    const auto& firstThing = getThing(0);
-    return firstThing && !firstThing->isDontHide() && (firstThing->isGround() || (isFreeView ? firstThing->isOnBottom() : firstThing->isOnBottom() && firstThing->blockProjectile()));
+    for (const auto& thing : m_things) {
+        // iterate until common item is encountered
+        if (thing->isCommon()) {
+            break;
+        }
+
+        if (!thing->isDontHide() && (thing->isGround() || (isFreeView ? thing->isOnBottom() : thing->isOnBottom() && thing->blockProjectile()))) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool Tile::checkForDetachableThing(const TileSelectType selectType)


### PR DESCRIPTION
# Description

In certain scenarios (probably broken maps) getThing(0) is not the wall nor the ground.
For example in canary map and the linked issue scenario, the first item on the tile is actually a wooden floor (441) which is neither a ground nor a wall, it's a ground border, thus this code incorrectly checks if there is a wall or a ground.

## Behavior
In certain scenarios doesn't correctly show/hide floors

### **Actual**

Described in #829 

### **Expected**

Described in #829 

## Fixes

Fix #829 

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
