### PR TITLE
fix: bestiary progress bar clipping

### DIFF
--- a/modules/game_cyclopedia/tab/bestiary/bestiary.lua
+++ b/modules/game_cyclopedia/tab/bestiary/bestiary.lua
@@ -46,6 +46,7 @@ function Cyclopedia.SetBestiaryProgress(fit, firstBar, secondBar, thirdBar, kill
     end
 
     local function setBarVisibility(bar, isVisible, width)
+        isVisible = isVisible and width > 0
         bar:setVisible(isVisible)
         if isVisible then
             bar:setImageRect({


### PR DESCRIPTION
# Description

Kill count is so small for the second progress stage, the calculations return width = 0 which breaks setImageRect. Using similar fix as in the bosstiary

## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/f045c39f-49cf-4eec-ad5a-eb5ee4a422ef)

### **Expected**

![image](https://github.com/user-attachments/assets/91c78b5f-523e-4c16-b6d4-1835ce737a7b)


## Fixes

\# Bestiary progress bar clipping

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: tfs master + patches
  - Client: mehah + patches
  - Operating System: Linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
