### PR TITLE
fix: typo in thingType:unserialize

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -517,6 +517,8 @@ void ThingType::unserialize(const uint16_t clientId, const ThingCategory categor
         m_spritesIndex.resize(totalSpritesCount + totalSprites);
         for (int j = totalSpritesCount; j < (totalSpritesCount + totalSprites); ++j)
             m_spritesIndex[j] = g_game.getFeature(Otc::GameSpritesU32) ? fin->getU32() : fin->getU16();
+
+        totalSpritesCount += totalSprites;
     }
 
     m_textureData.resize(m_animationPhases);


### PR DESCRIPTION
# Description

It looks like in #1019 I had deleted one line too much and I didn't notice, which resulted in broken framegrouped outfits (idle animations were not parsed at all)

## Behavior

### **Actual**

Looktypes disappear for certain outfits

### **Expected**

They shouldn't

## Fixes

Fix #1022

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
