### PR TITLE
fix: ActionBar packets (sendEquipItem) + Tier in actionbar

### DIFF
--- a/modules/corelib/ui/uiactionslot.lua
+++ b/modules/corelib/ui/uiactionslot.lua
@@ -10,5 +10,6 @@ function UIActionSlot.create()
     slot.useType = nil
     slot.autoSend = nil
     slot.parameter = nil
+    slot.getTier = nil
     return slot
 end

--- a/modules/game_actionbar/assign_object.otui
+++ b/modules/game_actionbar/assign_object.otui
@@ -1,4 +1,4 @@
-PreviewItem < UIItem
+PreviewItem < Item
   size: 85 85
   //background-color: gray
   padding: 10

--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -139,6 +139,7 @@ function copySlot(fromSlotId, toSlotId, visible)
     tmpslot.text = fromSlot.text
     tmpslot.parameter = fromSlot.parameter
     tmpslot.useType = fromSlot.useType
+    tmpslot.getTier = fromSlot.getTier
     tmpslot:getChildById('text'):setText(fromSlot:getChildById('text'):getText())
     tmpslot:setTooltip(fromSlot:getTooltip())
 end
@@ -188,6 +189,7 @@ function setupActionBar()
         slot.words = nil
         slot.text = nil
         slot.useType = nil
+        slot.getTier = nil
         g_mouse.bindPress(slot, function()
             slotToEdit = 'slot' .. i .. ''
         end, MouseLeftButton)
@@ -359,6 +361,8 @@ function clearSlot()
     slot.words = nil
     slot.text = nil
     slot.useType = nil
+    slot.getTier = nil
+    slot:getChildById('tier'):setVisible(false)
     slot:getChildById('text'):setText('')
     slot:setTooltip('')
 end
@@ -374,6 +378,8 @@ function clearSlotById(slotId)
     slot.words = nil
     slot.text = nil
     slot.useType = nil
+    slot.getTier = nil
+    slot:getChildById('tier'):setVisible(false)
     slot:getChildById('text'):setText('')
     slot:setTooltip('')
 end
@@ -486,6 +492,8 @@ function objectAssignAccept()
     slot:setImageSource('/images/game/actionbar/item-background')
     slot:setBorderWidth(0)
     slot.itemId = item:getId()
+    slot.getTier = objectAssignWindow:getChildById('previewItem').auxTier
+    ItemsDatabase.setTier(slot, slot.getTier)
     if item:isFluidContainer() then
         slot.subType = item:getSubType()
     end
@@ -517,6 +525,9 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
 
     if item and item:getPosition().x == 65535 and slotToEdit then
         objectAssignWindow:getChildById('previewItem'):setItemId(item:getId())
+        local tier = item:getTier()
+        ItemsDatabase.setTier(objectAssignWindow:getChildById('previewItem'), tier)
+        objectAssignWindow:getChildById('previewItem').auxTier = tier
         objectAssignWindow:getChildById('previewItem'):setItemCount(1)
         objectAssignWindow:getChildById('equipCheckbox'):setEnabled(false)
         objectAssignWindow:getChildById('useCheckbox'):setEnabled(false)
@@ -562,6 +573,9 @@ function onChooseItemByDrag(self, mousePosition, item)
     if item and item:getPosition().x == 65535 and slotToEdit then
         openObjectAssignWindow()
         objectAssignWindow:getChildById('previewItem'):setItemId(item:getId())
+        local tier = item:getTier()
+        ItemsDatabase.setTier(objectAssignWindow:getChildById('previewItem'), tier)
+        objectAssignWindow:getChildById('previewItem').auxTier = tier
         objectAssignWindow:getChildById('previewItem'):setItemCount(1)
         objectAssignWindow:getChildById('equipCheckbox'):setEnabled(false)
         objectAssignWindow:getChildById('useCheckbox'):setEnabled(false)
@@ -664,7 +678,7 @@ function setupHotkeys()
                 elseif slot.useType == 'useOnSelf' then
                     modules.game_hotkeys.executeHotkeyItem(HOTKEY_USEONSELF, slot.itemId, slot.subType)
                 elseif slot.useType == 'equip' then
-                    local item = g_game.findPlayerItem(slot.itemId, -1)
+                    local item = g_game.findPlayerItem(slot.itemId, -1, slot.getTier)
                     if item then
                         g_game.equipItem(item)
                     end
@@ -707,7 +721,7 @@ function setupHotkeys()
                     elseif slot.useType == 'useOnSelf' then
                         modules.game_hotkeys.executeHotkeyItem(HOTKEY_USEONSELF, slot.itemId, slot.subType)
                     elseif slot.useType == 'equip' then
-                        local item = g_game.findPlayerItem(slot.itemId, -1)
+                        local item = g_game.findPlayerItem(slot.itemId, -1, slot.getTier)
                         if item then
                             g_game.equipItem(item)
                         end
