### PR TITLE
fix: feature activation order: load features before .spr/.dat files

### DIFF
--- a/modules/client_entergame/entergame.otmod
+++ b/modules/client_entergame/entergame.otmod
@@ -5,8 +5,8 @@ Module
   website: https://github.com/edubart/otclient
 
   dependencies:
-    - game_things
     - game_features
+    - game_things
 
   @onLoad: |
     dofile 'entergame'


### PR DESCRIPTION
# Description

there is a precedence problem. 

example

Client need to activate these features
```lua
        g_game.enableFeature(GameSpritesU32)
        g_game.enableFeature(GameSpritesAlphaChannel)
        g_game.enableFeature(GameEnhancedAnimations)
        g_game.enableFeature(GameIdleAnimations)
```
 later load .spr / .dat


the main repo , first load the .dat / . spr and later activate features

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

fix #1079 

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
