### PR TITLE
fix: everything related to magicLevel changed to u16

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -349,13 +349,13 @@ void LocalPlayer::setMana(const uint32_t mana, const uint32_t maxMana)
     callLuaField("onManaChange", mana, maxMana, oldMana, oldMaxMana);
 }
 
-void LocalPlayer::setMagicLevel(const uint8_t magicLevel, const uint8_t magicLevelPercent)
+void LocalPlayer::setMagicLevel(const uint16_t magicLevel, const uint16_t magicLevelPercent)
 {
     if (m_magicLevel == magicLevel && m_magicLevelPercent == magicLevelPercent)
         return;
 
-    const uint8_t oldMagicLevel = m_magicLevel;
-    const uint8_t oldMagicLevelPercent = m_magicLevelPercent;
+    const uint16_t oldMagicLevel = m_magicLevel;
+    const uint16_t oldMagicLevelPercent = m_magicLevelPercent;
 
     m_magicLevel = magicLevel;
     m_magicLevelPercent = magicLevelPercent;
@@ -363,12 +363,12 @@ void LocalPlayer::setMagicLevel(const uint8_t magicLevel, const uint8_t magicLev
     callLuaField("onMagicLevelChange", magicLevel, magicLevelPercent, oldMagicLevel, oldMagicLevelPercent);
 }
 
-void LocalPlayer::setBaseMagicLevel(const uint8_t baseMagicLevel)
+void LocalPlayer::setBaseMagicLevel(const uint16_t baseMagicLevel)
 {
     if (m_baseMagicLevel == baseMagicLevel)
         return;
 
-    const uint8_t oldBaseMagicLevel = m_baseMagicLevel;
+    const uint16_t oldBaseMagicLevel = m_baseMagicLevel;
     m_baseMagicLevel = baseMagicLevel;
 
     callLuaField("onBaseMagicLevelChange", baseMagicLevel, oldBaseMagicLevel);

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -45,8 +45,8 @@ public:
     void setExperience(uint64_t experience);
     void setLevel(uint16_t level, uint8_t levelPercent);
     void setMana(uint32_t mana, uint32_t maxMana);
-    void setMagicLevel(uint8_t magicLevel, uint8_t magicLevelPercent);
-    void setBaseMagicLevel(uint8_t baseMagicLevel);
+    void setMagicLevel(uint16_t magicLevel, uint16_t magicLevelPercent);
+    void setBaseMagicLevel(uint16_t baseMagicLevel);
     void setSoul(uint8_t soul);
     void setStamina(uint16_t stamina);
     void setKnown(const bool known) { m_known = known; }
@@ -65,9 +65,9 @@ public:
     uint32_t getTotalCapacity() { return m_totalCapacity; }
 
     uint8_t getVocation() { return m_vocation; }
-    uint8_t getMagicLevel() { return m_magicLevel; }
-    uint8_t getMagicLevelPercent() { return m_magicLevelPercent; }
-    uint8_t getBaseMagicLevel() { return m_baseMagicLevel; }
+    uint16_t getMagicLevel() { return m_magicLevel; }
+    uint16_t getMagicLevelPercent() { return m_magicLevelPercent; }
+    uint16_t getBaseMagicLevel() { return m_baseMagicLevel; }
     uint8_t getSoul() { return m_soul; }
     uint8_t getLevelPercent() { return m_levelPercent; }
 
@@ -175,9 +175,9 @@ private:
     uint8_t m_levelPercent{ 0 };
     uint32_t m_mana{ 0 };
     uint32_t m_maxMana{ 0 };
-    uint8_t m_magicLevel{ 0 };
-    uint8_t m_magicLevelPercent{ 0 };
-    uint8_t m_baseMagicLevel{ 0 };
+    uint16_t m_magicLevel{ 0 };
+    uint16_t m_magicLevelPercent{ 0 };
+    uint16_t m_baseMagicLevel{ 0 };
     uint8_t m_soul{ 0 };
     uint16_t m_stamina{ 0 };
     uint16_t m_regenerationTime{ 0 };


### PR DESCRIPTION
# Description

in versions higher than 1281, magicLevel u16 is used, but everything related to magicLevel is u8.

![image](https://github.com/user-attachments/assets/36c1c309-ddb1-4ff0-ad51-713a14b53b74)


## Behavior

### **Actual**
currently on u8


### **Expected**

u16
![image](https://github.com/user-attachments/assets/6c5d5e08-a788-4e4a-b3b1-81982b80a377)
![image](https://github.com/user-attachments/assets/843b1fff-1bb1-4d84-ab3d-79b2dcea9ff8)
## Fixes

discord
![image](https://github.com/user-attachments/assets/e7d3fe71-6d99-4170-a81d-02c65029207a)

## Type of change


  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

add player 300 ML and check skills


**Test Configuration**:

  - Server Version: 13.40
  - Client: this pr
  - Operating System: win 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
