### PR TITLE
fix: incorrectly aligned looktypes for 32x32 idle sprites when using protobuf

### DIFF
--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -476,8 +476,6 @@ private:
         std::vector<Pos> pos;
     };
 
-    void prepareTextureLoad(const std::vector<Size>& sizes, const std::vector<int>& total_sprites);
-
     uint32_t getSpriteIndex(int w, int h, int l, int x, int y, int z, int a) const;
     uint32_t getTextureIndex(int l, int x, int y, int z) const;
 


### PR DESCRIPTION
# Description

Fix improperly positioned special looktypes that are 32x32 in idle, while 64x64 while walking.

Please test with .spr files, thanks.

## Behavior

### **Actual**

Are glitching

### **Expected**

Should render properly

## Fixes

Fix #914
Fix #828
Fix #961 
Fix #966 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
