### PR TITLE
fix: packets in game_questlog and game_outfit

### DIFF
--- a/modules/game_questlog/questlog.lua
+++ b/modules/game_questlog/questlog.lua
@@ -26,15 +26,18 @@ function terminate()
 
     destroyWindows()
     questLogButton:destroy()
+    questLogButton = nil
 end
 
 function destroyWindows()
     if questLogWindow then
         questLogWindow:destroy()
+        questLogWindow = nil
     end
 
     if questLineWindow then
         questLineWindow:destroy()
+        questLineWindow = nil
     end
 end
 
@@ -69,6 +72,7 @@ function onGameQuestLine(questId, questMissions)
     end
     if questLineWindow then
         questLineWindow:destroy()
+        questLineWindow = nil
     end
 
     questLineWindow = g_ui.createWidget('QuestLineWindow', rootWidget)
@@ -85,7 +89,7 @@ function onGameQuestLine(questId, questMissions)
     })
 
     for i, questMission in pairs(questMissions) do
-        local name, description = unpack(questMission)
+        local name, description, missionId = unpack(questMission)
 
         local missionLabel = g_ui.createWidget('MissionLabel')
         missionLabel:setText(name)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -478,7 +478,7 @@ void Game::processQuestLog(const std::vector<std::tuple<uint16_t, std::string, b
     g_lua.callGlobalField("g_game", "onQuestLog", questList);
 }
 
-void Game::processQuestLine(const uint16_t questId, const std::vector<std::tuple<std::string, std::string>>& questMissions)
+void Game::processQuestLine(const uint16_t questId, const std::vector<std::tuple<std::string_view, std::string_view, uint16_t>>& questMissions)
 {
     g_lua.callGlobalField("g_game", "onQuestLine", questId, questMissions);
 }

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -498,7 +498,7 @@ protected:
 
     // questlog
     static void processQuestLog(const std::vector<std::tuple<uint16_t, std::string, bool>>& questList);
-    static void processQuestLine(const uint16_t questId, const std::vector<std::tuple<std::string, std::string>>& questMissions);
+    static void processQuestLine(const uint16_t questId, const std::vector<std::tuple<std::string_view, std::string_view, uint16_t>>& questMissions);
 
     // modal dialogs >= 970
     static void processModalDialog(const uint32_t id, const std::string_view title, const std::string_view message, const std::vector<std::tuple<uint8_t, std::string>>

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2933,12 +2933,16 @@ void ProtocolGame::parseQuestLine(const InputMessagePtr& msg)
     const uint16_t questId = msg->getU16();
 
     const uint8_t missionCount = msg->getU8();
-    std::vector<std::tuple<std::string, std::string>> questMissions;
+    std::vector<std::tuple<std::string_view, std::string_view, uint16_t>> questMissions;
 
     for (auto i = 0; i < missionCount; ++i) {
+        auto missionId = 0;
+        if (g_game.getClientVersion() >= 1200) {
+            missionId = msg->getU16();
+        }
         const auto& missionName = msg->getString();
         const auto& missionDescrition = msg->getString();
-        questMissions.emplace_back(missionName, missionDescrition);
+        questMissions.emplace_back(missionName, missionDescrition, missionId);
     }
 
     g_game.processQuestLine(questId, questMissions);

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -788,7 +788,7 @@ void ProtocolGame::sendChangeOutfit(const Outfit& outfit)
         }
     }
 
-    if (g_game.getClientVersion() >= 1340) {
+    if (g_game.getClientVersion() >= 1334) {
         msg->addU8(static_cast<uint8_t>(outfit.hasMount()));
     }
 


### PR DESCRIPTION
# Description
canary 13.40
![image](https://github.com/user-attachments/assets/2c940617-c1a8-4f3d-bcb9-78d413cd08ec)
tfs 13.10
![image](https://github.com/user-attachments/assets/7d9fe44e-2e4d-4b78-ac1c-61eed4cadc66)

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**
![image](https://github.com/user-attachments/assets/0ef4729a-289c-489e-aacb-8b8679e63aee)

## Fixes
```log
ERROR: ProtocolGame parse message exception (1205 bytes, 1191 unread, last opcode is 0xf1 (241), prev opcode is 0xffffffff (-1)): InputMessage eof reached
Packet has been saved to packet.log, you can use it to find what was wrong. (Protocol: 1340)
```
![image](https://github.com/user-attachments/assets/7b2d5aee-a314-4491-8fb0-9be7c38adff4)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
