### PR TITLE
fix: vcpkg baseline error

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,5 +35,6 @@
       "name": "angle",
       "platform": "windows"
     }
-  ]
+  ],
+  "builtin-baseline":"d4f3e122069912636c123b7ece673f6e01513cea"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,5 @@
       "name": "angle",
       "platform": "windows"
     }
-  ],
-  "builtin-baseline":"b322364f06308bdd24823f9d8f03fe0cc86fd46f"
+  ]
 }


### PR DESCRIPTION
# Description

Vcpkg baseline error

## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/b17669d0-1a38-4f35-889f-de3db5b0d70b)

Do this and that doesn't happens

### **Expected**

![image](https://github.com/user-attachments/assets/9cc602ca-71fb-4151-904f-9c8934218a65)

Do this and that happens

## Fixes

Update or remove baseline from vcpkg.json

I removed the baseline completely, it is very difficult for a library to be updated to the point where it stops working completely, and as the repository is constantly updated it makes more sense to always be up to date, vcpkg has a lifetime limit for commits before, making it impossible to use the same baseline infinitely.

