### PR TITLE
improve: add macOS CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -101,6 +101,40 @@
         "TOGGLE_PRE_COMPILED_HEADER": "OFF",
         "SPEED_UP_BUILD_UNITY": "OFF"
       }
+    },
+    {
+      "name": "macos-release",
+      "displayName": "macOS - Release",
+      "description": "Sets Ninja generator, compilers, build and install directory and set build type as release",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+          "type": "FILEPATH"
+        },
+        "BUILD_STATIC_LIBRARY": "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "OPTIONS_ENABLE_SCCACHE": "ON",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O1 -DNDEBUG"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "macos-debug",
+      "inherits": "macos-release",
+      "displayName": "macOS - Debug",
+      "description": "Build Debug Mode",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "DEBUG_LOG": "ON",
+        "ASAN_ENABLED": "ON",
+        "BUILD_STATIC_LIBRARY": "OFF"
+      }
     }
   ],
   "buildPresets": [
@@ -123,6 +157,14 @@
     {
       "name": "windows-debug",
       "configurePreset": "windows-debug"
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos-release"
+    },
+    {
+      "name": "macos-debug",
+      "configurePreset": "macos-debug"
     }
   ]
 }


### PR DESCRIPTION
# Description

This should easy the build process on macOS by providing a set of presets that can be used to build the project with a single command.

The release preset sets the compiler optimization level to O1 because O2 and above crashes the client when starting up.

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

  - [x] I've tested both configurations on Apple Silicon Macs and it seems stable.

**Test Configuration**:

  - Server Version: 11.00
  - Client: 11.00
  - Operating System: macOS 15.2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
