### PR TITLE
fix #1056, correct variable name

### DIFF
--- a/modules/corelib/ui/tooltip.lua
+++ b/modules/corelib/ui/tooltip.lua
@@ -3,7 +3,7 @@ g_tooltip = {}
 
 -- private variables
 local toolTipLabel
-local SpecialoolTipLabel
+local SpecialToolTipLabel
 local currentHoveredWidget
 
 -- private functions
@@ -34,13 +34,13 @@ local function moveToolTip(first)
     toolTipLabel:setPosition(pos)
 end
 local function moveSpecialToolTip(first)
-    if not first and (not SpecialoolTipLabel:isVisible() or SpecialoolTipLabel:getOpacity() < 0.1) then
+    if not first and (not SpecialToolTipLabel:isVisible() or SpecialToolTipLabel:getOpacity() < 0.1) then
         return
     end
 
     local pos = g_window.getMousePosition()
     local windowSize = g_window.getSize()
-    local labelSize = SpecialoolTipLabel:getSize()
+    local labelSize = SpecialToolTipLabel:getSize()
 
     pos.x = pos.x + 1
     pos.y = pos.y + 1
@@ -57,7 +57,7 @@ local function moveSpecialToolTip(first)
         pos.y = pos.y + 10
     end
 
-    SpecialoolTipLabel:setPosition(pos)
+    SpecialToolTipLabel:setPosition(pos)
 end
 
 local function onWidgetDestroy(widget)
@@ -142,16 +142,18 @@ function g_tooltip.init()
         toolTipLabel:setBorderWidth(1)
         toolTipLabel:setTextOffset(topoint('5 3'))
         toolTipLabel:hide()
+        toolTipLabel:setPhantom(true)
     end)
 
     addEvent(function()
-        SpecialoolTipLabel = g_ui.createWidget('UIWidget', rootWidget)
-        SpecialoolTipLabel:setBackgroundColor('#c0c0c0ff')
-        SpecialoolTipLabel:setBorderColor("#4c4c4cff")
-        SpecialoolTipLabel:setBorderWidth(1)
-        SpecialoolTipLabel:setWidth(455)
-        SpecialoolTipLabel:setPaddingTop(2)
-        SpecialoolTipLabel:hide()
+        SpecialToolTipLabel = g_ui.createWidget('UIWidget', rootWidget)
+        SpecialToolTipLabel:setBackgroundColor('#c0c0c0ff')
+        SpecialToolTipLabel:setBorderColor("#4c4c4cff")
+        SpecialToolTipLabel:setBorderWidth(1)
+        SpecialToolTipLabel:setWidth(455)
+        SpecialToolTipLabel:setPaddingTop(2)
+        SpecialToolTipLabel:hide()
+        SpecialToolTipLabel:setPhantom(true)
     end)
 end
 
@@ -192,18 +194,18 @@ function g_tooltip.display(text)
 end
 
 function g_tooltip.displaySpecial(special)
-    if not SpecialoolTipLabel then
+    if not SpecialToolTipLabel then
         return
     end
 
     local width = 4
     local height = 4
-    SpecialoolTipLabel:destroyChildren()
+    SpecialToolTipLabel:destroyChildren()
     for index, data in ipairs(special) do
         local headerW = 0
         local headerH = 0
         if string.len(data.header) > 0 then
-            local header = g_ui.createWidget('UILabel', SpecialoolTipLabel)
+            local header = g_ui.createWidget('UILabel', SpecialToolTipLabel)
             if index == 1 then
                 header:addAnchor(AnchorTop, 'parent', AnchorTop)
             else
@@ -221,7 +223,7 @@ function g_tooltip.displaySpecial(special)
             headerH = header:getHeight()
         end
 
-        local info = g_ui.createWidget('UILabel', SpecialoolTipLabel)
+        local info = g_ui.createWidget('UILabel', SpecialToolTipLabel)
         if string.len(data.header) > 0 then
             info:addAnchor(AnchorTop, 'prev', AnchorBottom)
         else
@@ -238,11 +240,11 @@ function g_tooltip.displaySpecial(special)
         height = height + headerH + info:getHeight()
     end
 
-    SpecialoolTipLabel:resize(width, height)
-    SpecialoolTipLabel:show()
-    SpecialoolTipLabel:raise()
-    SpecialoolTipLabel:enable()
-    g_effects.fadeIn(SpecialoolTipLabel, 100)
+    SpecialToolTipLabel:resize(width, height)
+    SpecialToolTipLabel:show()
+    SpecialToolTipLabel:raise()
+    SpecialToolTipLabel:enable()
+    g_effects.fadeIn(SpecialToolTipLabel, 100)
     moveSpecialToolTip(true)
 
     connect(rootWidget, {
@@ -259,8 +261,7 @@ function g_tooltip.hide()
 end
 
 function g_tooltip.hideSpecial()
-    g_effects.fadeOut(SpecialoolTipLabel, 100)
-
+    g_effects.fadeOut(SpecialToolTipLabel, 100)
     disconnect(rootWidget, {
         onMouseMove = moveSpecialToolTip
     })


### PR DESCRIPTION
# Description

1. closes #1056 by setting `phantom` property to tooltips
(this makes the button read hover event despite being covered by the tooltip)
2. corrects a typo in variable name

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

1. I set `g_effects.fadeOut` to `3000` in `modules/corelib/ui/tooltip.lua`
2. in `init.lua` I enabled `status` in `Services`
3. this was sent by my webservice (in order to reproduce the exact scenario described in the issue):
```php
function sendMessage($message) {
	$response = json_encode($message);
	die($response);
}

// case 'eventschedule':
// getEventSchedule();
// break;
function getEventSchedule() {
	$eventlist = [];
	$ev = array(
		'colorlight' => "#FFFFFF",
		'colordark' => "#000000",
		'description' => "EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT EVENT",
		'displaypriority' => 1,
		'isseasonal' => false,
		'name' => "TEST",
		'startdate' => 1737304005,
		'enddate' => 1747304005,
		'specialevent' => 0
	);
	array_push($eventlist, $ev);
	sendMessage(array(
		'eventlist' => $eventlist, 
		'lastupdatetimestamp' => time()
	));
}
```
4. the button was not clickable as described in the issue, setting `phantom` property to the tooltip resolved this problem

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
