### PR TITLE
dockerignore - ignore Windows build files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
+/.git/
+/.github/
+/.idea/
+/.vs/
+/android/
 /build/
+/cmake-build*
+/vc17/
 Dockerfile
+*.dll
+*.exe
+*.pdb


### PR DESCRIPTION
# Description

`docker build .` transfers all files from OTC directory into build container as "build context".
Only files listed in `.dockerignore` are skipped.

## Behavior

### **Actual**

If you build multiple targets in Visual Studio and using CMake (ex. in CLion IDE) and then run `docker build .`
It may transfer up to 17 GB of data ("transferring context: 16.75GB") into Docker container, before it even start build process.
On Windows it may take few minutes, because there is a problem with files transfer speed Windows -> Linux.

### **Expected**

Only files required to build and run OTC should be transferred into container.

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
