### PR TITLE
Use GNUInstallDirs and add cmake/Findphmap.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # *****************************************************************************
 include(MessageColors)
 include(LoggingHelper)
-include(CheckIncludeFileCXX)
+include(GNUInstallDirs)
 
 # *****************************************************************************
 # Options

--- a/cmake/Findphmap.cmake
+++ b/cmake/Findphmap.cmake
@@ -1,0 +1,4 @@
+include(CheckIncludeFileCXX)
+set(CMAKE_REQUIRED_INCLUDES "${CMAKE_INSTALL_INCLUDEDIR}")
+check_include_file_cxx(parallel_hashmap/phmap.h PHMAP_PHMAP_INCLUDE)
+check_include_file_cxx(parallel_hashmap/btree.h PHMAP_BTREE_INCLUDE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,6 +187,7 @@ add_definitions(-D"BUILD_REVISION=\\\"${BUILD_REVISION}\\\"")
 find_package(OpenSSL QUIET)
 find_package(PhysFS REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(phmap REQUIRED)
 find_package(absl CONFIG REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(LibLZMA REQUIRED)
@@ -197,7 +198,6 @@ find_package(STDUUID CONFIG REQUIRED)
 find_package(pugixml CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(httplib CONFIG REQUIRED)
-CHECK_INCLUDE_FILE_CXX(phmap/phmap.h PHMAP_Found REQUIRED)
 
 if(APPLE)
 	# Required for Physfs
@@ -455,7 +455,8 @@ if(MSVC)
 
 	target_include_directories(${PROJECT_NAME}
 		PRIVATE
-		${CMAKE_SOURCE_DIR}/src
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 		${LUAJIT_INCLUDE_DIR}
 		${Protobuf_INCLUDE_DIRS}
 		${VORBISFILE_INCLUDE_DIR}
@@ -496,7 +497,8 @@ if(MSVC)
 elseif(ANDROID)
 	target_include_directories(${PROJECT_NAME}
 		PRIVATE
-		${CMAKE_SOURCE_DIR}/src
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 		${LUAJIT_INCLUDE_DIR}
 		${CMAKE_THREAD_LIBS_INIT}
 		${Protobuf_INCLUDE_DIRS}
@@ -540,7 +542,8 @@ elseif(ANDROID)
 else() # Linux
 	target_include_directories(${PROJECT_NAME}
 		PRIVATE
-		${CMAKE_SOURCE_DIR}/src
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 		${LUAJIT_INCLUDE_DIR}
 		${CMAKE_THREAD_LIBS_INIT}
 		${Protobuf_INCLUDE_DIRS}


### PR DESCRIPTION
# Description

Move [parallel-hashmap](https://github.com/greg7mdp/parallel-hashmap) detection to `cmake/Findphmap.cmake` (probably needs adding a break or exit in case of failure REQUIRED flag doesn't work here)

Add `include(GnuInstallDirs)` for platform independent CMAKE_INSTALL_* dirs

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Linux-6.11.4 EM64T

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
