### PR TITLE
improve: UIGraph line smooth

### DIFF
--- a/src/framework/graphics/painter.cpp
+++ b/src/framework/graphics/painter.cpp
@@ -128,6 +128,9 @@ void Painter::drawLine(const std::vector<float>& vertex, const int size, const i
     m_drawLineProgram->setProjectionMatrix(m_projectionMatrix);
     m_drawLineProgram->setTextureMatrix(m_textureMatrix);
     m_drawLineProgram->setColor(m_color);
+#ifndef OPENGL_ES
+    glEnable(GL_LINE_SMOOTH);
+#endif
     glLineWidth(width);
 
     PainterShaderProgram::disableAttributeArray(PainterShaderProgram::TEXCOORD_ATTR);
@@ -136,6 +139,9 @@ void Painter::drawLine(const std::vector<float>& vertex, const int size, const i
     glDrawArrays(GL_LINE_STRIP, 0, size);
 
     PainterShaderProgram::enableAttributeArray(PainterShaderProgram::TEXCOORD_ATTR);
+#ifndef OPENGL_ES
+    glDisable(GL_LINE_SMOOTH);
+#endif
 }
 
 void Painter::resetState()


### PR DESCRIPTION
I’m not interested in the fan war between OTC, I liked this feature and I want it in my client. I’m sharing it.
by oen

I was waiting for more fixes from uigraph (to have everything in one commits) but some people are worried.

Przed:
GL
![image](https://github.com/user-attachments/assets/8b9dafae-c4b9-4c29-92f0-0dcb14ed8319)

teraz:
GL PR
![image](https://github.com/user-attachments/assets/fddb1416-530f-46d0-9a36-aecff884801d)


does not break dx:
DX
![image](https://github.com/user-attachments/assets/69020e13-cb4f-4325-9350-1e2378c3cebc)


I’m not interested in the fan war between OTC, I liked this feature and I want it in my client. I’m sharing it.
by oen