### PR TITLE
fix: correct search for keybind (eg. ctrl+e)

### DIFF
--- a/modules/client_options/keybins.lua
+++ b/modules/client_options/keybins.lua
@@ -600,7 +600,7 @@ function searchActions(field, text, oldText)
 end
 
 function performeSearchActions()
-    local searchText = panels.keybindsPanel.search.field:getText():trim():lower()
+    local searchText = panels.keybindsPanel.search.field:getText():trim():lower():gsub("%+", "%%+")
 
     local rows = panels.keybindsPanel.tablePanel.keybinds.dataSpace:getChildren()
     if searchText:len() > 0 then


### PR DESCRIPTION
# Description

When searching for the keybind (eg.: ctrl+e) the search will not return results.

The find function in Lua is used to search for a pattern within a string. By default, find uses Lua's pattern matching, which is similar to regular expressions but with some differences. The + character in Lua patterns is a special character that matches one or more occurrences of the previous character.

We need to escape the `+` character if it is present on the search text.

## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/d887c475-704e-47d2-916d-b443a5ff1a44)

### **Expected**

![image](https://github.com/user-attachments/assets/c0007ac9-6a41-4813-afed-13c22c25e7fa)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