@@ -819,7 +833,8 @@ function saveActionBar()
             useType = slot.useType,
             text = slot.text,
             words = slot.words,
-            parameter = slot.parameter
+            parameter = slot.parameter,
+            getTier = slot.getTier
         }
     end
 
@@ -843,6 +858,7 @@ function loadObject(slot)
     slot:setImageClip('0 0 0 0')
     slot:getChildById('text'):setText('')
     slot:setBorderWidth(0)
+    ItemsDatabase.setTier(slot, slot.getTier)
     setupHotkeys()
 end
 
@@ -882,6 +898,8 @@ function loadActionBar()
                 slot.useType = setting.useType
                 slot.autoSend = setting.autoSend
                 slot.parameter = setting.parameter
+                slot.getTier = setting.getTier
+                ItemsDatabase.setTier(slot, slot.getTier)
                 if slot.hotkey then
                     local text = slot.hotkey
                     if type(text) == 'string' then
@@ -934,7 +952,10 @@ function updateCooldown(progressRect, duration, spellId, count)
         end, 100)
     else
         cooldown[spellId] = nil
-        progressRect:destroy()
+        if progressRect and not progressRect:isDestroyed() then
+            progressRect:destroy()
+            progressRect = nil
+        end
     end
 end
 
@@ -952,7 +973,10 @@ function updateGroupCooldown(progressRect, duration, groupId)
         end, 100)
     else
         groupCooldown[groupId] = nil
-        progressRect:destroy()
+        if progressRect and not progressRect:isDestroyed() then
+            progressRect:destroy()
+            progressRect = nil
+        end
     end
 end
 

--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -925,7 +925,7 @@ end
 
 function setActionBarVisible(visible)
     if visible then
-        actionBar:setHeight(34)
+        actionBar:setHeight(38)
         actionBar:show()
     else
         actionBar:setHeight(0)

--- a/modules/game_actionbar/game_actionbar.otui
+++ b/modules/game_actionbar/game_actionbar.otui
@@ -17,6 +17,20 @@ ActionSlot < UIActionSlot
     opacity: 0.7
   $!pressed:
     opacity: 1.0
+
+  UIWidget
+    id: tier
+    size: 10 9
+    image-source: /images/inventory/tiers-strip
+    image-clip: 0 0 10 9
+    image-size: 10 9
+    anchors.top: parent.top
+    anchors.right: parent.right
+    phantom: true
+    focusable: false
+    visible: false
+    image-smooth: true
+      
   Label
     id: key
     anchors.top: parent.top

--- a/modules/gamelib/game.lua
+++ b/modules/gamelib/game.lua
@@ -2,7 +2,7 @@ function g_game.getRsa()
     return G.currentRsa
 end
 
-function g_game.findPlayerItem(itemId, subType)
+function g_game.findPlayerItem(itemId, subType, tier)
     local localPlayer = g_game.getLocalPlayer()
     if localPlayer then
         for slot = InventorySlotFirst, InventorySlotLast do
@@ -13,7 +13,7 @@ function g_game.findPlayerItem(itemId, subType)
         end
     end
 
-    return g_game.findItemInContainers(itemId, subType)
+    return g_game.findItemInContainers(itemId, subType, tier or 0)
 end
 
 function g_game.chooseRsa(host)

--- a/modules/gamelib/items.lua
+++ b/modules/gamelib/items.lua
@@ -40,36 +40,33 @@ local function clipfunction(value)
 end
 
 function ItemsDatabase.setRarityItem(widget, item, style)
-    if not g_game.getFeature(GameColorizedLootValue) then
+    if not g_game.getFeature(GameColorizedLootValue) or not widget then
         return
     end
-
-    if not widget then
-        return
-    end
-
     local frameOption = modules.client_options.getOption('framesRarity')
     if frameOption == "none" then
         return
     end
+    local imagePath = '/images/ui/item'
+    local clip = nil
     if item then
         local price = type(item) == "number" and item or (item and item:getMeanPrice()) or 0
         local itemRarity = getColorForValue(price)
         if itemRarity then
-            local clip = clipfunction(price)
+            clip = clipfunction(price)
             if clip ~= "" then
-                local imagePath = '/images/ui/item'
                 if frameOption == "frames" then
                     imagePath = "/images/ui/rarity_frames"
                 elseif frameOption == "corners" then
                     imagePath = "/images/ui/containerslot-coloredges"
                 end
-                widget:setImageClip(clip)
-                widget:setImageSource(imagePath)
+            else
+                clip = nil
             end
         end
     end
-
+    widget:setImageClip(clip)
+    widget:setImageSource(imagePath)
     if style then
         widget:setStyle(style)
     end

--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -60,10 +60,10 @@ void Container::onAddItem(const ItemPtr& item, int slot)
     callLuaField("onAddItem", slot, item);
 }
 
