### PR TITLE
Option: hide loot message on screen

### DIFF
--- a/modules/client_options/data_options.lua
+++ b/modules/client_options/data_options.lua
@@ -35,6 +35,7 @@ return {
     showPrivateMessagesInConsole      = true,
     showOthersStatusMessagesInConsole = false,
     showPrivateMessagesOnScreen       = true,
+    showLootMessagesOnScreen          = true,
     showOutfitsOnList                 = {
         value = true,
         action = function(value, options, controller, panels, extraWidgets)

--- a/modules/client_options/styles/interface/console.otui
+++ b/modules/client_options/styles/interface/console.otui
@@ -88,3 +88,14 @@ UIWidget
       id: showPrivateMessagesOnScreen
       !text: tr('Show private messages on screen')
 
+  SmallReversedQtPanel
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 7
+    height: 22
+  
+    OptionCheckBox
+      id: showLootMessagesOnScreen
+      !text: tr('Show loot messages on screen')
+

--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -1016,7 +1016,13 @@ function addTabText(text, speaktype, tab, creatureName)
     local consoleBuffer = panel:getChildById('consoleBuffer')
     local label = g_ui.createWidget('ConsoleLabel', consoleBuffer)
     label:setId('consoleLabel' .. consoleBuffer:getChildCount())
-    label:setText(text)
+
+    if speaktype.colored then
+        label:setColoredText(text)
+    else
+        label:setText(text)
+    end
+    
     label:setColor(speaktype.color)
     -- consoleTabBar:blinkTab(tab)
     if consoleTabBar:getCurrentTab() ~= tab then

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -154,19 +154,26 @@ function displayMessage(mode, text)
         -- TODO move to game_console
     end
 
+    if msgtype == MessageSettings.loot then
+        local coloredText = ItemsDatabase.setColorLootMessage(text)
+        local getTabServerLog = modules.game_console.consoleTabBar:getTabPanel(modules.game_console.serverTab)
+        if getTabServerLog then
+            getTabServerLog:getChildById('consoleBuffer'):getLastChild():setColoredText(coloredText)
+        end
+    end
+
     if msgtype.screenTarget then
         local label = messagesPanel:recursiveGetChildById(msgtype.screenTarget)
-        if msgtype == MessageSettings.loot then
+        if msgtype == MessageSettings.loot and not modules.client_options.getOption('showLootMessagesOnScreen') then
+            return
+        elseif msgtype == MessageSettings.loot then
             local coloredText = ItemsDatabase.setColorLootMessage(text)
             label:setColoredText(coloredText)
-            local getTabServerLog = modules.game_console.consoleTabBar:getTabPanel(modules.game_console.serverTab)
-            if getTabServerLog then
-                getTabServerLog:getChildById('consoleBuffer'):getLastChild():setColoredText(coloredText)
-            end
-		else
+        else
             label:setText(text)
             label:setColor(msgtype.color)
         end
+
         label:setVisible(true)
         removeEvent(label.hideEvent)
         label.hideEvent = scheduleEvent(function()

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -58,7 +58,8 @@ MessageSettings = {
         color = TextColors.white,
         consoleTab = 'Loot',
         screenTarget = 'highCenterLabel',
-        consoleOption = 'showInfoMessagesInConsole'
+        consoleOption = 'showInfoMessagesInConsole',
+        colored = true
     }
 }
 
@@ -156,10 +157,7 @@ function displayMessage(mode, text)
 
     if msgtype == MessageSettings.loot then
         local coloredText = ItemsDatabase.setColorLootMessage(text)
-        local getTabServerLog = modules.game_console.consoleTabBar:getTabPanel(modules.game_console.serverTab)
-        if getTabServerLog then
-            getTabServerLog:getChildById('consoleBuffer'):getLastChild():setColoredText(coloredText)
-        end
+        modules.game_console.addText(coloredText, msgtype, tr("Server Log"))
     end
 
     if msgtype.screenTarget then


### PR DESCRIPTION
# Description

Option to hide loot messages on screen. Especially on ots where drop rate is high the message distracts as the screen gets crowded.

The message still appears in the serverlog.

## Behavior

### **Actual**

Hiding loot messages is currently not possible.

### **Expected**

![grafik](https://github.com/user-attachments/assets/61be5558-08a0-4068-92bc-b8ad29957cf7)

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: canary 3.1.2
  - Client: otclient main branch
  - Operating System: win11

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
