### PR TITLE
fix: trade between players in canary 13.40

### DIFF
--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -117,7 +117,7 @@ namespace Proto
         GameServerMissleEffect = 133, // Anthem on 13.x
         GameServerItemClasses = 134,
         GameServerTrappers = 135,
-        GameServercloseForgeWindow = 137,
+        GameServerCloseForgeWindow = 137,
         GameServerCreatureData = 139,
         GameServerCreatureHealth = 140,
         GameServerCreatureLight = 141,

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -117,6 +117,7 @@ namespace Proto
         GameServerMissleEffect = 133, // Anthem on 13.x
         GameServerItemClasses = 134,
         GameServerTrappers = 135,
+        GameServercloseForgeWindow = 137,
         GameServerCreatureData = 139,
         GameServerCreatureHealth = 140,
         GameServerCreatureLight = 141,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -231,6 +231,7 @@ private:
     void parseCreatureMark(const InputMessagePtr& msg);
     void parseTrappers(const InputMessagePtr& msg);
     void addCreatureIcon(const InputMessagePtr& msg);
+    void parsecloseForgeWindow(const InputMessagePtr& msg);
     void parseCreatureData(const InputMessagePtr& msg);
     void parseCreatureHealth(const InputMessagePtr& msg);
     void parseCreatureLight(const InputMessagePtr& msg);

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -231,7 +231,7 @@ private:
     void parseCreatureMark(const InputMessagePtr& msg);
     void parseTrappers(const InputMessagePtr& msg);
     void addCreatureIcon(const InputMessagePtr& msg);
-    void parsecloseForgeWindow(const InputMessagePtr& msg);
+    void parseCloseForgeWindow(const InputMessagePtr& msg);
     void parseCreatureData(const InputMessagePtr& msg);
     void parseCreatureHealth(const InputMessagePtr& msg);
     void parseCreatureLight(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -1847,7 +1847,7 @@ void ProtocolGame::addCreatureIcon(const InputMessagePtr& msg)
     // TODO: implement creature icons usage
 }
 
-void ProtocolGame::parsecloseForgeWindow(const InputMessagePtr& msg)
+void ProtocolGame::parsecloseForgeWindow(const InputMessagePtr& /*msg*/)
 {
     g_lua.callGlobalField("g_game", "onCloseForgeCloseWindows");
 }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -267,8 +267,8 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 case Proto::GameServerTrappers:
                     parseTrappers(msg);
                     break;
-                case Proto::GameServercloseForgeWindow:
-                    parsecloseForgeWindow(msg);
+                case Proto::GameServerCloseForgeWindow:
+                    parseCloseForgeWindow(msg);
                     break;
                 case Proto::GameServerCreatureData:
                     parseCreatureData(msg);
@@ -1847,7 +1847,7 @@ void ProtocolGame::addCreatureIcon(const InputMessagePtr& msg)
     // TODO: implement creature icons usage
 }
 
-void ProtocolGame::parsecloseForgeWindow(const InputMessagePtr& /*msg*/)
+void ProtocolGame::parseCloseForgeWindow(const InputMessagePtr& /*msg*/)
 {
     g_lua.callGlobalField("g_game", "onCloseForgeCloseWindows");
 }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -267,6 +267,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 case Proto::GameServerTrappers:
                     parseTrappers(msg);
                     break;
+                case Proto::GameServercloseForgeWindow:
+                    parsecloseForgeWindow(msg);
+                    break;
                 case Proto::GameServerCreatureData:
                     parseCreatureData(msg);
                     break;
@@ -1842,6 +1845,11 @@ void ProtocolGame::addCreatureIcon(const InputMessagePtr& msg)
     }
 
     // TODO: implement creature icons usage
+}
+
+void ProtocolGame::parsecloseForgeWindow(const InputMessagePtr& msg)
+{
+    g_lua.callGlobalField("g_game", "onCloseForgeCloseWindows");
 }
 
 void ProtocolGame::parseCreatureData(const InputMessagePtr& msg)


### PR DESCRIPTION
# Description

for some reason in canary after accepting a trade between players, the server sends packet 0x89(closeForgeWindow). 


![image](https://github.com/user-attachments/assets/6ced3787-457f-4ffe-aa9a-c47b6ac0d940)
![image](https://github.com/user-attachments/assets/f29d3c98-5050-4fb9-a25d-1060e8503d72)

```
void ProtocolGame::closeForgeWindow() {
	NetworkMessage msg;
	msg.addByte(0x89);
	writeToOutputBuffer(msg);
}
```
## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

@ igorcardosoo

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
