### PR TITLE
improve: Encryption System

### DIFF
--- a/src/framework/config.h
+++ b/src/framework/config.h
@@ -36,6 +36,7 @@
 #define ENABLE_ENCRYPTION_BUILDER 0
 // for security reasons make sure you are using password with at last 100+ characters
 #define ENCRYPTION_PASSWORD "SET_YOUR_PASSWORD_HERE"
+// do not insert special characters in the header (ONLY UPPERCASE LETTERS, LOWERCASE LETTERS AND NUMBERS)
 #define ENCRYPTION_HEADER "SET_YOUR_HEADER_HERE"
 
 // DISCORD RPC (https://discord.com/developers/applications)

--- a/src/framework/config.h
+++ b/src/framework/config.h
@@ -21,6 +21,7 @@
  */
 
 #pragma once
+#include <obfuscate.h>
 
  // APPEARANCES
 #define BYTES_IN_SPRITE_SHEET 384 * 384 * 4
@@ -35,9 +36,9 @@
 // You can compile it once and use this executable to only encrypt client files once with command --encrypt which will be using password below.
 #define ENABLE_ENCRYPTION_BUILDER 0
 // for security reasons make sure you are using password with at last 100+ characters
-#define ENCRYPTION_PASSWORD "SET_YOUR_PASSWORD_HERE"
-// do not insert special characters in the header (ONLY UPPERCASE LETTERS, LOWERCASE LETTERS AND NUMBERS) | example: #define ENCRYPTION_HEADER "21UsO5ARfRnIScs415BNMab"
-#define ENCRYPTION_HEADER "SET_YOUR_HEADER_HERE"
+#define ENCRYPTION_PASSWORD AY_OBFUSCATE("SET_YOUR_PASSWORD_HERE")
+// do not insert special characters in the header (ONLY UPPERCASE LETTERS, LOWERCASE LETTERS AND NUMBERS) | example: #define ENCRYPTION_HEADER AY_OBFUSCATE("21UsO5ARfRnIScs415BNMab")
+#define ENCRYPTION_HEADER AY_OBFUSCATE("SET_YOUR_HEADER_HERE")
 
 // DISCORD RPC (https://discord.com/developers/applications)
 // Note: Only for VSSolution, doesn't work with CMAKE

--- a/src/framework/config.h
+++ b/src/framework/config.h
@@ -36,7 +36,7 @@
 #define ENABLE_ENCRYPTION_BUILDER 0
 // for security reasons make sure you are using password with at last 100+ characters
 #define ENCRYPTION_PASSWORD "SET_YOUR_PASSWORD_HERE"
-// do not insert special characters in the header (ONLY UPPERCASE LETTERS, LOWERCASE LETTERS AND NUMBERS)
+// do not insert special characters in the header (ONLY UPPERCASE LETTERS, LOWERCASE LETTERS AND NUMBERS) | example: #define ENCRYPTION_HEADER "21UsO5ARfRnIScs415BNMab"
 #define ENCRYPTION_HEADER "SET_YOUR_HEADER_HERE"
 
 // DISCORD RPC (https://discord.com/developers/applications)

--- a/src/framework/core/filestream.cpp
+++ b/src/framework/core/filestream.cpp
@@ -61,7 +61,7 @@ FileStream::~FileStream()
         close();
 }
 
-void FileStream::cache(bool /*useEnc*/)
+void FileStream::cache(bool useEnc)
 {
     m_caching = true;
 

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -231,15 +231,17 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
         hasHeader = true;
     }
 
-    if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
-        if (fullPath.find(AY_OBFUSCATE("/bot/")) != std::string::npos && !hasHeader) {
-            return buffer;
-        }
-    }
-
     if (hasHeader) {
         buffer = buffer.substr(std::string(ENCRYPTION_HEADER).size());
         buffer = decrypt(buffer);
+    } else {
+        if (fullPath.find(std::string(AY_OBFUSCATE("/bot/"))) != std::string::npos) {
+            if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
+                return buffer;
+            } else {
+                return "";
+            }
+        }
     }
 #endif
 

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -225,22 +225,19 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
     PHYSFS_close(file);
 
 #if ENABLE_ENCRYPTION == 1
