### PR TITLE
fix: mobile detection when compiling for macOS

### DIFF
--- a/src/framework/platform/unixplatform.cpp
+++ b/src/framework/platform/unixplatform.cpp
@@ -43,7 +43,7 @@ void Platform::init(std::vector<std::string>& args)
 
 #ifdef __APPLE__
     #include "TargetConditionals.h"
-    #if defined(TARGET_OS_IPHONE) || defined(TARGET_IPHONE_SIMULATOR)
+    #if (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) || (defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR)
         setDevice({ Mobile, iOS });
     #else
         setDevice({ Desktop, macOS });


### PR DESCRIPTION
# Description

Previously the mobile detection code was not working properly. It was detecting macOS as a mobile platform. This PR fixes it.

## Behavior

### **Actual**

When compiling for macOS and running the client it was showing a joystick and other UI artifacts designed for a mobile platform like Android or iOS.

### **Expected**

When compiling for macOS it should behave as a desktop platform.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] I've compiled it after the change and the joystick and other mobile UI artifacts were gone. The client was behaving as expected.
  - [ ] I wasn't able to test builds in other platforms like Android or Windows, but given the very small change I'm not expecting any issues.

**Test Configuration**:

  - Server Version: 11.00
  - Client: latest master commit
  - Operating System: macOS 15.2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