-ItemPtr Container::findItemById(const uint32_t itemId, const int subType) const
+ItemPtr Container::findItemById(const uint32_t itemId, const int subType, const uint8_t tier) const
 {
     for (const auto& item : m_items)
-        if (item->getId() == itemId && (subType == -1 || item->getSubType() == subType))
+        if (item->getId() == itemId && (subType == -1 || item->getSubType() == subType) && item->getTier() == tier)
             return item;
     return nullptr;
 }

--- a/src/client/container.h
+++ b/src/client/container.h
@@ -46,7 +46,7 @@ public:
     bool hasPages() { return m_hasPages; }
     int getSize() { return m_size; }
     int getFirstIndex() { return m_firstIndex; }
-    ItemPtr findItemById(uint32_t itemId, int subType) const;
+    ItemPtr findItemById(uint32_t itemId, int subType, uint8_t tier) const;
 
 protected:
     Container(const uint8_t id, const uint8_t capacity, const std::string_view name, ItemPtr containerItem, const bool hasParent, const bool isUnlocked, const bool hasPages, const uint16_t containerSize, const uint16_t firstIndex)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -858,11 +858,11 @@ void Game::useInventoryItemWith(const uint16_t itemId, const ThingPtr& toThing)
     g_lua.callGlobalField("g_game", "onUseWith", pos, itemId, toThing, 0);
 }
 
-ItemPtr Game::findItemInContainers(const uint32_t itemId, const int subType)
+ItemPtr Game::findItemInContainers(const uint32_t itemId, const int subType, const uint8_t tier)
 {
     for (const auto& it : m_containers) {
         if (const auto& container = it.second) {
-            if (const auto& item = container->findItemById(itemId, subType)) {
+            if (const auto& item = container->findItemById(itemId, subType, tier)) {
                 return item;
             }
         }
@@ -1412,7 +1412,7 @@ void Game::equipItem(const ItemPtr& item)
     if (!canPerformGameAction())
         return;
 
-    m_protocolGame->sendEquipItem(item->getId(), item->getCountOrSubType());
+    m_protocolGame->sendEquipItem(item->getId(), item->getTier());
 }
 
 void Game::mount(const bool mount)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1412,7 +1412,11 @@ void Game::equipItem(const ItemPtr& item)
     if (!canPerformGameAction())
         return;
 
-    m_protocolGame->sendEquipItem(item->getId(), item->getTier());
+    if (g_game.getFeature(Otc::GameThingUpgradeClassification) && item->getClassification() > 0) {
+        m_protocolGame->sendEquipItemWithTier(item->getId(), item->getTier());
+    } else {
+        m_protocolGame->sendEquipItemWithCountOrSubType(item->getId(), item->getCountOrSubType());
+    }
 }
 
 void Game::mount(const bool mount)

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -556,7 +556,7 @@ public:
     void useWith(const ItemPtr& item, const ThingPtr& toThing);
     void useInventoryItem(uint16_t itemId);
     void useInventoryItemWith(uint16_t itemId, const ThingPtr& toThing);
-    ItemPtr findItemInContainers(uint32_t itemId, int subType);
+    ItemPtr findItemInContainers(uint32_t itemId, int subType, uint8_t tier);
 
     // container related
     int open(const ItemPtr& item, const ContainerPtr& previousContainer);

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -53,7 +53,8 @@ public:
     void sendTurnSouth();
     void sendTurnWest();
     void sendGmTeleport(const Position& pos);
-    void sendEquipItem(uint16_t itemId, uint8_t tier);
+    void sendEquipItemWithTier(uint16_t itemId, uint8_t tierOrFluid);
+    void sendEquipItemWithCountOrSubType(uint16_t itemId, uint16_t tierOrFluid);
     void sendMove(const Position& fromPos, uint16_t thingId, uint8_t stackpos, const Position& toPos, uint16_t count);
     void sendInspectNpcTrade(uint16_t itemId, uint16_t count);
     void sendBuyItem(uint16_t itemId, uint8_t subType, uint16_t amount, bool ignoreCapacity, bool buyWithBackpack);

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -53,7 +53,7 @@ public:
     void sendTurnSouth();
     void sendTurnWest();
     void sendGmTeleport(const Position& pos);
-    void sendEquipItem(uint16_t itemId, uint16_t countOrSubType);
+    void sendEquipItem(uint16_t itemId, uint8_t tier);
     void sendMove(const Position& fromPos, uint16_t thingId, uint8_t stackpos, const Position& toPos, uint16_t count);
     void sendInspectNpcTrade(uint16_t itemId, uint16_t count);
     void sendBuyItem(uint16_t itemId, uint8_t subType, uint16_t amount, bool ignoreCapacity, bool buyWithBackpack);

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -292,15 +292,13 @@ void ProtocolGame::sendGmTeleport(const Position& pos)
     send(msg);
 }
 
