### PR TITLE
fix: incorrect usage of const ref shared ptr in container class

### DIFF
--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -85,7 +85,7 @@ void Container::onUpdateItem(int slot, const ItemPtr& item)
         return;
     }
 
-    const auto& oldItem = m_items[slot];
+    const auto oldItem = m_items[slot];
     m_items[slot] = item;
     item->setPosition(getSlotPosition(slot));
 
@@ -106,7 +106,7 @@ void Container::onRemoveItem(int slot, const ItemPtr& lastItem)
         return;
     }
 
-    const auto& item = m_items[slot];
+    const auto item = m_items[slot];
     m_items.erase(m_items.begin() + slot);
 
     if (lastItem) {


### PR DESCRIPTION
# Description

Fix an invalid (unsafe) usage of const reference to shared_ptr in container class.

## Behavior

### **Actual**

Crashes with stacktrace pointing to LuaInterface::pushObject. This happens, because the const ref is unsafe there.
After you remove the shared pointer from container it may get destructured (shared_ptr is a normal instance of a class).
This happens in this case, we need a copy to keep the pointer alive here.
I haven't had luck with reproducing this in Release mode, likely, because compiler somehow optimizes the code.

Stacktrace:
![image](https://github.com/user-attachments/assets/43ca3f8b-8152-409c-b45f-8163af3d0a79)


### **Expected**

I reproduced this crash several times by running around and spamming ultimate healing runes with open backpacks via action bar.

## Fixes

not a reported issue

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
