### PR TITLE
Stop using Apple's OpenAL implementation

### DIFF
--- a/src/framework/sound/declarations.h
+++ b/src/framework/sound/declarations.h
@@ -24,15 +24,10 @@
 
 #include <framework/global.h>
 
-#if defined(__APPLE__)
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
 #include <AL/efx-presets.h>
 #include <AL/efx.h>
-#endif
 
 class SoundManager;
 class SoundSource;


### PR DESCRIPTION
# Description

This project doesn't compile with Apple's OpenAL implementation. Also, Apple's OpenAL implementation was deprecated on macOS 10.15 and later (back in 2019).

For instance, here's one of the many hundred errors that happens:

```
In file included from build/macos-release/src/CMakeFiles/otclient.dir/Unity/unity_20_cxx.cxx:4:
In file included from src/framework/sound/soundeffect.cpp:30:
build/macos-release/vcpkg_installed/arm64-osx/include/AL/efx.h:208:61: error: expected ';' after top level declarator
  208 | typedef void (AL_APIENTRY *LPALGENEFFECTS)(ALsizei, ALuint*) AL_API_NOEXCEPT17;
      |                                                             ^
```

The root cause for the error above is that we're mixing Apple's OpenAL headers with OpenAL Soft headers. But there are many other errors and warnings. I believe the best is for us to use a single implementation across all the platforms.

## Behavior

### **Actual**

Check the description above.

### **Expected**

You should be able to compile for macOS without issues. Also, sound should work fine when running the binary.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] This compiles and works fine on macOS.
  - [x] It should not affect non-Apple builds.

**Test Configuration**:

  - Server Version: 11.00
  - Client: 11.00
  - Operating System: macOS 15.2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
