### PR TITLE
lto-wrapper: warning: using serial compilation #630

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -444,6 +444,7 @@ endif()
 
 
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCE_FILES})
+target_link_options(${PROJECT_NAME} PUBLIC -flto=auto)
 
 # *****************************************************************************
 # Includes and librarys


### PR DESCRIPTION
# Description

LTO on Linux runs on 1 CPU core, not all CPU cores.
Linker shows warning and total compilation time is few seconds longer.

## Behavior

### **Actual**

LTO runs on 1 core, linker shows warning:
```
#20 49.99 [100%] Linking CXX executable ../../otclient
#20 58.98 lto-wrapper: warning: using serial compilation of 18 LTRANS jobs
#20 109.7 [100%] Built target otclient
```

### **Expected**

LTO runs on all cores, no warning.

## Fixes

#630

## Type of change

Please delete options that are not relevant.

  - Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: *
  - Client: *
  - Operating System: Linux

