### PR TITLE
fix: add missing runtime library for x86 debug build

### DIFF
--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -174,6 +174,7 @@
       <DisableSpecificWarnings>4244;4251;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <CombineFilesOnlyFromTheSameFolder>true</CombineFilesOnlyFromTheSameFolder>
       <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>

--- a/vc17/otclient.vcxproj.filters
+++ b/vc17/otclient.vcxproj.filters
@@ -1055,9 +1055,6 @@
     <ClInclude Include="..\src\framework\graphics\shader\shadersources.h">
       <Filter>Header Files\framework\graphics\shader</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\protobuf\appearances.pb.h">
-      <Filter>Header Files\protobuf</Filter>
-    </ClInclude>
     <ClInclude Include="..\src\client\attachableobject.h">
       <Filter>Header Files\client</Filter>
     </ClInclude>

--- a/vc17/settings.props
+++ b/vc17/settings.props
@@ -51,7 +51,7 @@
         gdi32.lib;
         glew32d.lib;
         kernel32.lib;
-		ole32.lib;
+        ole32.lib;
         lua51.lib;
         ogg.lib;
         lzma.lib;


### PR DESCRIPTION
# Description

In #1023 I have missed one change in runtime library.
Pointed out here: https://github.com/mehah/otclient/pull/1023#issuecomment-2578816764

Follow up #1023 

## Behavior

### **Actual**

x86 debug -> dx/opengl doesn't compile

### **Expected**

it should

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
