### PR TITLE
fix: horizontal scrollbars are not correctly aligned

### DIFF
--- a/data/styles/10-scrollbars.otui
+++ b/data/styles/10-scrollbars.otui
@@ -190,6 +190,7 @@ HorizontalQtScrollBar < UIScrollBar
 SmallButton < UIButton
   size: 106 20
   font: cipsoftFont
+  text-offset: 0 2
   image-source: /images/ui/button
   image-clip: 0 0 22 23
   image-border: 3

--- a/data/styles/10-scrollbars.otui
+++ b/data/styles/10-scrollbars.otui
@@ -190,7 +190,6 @@ HorizontalQtScrollBar < UIScrollBar
 SmallButton < UIButton
   size: 106 20
   font: cipsoftFont
-  text-offset: 0 2
   image-source: /images/ui/button
   image-clip: 0 0 22 23
   image-border: 3

--- a/data/styles/10-scrollbars.otui
+++ b/data/styles/10-scrollbars.otui
@@ -150,7 +150,6 @@ VerticalQtScrollBar < UIScrollBar
 HorizontalScrollBarQtSlider < UIButton
   id: sliderButton
   anchors.centerIn: parent
-  margin-top: 1
   size: 44 12
   image-source: /images/ui/scrollbar_new_horizontal
   image-clip: 34 22 44 12
@@ -168,7 +167,7 @@ HorizontalQtScrollBar < UIScrollBar
 
   UIButton
     id: decrementButton
-    anchors.top: parent.top
+    anchors.verticalCenter: parent.verticalCenter
     anchors.left: parent.left
     image-source: /images/ui/scrollbar_new_horizontal
     image-clip: 42 10 12 12
@@ -178,7 +177,7 @@ HorizontalQtScrollBar < UIScrollBar
 
   UIButton
     id: incrementButton
-    anchors.top: parent.top
+    anchors.verticalCenter: parent.verticalCenter
     anchors.right: parent.right
     size: 12 12
     image-source: /images/ui/scrollbar_new_horizontal

--- a/modules/client_options/options.otui
+++ b/modules/client_options/options.otui
@@ -107,6 +107,7 @@ OptionScaleScrollMarked < Label
     id: valueBar
     step: 1
     anchors.right: toolTipWidget.left
+    anchors.verticalCenter: toolTipWidget.verticalCenter
     margin-right: 10
     width: 174
     @onValueChange: |


### PR DESCRIPTION
# Description

Even after #1040 and #1036, the horizontal scrollbars are not correctly aligned.

I ask you all to help testing this before merging, because the last PR on scrolls I made, everything was working for me but still some scrollbars got mixed up. @nekiro please review the changes, since you made the last change.

Thanks.

Before:
![image](https://github.com/user-attachments/assets/fb216740-d8f2-4484-ad56-37e1a85a7b1c)

After:
![image](https://github.com/user-attachments/assets/cd6265de-dea4-4f8d-9b73-a4c9c7b7e2cc)

(https://github.com/mehah/otclient/pull/1040#issuecomment-2596787794)

Also the marked scrollbar was not aligned too:

Before:
![image](https://github.com/user-attachments/assets/c8b6c5f2-63f7-43f9-ba3f-2365a8e56ad2)

After:
![image](https://github.com/user-attachments/assets/cada49c6-9f28-48a9-8c3d-bcea5b0d510d)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code