-void ProtocolGame::sendEquipItem(const uint16_t itemId, const uint16_t countOrSubType)
+void ProtocolGame::sendEquipItem(const uint16_t itemId, const uint8_t tier)
 {
     const auto& msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientEquipItem);
     msg->addU16(itemId);
-    if (g_game.getFeature(Otc::GameCountU16))
-        msg->addU16(countOrSubType);
-    else
-        msg->addU8(static_cast<uint8_t>(countOrSubType));
+    if (g_game.getFeature(Otc::GameThingUpgradeClassification))
+        msg->addU8(tier);
     send(msg);
 }
 

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -292,13 +292,25 @@ void ProtocolGame::sendGmTeleport(const Position& pos)
     send(msg);
 }
 
-void ProtocolGame::sendEquipItem(const uint16_t itemId, const uint8_t tier)
+void ProtocolGame::sendEquipItemWithTier(const uint16_t itemId, const uint8_t tier)
 {
     const auto& msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientEquipItem);
     msg->addU16(itemId);
-    if (g_game.getFeature(Otc::GameThingUpgradeClassification))
-        msg->addU8(tier);
+    msg->addU8(tier);
+    send(msg);
+}
+
+void ProtocolGame::sendEquipItemWithCountOrSubType(const uint16_t itemId, const uint16_t countOrSubType)
+{
+    const auto& msg = std::make_shared<OutputMessage>();
+    msg->addU8(Proto::ClientEquipItem);
+    msg->addU16(itemId);
+    if (g_game.getFeature(Otc::GameCountU16)) {
+        msg->addU16(countOrSubType);
+    } else {
+        msg->addU8(static_cast<uint8_t>(countOrSubType));
+    }
     send(msg);
 }
 


### PR DESCRIPTION
# Description

The function sendEquipItem (which only affects game_actionbar) was sending 2 packets:
according OTCR
u16 the itemId
u8 or u16 countOrSubType
But this is incorrect.
According to Canary, the 2 packets to send are:

u16 the itemId
u8 tier.
This error manifests when trying to equip an item with a tier through the action bar.
The client sends the itemId and count (1).
For example, attempting to equip an Helmet tier +5.
The server interprets itemId and tier = 1(count), failing to find the item.
As a result, it doesn't work.


# Canary 13.40

2 packets: 
U16 item ID
u8 Tier

https://github.com/opentibiabr/canary/blob/5781de718e5d22ce9e7f136151d8b4032c85843d/src/server/network/protocol/protocolgame.cpp#L1392-L1400

![image](https://github.com/user-attachments/assets/e0dcf799-107d-4f42-ac3f-3ed39d2faee2)

# Tfs 10.98 blacktek

only packet U16 Item ID ( no have this feature GameThingUpgradeClassification)
https://github.com/Black-Tek/BlackTek-Server/blob/7130b41899fcb643b582e78a52ff27e891110d54/src/protocolgame.cpp#L983-L989

![image](https://github.com/user-attachments/assets/2e3f26c6-4fc6-4238-81c1-211277e65bcf)


# tfs forgottenserver-optimized SaiyansKing

only packet U16 Item ID ( no have this feature GameThingUpgradeClassification)

https://github.com/mehah/forgottenserver-optimized/blob/148baaa48c8ca159b16d0b632bd813749399b013/src/protocolgame.cpp#L1256-L1262

![image](https://github.com/user-attachments/assets/49be0878-3b00-4a8d-906d-ca8102781bce)

# tfs 8.6
does not have this function
# tfs 13.10

13.10 does not have many features, this is one of them

https://github.com/otland/forgottenserver/blob/b227678ab3584b8349913abfe4529292678a3fdf/src/protocolgame.cpp#L1300-L1308
![image](https://github.com/user-attachments/assets/3de9fcfa-9b83-4638-b5d0-f639ace5d522)

## Behavior

### **Actual**


![cvcaca](https://github.com/user-attachments/assets/ae78fff7-0235-4e13-8b01-773475a68c9c)


### **Expected**


![avavaaxc](https://github.com/user-attachments/assets/03b6db2c-cdc1-4d2f-9afc-38217c72354b)

## Fixes

usser in discord

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- login
- logout
- item with and without tier
- clear item
- 13.40 , 8.6 , 13.10, 10.98

**Test Configuration**:

  - Server Version: 13.40 , 8.6 , 13.10, 10.98
  - Client: this pr
  - Operating System: win 11

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  
  
+ tier : 
  
![image](https://github.com/user-attachments/assets/66fccb85-c0da-4d3d-b6f9-aa5993040f54)

![image](https://github.com/user-attachments/assets/829cbe5b-c8d2-495b-b718-acd37911b915)

