### PR TITLE
feat: allow to disable animation for Thing

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -1005,6 +1005,8 @@ ThingType* Creature::getMountThingType() const {
 
 uint16_t Creature::getCurrentAnimationPhase(const bool mount)
 {
+    if (!canAnimate()) return 0;
+
     const auto thingType = mount ? getMountThingType() : getThingType();
 
     if (const auto idleAnimator = thingType->getIdleAnimator()) {

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -36,22 +36,24 @@ void Effect::draw(const Point& dest, const bool drawThings, const LightViewPtr& 
     if (m_animationTimer.ticksElapsed() < m_timeToStartDrawing)
         return;
 
-    int animationPhase;
-    if (g_game.getFeature(Otc::GameEnhancedAnimations)) {
-        const auto* animator = getThingType()->getIdleAnimator();
-        if (!animator)
-            return;
+    int animationPhase = 0;
+    if (canAnimate()) {
+        if (g_game.getFeature(Otc::GameEnhancedAnimations)) {
+            const auto* animator = getThingType()->getIdleAnimator();
+            if (!animator)
+                return;
 
-        // This requires a separate getPhaseAt method as using getPhase would make all magic effects use the same phase regardless of their appearance time
-        animationPhase = animator->getPhaseAt(m_animationTimer);
-    } else {
-        // hack to fix some animation phases duration, currently there is no better solution
-        int ticks = g_gameConfig.getEffectTicksPerFrame();
-        if (m_clientId == 33) {
-            ticks <<= 2;
+            // This requires a separate getPhaseAt method as using getPhase would make all magic effects use the same phase regardless of their appearance time
+            animationPhase = animator->getPhaseAt(m_animationTimer);
+        } else {
+            // hack to fix some animation phases duration, currently there is no better solution
+            int ticks = g_gameConfig.getEffectTicksPerFrame();
+            if (m_clientId == 33) {
+                ticks <<= 2;
+            }
+
+            animationPhase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / ticks), getAnimationPhases() - 1);
         }
-
-        animationPhase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / ticks), getAnimationPhases() - 1);
     }
 
     const int offsetX = m_position.x - g_map.getCentralPosition().x;

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -246,7 +246,7 @@ void Item::updatePatterns()
 
 int Item::calculateAnimationPhase()
 {
-    if (!hasAnimationPhases()) return 0;
+    if (!hasAnimationPhases() || !canAnimate()) return 0;
 
     if (getIdleAnimator()) return getIdleAnimator()->getPhase();
 

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -454,6 +454,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Thing>("setShader", &Thing::setShader);
     g_lua.bindClassMemberFunction<Thing>("setPosition", &Thing::setPosition);
     g_lua.bindClassMemberFunction<Thing>("setMarked", &Thing::lua_setMarked);
+    g_lua.bindClassMemberFunction<Thing>("setAnimate", &Thing::setAnimate);
     g_lua.bindClassMemberFunction<Thing>("isMarked", &Thing::isMarked);
     g_lua.bindClassMemberFunction<Thing>("getId", &Thing::getId);
     g_lua.bindClassMemberFunction<Thing>("getTile", &Thing::getTile);
@@ -498,6 +499,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Thing>("setHighlight", &Thing::lua_setHighlight);
     g_lua.bindClassMemberFunction<Thing>("isHighlighted", &Thing::isHighlighted);
     g_lua.bindClassMemberFunction<Thing>("getExactSize", &Thing::getExactSize);
+    g_lua.bindClassMemberFunction<Thing>("canAnimate", &Thing::canAnimate);
 
 #ifdef FRAMEWORK_EDITOR
     g_lua.registerClass<House>();

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -208,6 +208,9 @@ public:
     uint8_t getPatternY()const { return m_numPatternY; }
     uint8_t getPatternZ()const { return m_numPatternZ; }
 
+    bool canAnimate() { return m_animate; }
+    void setAnimate(bool aniamte) { m_animate = aniamte; }
+
 protected:
     virtual ThingType* getThingType() const = 0;
 
@@ -242,6 +245,7 @@ private:
     void lua_setHighlight(const std::string_view color) { setHighlight(Color(color)); }
 
     bool m_canDraw{ true };
+    bool m_animate{ true };
 
     friend class Client;
     friend class Tile;


### PR DESCRIPTION
# Description

Allow to disable animation for all classes inheriting from Thing, ex: Effect, Item, Creature

```
thing = g_ui.createWidget("UIItem")
thing:getItem():setAnimate(false)
```

UIItem etc could also receive setAnimate(), but for simplicity I didn't add them.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
