### PR TITLE
fix: magic effect crash

### DIFF
--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -142,9 +142,15 @@ void Effect::setPosition(const Position& position, const uint8_t stackPos, const
         return;
 
     Thing::setPosition(position, stackPos, hasElevation);
+    int pattern_x = getNumPatternX();
+    int pattern_y = getNumPatternY();
+    if (pattern_x == 0 || pattern_y == 0) {
+        g_logger.warning(std::format("Failed to send magic effect {:d}. No sprites declared.", m_clientId));
+        return;
+    }
 
-    m_numPatternX = m_position.x % getNumPatternX();
-    m_numPatternY = m_position.y % getNumPatternY();
+    m_numPatternX = m_position.x % pattern_x;
+    m_numPatternY = m_position.y % pattern_y;
 }
 
 ThingType* Effect::getThingType() const {

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -145,7 +145,7 @@ void Effect::setPosition(const Position& position, const uint8_t stackPos, const
     int pattern_x = getNumPatternX();
     int pattern_y = getNumPatternY();
     if (pattern_x == 0 || pattern_y == 0) {
-        g_logger.warning(std::format("Failed to send magic effect {:d}. No sprites declared.", m_clientId));
+        g_logger.warning(stdext::format("Failed to send magic effect %d. No sprites declared.", m_clientId));
         return;
     }
 


### PR DESCRIPTION
# Description

closes #1085 by removing division by zero scenario

## Behavior

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

this can be reproduced when the magic effect is lower than the highest magic effect id, but does not exist (see #1085)

I sent !z 248 to play a non-existent magic effect.