### PR TITLE
fix: freezing walking

### DIFF
--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -2,6 +2,7 @@ local smartWalkDirs = {}
 local smartWalkDir = nil
 local walkEvent = nil
 local lastTurn = 0
+local lastCancelWalkTime = 0
 local nextWalkDir = nil
 
 WalkController = Controller:new()
@@ -75,7 +76,10 @@ end
 
 --- Adds a walk event with an optional delay.
 local function addWalkEvent(dir, delay)
-    cancelWalkEvent()
+    if os.time() - lastCancelWalkTime > 10 then
+        cancelWalkEvent()
+        lastCancelWalkTime = os.time()
+    end
 
     local function walkCallback()
         if g_keyboard.getModifiers() ~= KeyboardNoModifier then


### PR DESCRIPTION
fix #1067

I don't know if this is the best solution, but this happens when we set the ```g_keyboard.setKeyDelay(key, 10)``` and with that the cancelWalkEvent() in addWalkEvent is called before even executing the walk,


#### note: this bug already occurs even before I refactored to use the Controller System.