-    bool hasHeader = false;
-    if (buffer.size() >= std::string(ENCRYPTION_HEADER).size() &&
-        buffer.substr(0, std::string(ENCRYPTION_HEADER).size()) == std::string(ENCRYPTION_HEADER)) {
-        hasHeader = true;
-    }
+    const auto headerSize = std::string(ENCRYPTION_HEADER).size();
+    const bool hasHeader = (buffer.size() >= headerSize &&
+                            buffer.compare(0, headerSize, ENCRYPTION_HEADER) == 0);
 
     if (hasHeader) {
-        buffer = buffer.substr(std::string(ENCRYPTION_HEADER).size());
+        buffer = buffer.substr(headerSize);
         buffer = decrypt(buffer);
     } else {
         if (fullPath.find(std::string(AY_OBFUSCATE("/bot/"))) != std::string::npos) {
             if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
                 return buffer;
-            } else {
-                return "";
             }
+            return "";
         }
     }
 #endif

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -209,7 +209,7 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
 {
     const std::string fullPath = resolvePath(fileName);
 
-    if (fullPath.find(g_resources.getByteStrings(0)) != std::string::npos) {
+    if (fullPath.find(AY_OBFUSCATE("/downloads")) != std::string::npos) {
         const auto dfile = g_http.getFile(fullPath.substr(10));
         if (dfile)
             return std::string(dfile->response.begin(), dfile->response.end());
@@ -232,7 +232,7 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
     }
 
     if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
-        if (fullPath.find(g_resources.getByteStrings(1)) != std::string::npos && !hasHeader) {
+        if (fullPath.find(AY_OBFUSCATE("/bot/")) != std::string::npos && !hasHeader) {
             return buffer;
         }
     }
@@ -758,26 +758,4 @@ std::unordered_map<std::string, std::string> ResourceManager::decompressArchive(
 {
     std::unordered_map<std::string, std::string> ret;
     return ret;
-}
-
-std::string ResourceManager::decodificateStrings(const std::vector<unsigned char>& bytes) {
-    std::string result;
-    for (const unsigned char c : bytes) {
-        result.push_back(c ^ 0xAA);
-    }
-    return result;
-}
-
-// used to obfuscate vulnerable strings (provisional)
-std::string ResourceManager::getByteStrings(const size_t line) {
-    const std::vector<std::vector<unsigned char>> strTable = {
-        {0x85, 0xCE, 0xC5, 0xDD, 0xC4, 0xC6, 0xC5, 0xCB, 0xCE, 0xD9},  // "/downloads"
-        {0x85, 0xC8, 0xC5, 0xDE, 0x85},  // "/bot/"
-        {0xE6, 0xC3, 0xC4, 0xC2, 0xCB, 0x8A, 0xCE, 0xCF, 0x8A, 0xD8, 0xCF, 0xDE, 0xC5, 0xD8, 0xC4, 0xC5, 0x8A, 0xC3, 0xC4, 0xDC, 0xCB, 0xC6, 0xC3, 0xCE, 0xCB},  // "Linha de retorno invalida"
-    };
-
-    if (line < strTable.size()) {
-        return decodificateStrings(strTable[line]);
-    }
-    return decodificateStrings(strTable[2]);
 }

--- a/src/framework/core/resourcemanager.h
+++ b/src/framework/core/resourcemanager.h
@@ -93,8 +93,6 @@ public:
     bool launchCorrect(const std::vector<std::string>& args);
     std::string createArchive(const std::unordered_map<std::string, std::string>& files);
     std::unordered_map<std::string, std::string> decompressArchive(std::string dataOrPath);
-    std::string decodificateStrings(const std::vector<unsigned char>& bytes);
-    std::string getByteStrings(size_t line);
 
     std::string getBinaryPath() { return m_binaryPath.string(); }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,7 @@ extern "C" {
 #if ENABLE_ENCRYPTION == 1 && ENABLE_ENCRYPTION_BUILDER == 1
         if (std::find(args.begin(), args.end(), "--encrypt") != args.end()) {
             g_lua.init();
-            g_resources.runEncryption(args.size() >= 3 ? args[2] : ENCRYPTION_PASSWORD);
+            g_resources.runEncryption(args.size() >= 3 ? args[2] :  std::string(ENCRYPTION_PASSWORD));
             std::cout << "Encryption complete" << std::endl;
 #ifdef WIN32
             MessageBoxA(NULL, "Encryption complete", "Success", 0);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "cpp-httplib",
     "discord-rpc",
     "liblzma",
+    "libobfuscate",
     "libogg",
     "libvorbis",
     "nlohmann-json",


### PR DESCRIPTION
- Fixes a compilation error when using ENABLE_ENCRYPTION 1 (so you will no longer have black screen problems as reported on discord)

- Improvements in encryption (we now hide the key and header strings in the compiled file, using libobfuscate)

**BEFORE:**
![BEFORE](https://github.com/user-attachments/assets/5883df4e-3c08-492e-9238-039dce80fddb)

**AFTER:**
![AFTER](https://github.com/user-attachments/assets/a0d4de17-4847-44dd-b08b-ad1fa300944b)

- Removed temporary string hiding function (it was being used to hide characters from the readFileContents function, which, if found in any debugger, could easily be jumped to return the buffer directly without the crypto, they were also replaced by libobfuscate)