### PR TITLE
feature: support cwm sprites loading

### DIFF
--- a/src/client/spritemanager.h
+++ b/src/client/spritemanager.h
@@ -25,6 +25,29 @@
 #include <framework/core/declarations.h>
 #include <framework/graphics/declarations.h>
 #include "gameconfig.h"
+#include <framework/core/filestream.h>
+
+class FileMetadata
+{
+public:
+    FileMetadata() = default;
+    FileMetadata(const FileStreamPtr& file) {
+        offset = file->getU32();
+        fileSize = file->getU32();
+        fileName = file->getString();
+        spriteId = std::stoi(fileName);
+    }
+
+    uint32_t getSpriteId() const { return spriteId; }
+    const std::string& getFileName() const { return fileName; }
+    uint32_t getOffset() const { return offset; }
+    uint32_t getFileSize() const { return fileSize; }
+private:
+    std::string fileName;
+    uint32_t offset = 0;
+    uint32_t fileSize = 0;
+    uint32_t spriteId = 0;
+};
 
  //@bindsingleton g_sprites
 class SpriteManager
@@ -34,6 +57,8 @@ public:
     void terminate();
 
     bool loadSpr(std::string file);
+    bool loadRegularSpr(std::string file);
+    bool loadCwmSpr(std::string file);
     void reload();
     void unload();
 
@@ -59,16 +84,19 @@ private:
         return m_spritesFiles[0]->file;
     }
 
+    ImagePtr getSpriteImageHd(int id, const FileStreamPtr& file);
     ImagePtr getSpriteImage(int id, const FileStreamPtr& file);
 
     std::string m_lastFileName;
 
+    bool m_spritesHd{ false };
     bool m_loaded{ false };
     uint32_t m_signature{ 0 };
     uint32_t m_spritesCount{ 0 };
     uint32_t m_spritesOffset{ 0 };
 
     std::vector<std::unique_ptr<FileStream_m>> m_spritesFiles;
+    std::unordered_map<uint32_t, FileMetadata> m_cwmSpritesMetadata;
 };
 
 extern SpriteManager g_sprites;

--- a/src/framework/graphics/image.cpp
+++ b/src/framework/graphics/image.cpp
@@ -49,10 +49,9 @@ ImagePtr Image::load(const std::string& file)
     return nullptr;
 }
 
-ImagePtr Image::loadPNG(const std::string& file)
+ImagePtr Image::loadPNG(const char* data, size_t size)
 {
-    std::stringstream fin;
-    g_resources.readFileStream(file, fin);
+    std::stringstream fin(std::string{ data, size });
     ImagePtr image;
     if (apng_data apng; load_apng(fin, &apng) == 0) {
         image = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata);
@@ -68,6 +67,16 @@ ImagePtr Image::loadPNG(const std::string& file)
     }
 
     return image;
+}
+
+ImagePtr Image::loadPNG(const std::string& file)
+{
+    std::stringstream fin;
+    g_resources.readFileStream(file, fin);
+
+    std::string buffer{ fin.str() };
+
+    return loadPNG(buffer.data(), buffer.size());
 }
 
 void Image::savePNG(const std::string& fileName)

--- a/src/framework/graphics/image.h
+++ b/src/framework/graphics/image.h
@@ -30,6 +30,7 @@ public:
     Image(const Size& size, int bpp = 4, uint8_t* pixels = nullptr);
 
     static ImagePtr load(const std::string& file);
+    static ImagePtr loadPNG(const char* data, size_t size);
     static ImagePtr loadPNG(const std::string& file);
     static ImagePtr fromQRCode(const std::string& code, int border);
 


### PR DESCRIPTION
# Description

Support for loading CWM (hd sprites, larger than 32x32).
I did **NOT** test this, because I'm unable to generate cwm sprite file from my 1098 .spr, the images come out as empty magenta colored textures.

Resolve #741

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

It was not.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
