### PR TITLE
fix: don't require vorbis config and fix linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -216,7 +216,7 @@ endif()
 if(TOGGLE_FRAMEWORK_SOUND)
 	find_package(OpenAL CONFIG REQUIRED)
 	find_package(VorbisFile REQUIRED)
-	find_package(Vorbis CONFIG REQUIRED)
+	find_package(Vorbis REQUIRED)
 	find_package(Ogg CONFIG REQUIRED)
 endif()
 if(ANDROID)
@@ -471,9 +471,9 @@ if(MSVC)
 		${OPENGL_LIBRARIES}
 		${DirectX_LIBRARY}
 		${DirectX_LIBRARIES}
+		${OGG_LIBRARY}
 		${VORBISFILE_LIBRARY}
 		${VORBIS_LIBRARY}
-		${OGG_LIBRARY}
 		${GMP_LIBRARY}
 		${OPENSSL_LIBRARIES}
 		${DBGHELP_LIBRARY}
@@ -512,6 +512,8 @@ elseif(ANDROID)
 		${NLOHMANN_JSON_LIBRARY}
 		${EGL_LIBRARY}
 		${OGG_LIBRARY}
+		${VORBISFILE_LIBRARY}
+		${VORBIS_LIBRARY}
 		${GMP_LIBRARY}
 		${OpenAL_LIBRARY}
 		${OPENSSL_LIBRARIES}
@@ -521,8 +523,6 @@ elseif(ANDROID)
 		Threads::Threads
 		asio::asio
 		OpenSLES
-		Vorbis::vorbis
-		Vorbis::vorbisfile
 		LibLZMA::LibLZMA
 		game-activity::game-activity
 		GLESv3
@@ -556,6 +556,8 @@ else() # Linux
 		${DirectX_LIBRARY}
 		${DirectX_LIBRARIES}
 		${OGG_LIBRARY}
+		${VORBISFILE_LIBRARY}
+		${VORBIS_LIBRARY}
 		${GMP_LIBRARY}
 		${STDUUID}
 		${FOUNDATION}
@@ -568,8 +570,6 @@ else() # Linux
 		X11::X11
 		asio::asio
 		OpenAL::OpenAL
-		Vorbis::vorbis
-		Vorbis::vorbisfile
 		LibLZMA::LibLZMA
 		pugixml::pugixml
 		ZLIB::ZLIB


### PR DESCRIPTION
# Description

Fixes building with sound support on Linux + newer libvorbis

~~**but for now also breaks building with older libvorbis.** therefore drafting.~~

## Behavior

### **Actual**

First it requires Vorbis config which doesn't exist, after fixing it, it can't link.

### **Expected**

it should werk

## Fixes

#753

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] it builds
  - [x] sound werks after building

**Test Configuration**:

  - Server Version: n/a
  - Client: latest commit as of today, https://github.com/mehah/otclient/commit/22db98ea35a0d4098422d2c7d690931c4c3c2fe9
  - Operating System: NixOS 24.11.20241009.65d98cb

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
