### PR TITLE
fix: correctly draw large borders

### DIFF
--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -92,7 +92,7 @@ void Item::setConductor()
     if (isSingleGround()) {
         m_drawConductor.agroup = true;
         m_drawConductor.order = FIRST;
-    } else if (isSingleGroundBorder() && !hasElevation()) {
+    } else if (isGroundBorder() && !hasElevation()) {
         m_drawConductor.agroup = true;
         m_drawConductor.order = SECOND;
     }


### PR DESCRIPTION
# Description

Fix #1013 
Honestly I don't know why this code was only written to work with single dimension borders (1x32px), this fixes it. I don't know if that's the correct fix.

## Behavior

### **Actual**

Described in #1013 

### **Expected**

Border should be drawn

## Fixes

#1013 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
