### PR TITLE
fix: forgot password label was not working

### DIFF
--- a/modules/client_entergame/entergame.otui
+++ b/modules/client_entergame/entergame.otui
@@ -89,10 +89,11 @@ EnterGameWindow
     $!on:
       visible: false
 
-  Label
+  UIButton
     !text: tr('Forgot password and/or email')
     id: Forgot_password_email
     font: verdana-11px-monochrome-underline
+    text-align: left
     anchors.left: rememberEmailBox.left
     anchors.right: parent.right
     anchors.top: rememberEmailBox.bottom


### PR DESCRIPTION
Layout now is like:

![image](https://github.com/user-attachments/assets/f35834c4-addc-41ad-af47-d34b6ddd5e2d)

## Fixes

Fixes #1048 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Running and clicking on it

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
