### PR TITLE
feat: support adding items to any slot in containers

### DIFF
--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -52,10 +52,8 @@ void Container::onAddItem(const ItemPtr& item, int slot)
         return;
     }
 
-    if (slot == 0)
-        m_items.emplace_front(item);
-    else
-        m_items.emplace_back(item);
+    m_items.insert(m_items.begin() + slot, item);
+
     updateItemsPositions();
 
     callLuaField("onSizeChange", m_size);


### PR DESCRIPTION
# Description

Right now the code either adds to first or last slot, with this change we can add to any slot. I needed this behaviour for custom ordered backpacks. Servers (based on tfs) send 0 always and pageEnd (max slot) for paginated containers, so this change should be safe to do.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
