### PR TITLE
fix: prevent error colored text loot in non-English language(locales)

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -159,7 +159,7 @@ function displayMessage(mode, text)
         if msgtype == MessageSettings.loot then
             local coloredText = ItemsDatabase.setColorLootMessage(text)
             label:setColoredText(coloredText)
-            local getTabServerLog = modules.game_console.consoleTabBar:getTabPanel(modules.game_console.getTab("Server Log"))
+            local getTabServerLog = modules.game_console.consoleTabBar:getTabPanel(modules.game_console.serverTab)
             if getTabServerLog then
                 getTabServerLog:getChildById('consoleBuffer'):getLastChild():setColoredText(coloredText)
             end


### PR DESCRIPTION
# Description

if user have a language other than English, the code does not find the serverTab

**polaco**
`["Server Log"] = "Log Serwera",`
**portugues**
`["Server Log"] = "Registro do servidor",`

## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/7fce8c7e-734b-4db2-af5c-f4efc19b785c)

### **Expected**

Do this and that happens

## Fixes

discord 

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
