### PR TITLE
feat: checkbox for quickloot accepted items

### DIFF
--- a/modules/game_cyclopedia/tab/items/items.lua
+++ b/modules/game_cyclopedia/tab/items/items.lua
@@ -61,6 +61,15 @@ function showItems()
     controllerCyclopedia.ui.GoldBase:setVisible(false)
     controllerCyclopedia.ui.BestiaryTrackerButton:setVisible(false)
 
+    local lootFilterValue = modules.game_quickloot.quickLootController.ui.filters.add:getText()
+    if string.match(lootFilterValue:lower(), "skipped") then
+        UI.InfoBase.SkipQuickLootCheck:setVisible(true)
+        UI.InfoBase.LootQuickLootCheck:setVisible(false)
+    else
+        UI.InfoBase.SkipQuickLootCheck:setVisible(false)
+        UI.InfoBase.LootQuickLootCheck:setVisible(true)
+    end
+
     local CategoryColor = "#484848"
 
     for _, data in ipairs(Cyclopedia.CategoryItems) do
@@ -264,6 +273,15 @@ function Cyclopedia.internalCreateItem(data)
                 modules.game_quickloot.QuickLoot.addLootList(data:getId(), 1)
             else
                 modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 1)
+            end
+        end
+
+        UI.InfoBase.LootQuickLootCheck.onCheckChange = function(self, checked)
+            UI.InfoBase.LootQuickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), 2))
+            if checked then
+                modules.game_quickloot.QuickLoot.addLootList(data:getId(), 2)
+            else
+                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 2)
             end
         end
 

--- a/modules/game_cyclopedia/tab/items/items.lua
+++ b/modules/game_cyclopedia/tab/items/items.lua
@@ -61,15 +61,6 @@ function showItems()
     controllerCyclopedia.ui.GoldBase:setVisible(false)
     controllerCyclopedia.ui.BestiaryTrackerButton:setVisible(false)
 
-    local lootFilterValue = modules.game_quickloot.quickLootController.ui.filters.add:getText()
-    if string.match(lootFilterValue:lower(), "skipped") then
-        UI.InfoBase.SkipQuickLootCheck:setVisible(true)
-        UI.InfoBase.LootQuickLootCheck:setVisible(false)
-    else
-        UI.InfoBase.SkipQuickLootCheck:setVisible(false)
-        UI.InfoBase.LootQuickLootCheck:setVisible(true)
-    end
-
     local CategoryColor = "#484848"
 
     for _, data in ipairs(Cyclopedia.CategoryItems) do
@@ -267,25 +258,21 @@ function Cyclopedia.internalCreateItem(data)
         end
         widget:setBackgroundColor("#585858")
        
-        UI.InfoBase.SkipQuickLootCheck.onCheckChange = function(self, checked)
-            UI.InfoBase.SkipQuickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), 1))
+        if modules.game_quickloot.QuickLoot.data.filter == 2 then
+            UI.InfoBase.quickLootCheck:setText("Loot when Quick Looting")
+        else
+            UI.InfoBase.quickLootCheck:setText('Skip when Quick Looting')
+        end
+        UI.InfoBase.quickLootCheck.onCheckChange = function(self, checked)
             if checked then
-                modules.game_quickloot.QuickLoot.addLootList(data:getId(), 1)
+                modules.game_quickloot.QuickLoot.addLootList(data:getId(), modules.game_quickloot.QuickLoot.data.filter)
             else
-                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 1)
+                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), modules.game_quickloot.QuickLoot.data.filter)
             end
         end
+        UI.InfoBase.quickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), modules.game_quickloot.QuickLoot.data.filter))
 
-        UI.InfoBase.LootQuickLootCheck.onCheckChange = function(self, checked)
-            UI.InfoBase.LootQuickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), 2))
-            if checked then
-                modules.game_quickloot.QuickLoot.addLootList(data:getId(), 2)
-            else
-                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 2)
-            end
-        end
-
-         local buy, sell = Cyclopedia.formatSaleData(internalData:getNpcSaleData())
+        local buy, sell = Cyclopedia.formatSaleData(internalData:getNpcSaleData())
         local sellColor = "#484848"
 
         for index, value in ipairs(sell) do

--- a/modules/game_cyclopedia/tab/items/items.otui
+++ b/modules/game_cyclopedia/tab/items/items.otui
@@ -432,6 +432,14 @@ UIWidget
       !text: tr('Skip when Quick Looting')
 
       text-auto-resize: true
+    CheckBox
+      id: LootQuickLootCheck
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      margin-bottom: 35
+      !text: tr('Loot when Quick Looting')
+
+      text-auto-resize: true
 
   Button
     id: ManageButton

--- a/modules/game_cyclopedia/tab/items/items.otui
+++ b/modules/game_cyclopedia/tab/items/items.otui
@@ -425,21 +425,17 @@ UIWidget
       !text: tr('Track drops of this item')
       text-auto-resize: true
     CheckBox
-      id: SkipQuickLootCheck
+      id: quickLootCheck
       anchors.right: parent.right
       anchors.bottom: parent.bottom
       margin-bottom: 35
-      !text: tr('Skip when Quick Looting')
-
       text-auto-resize: true
-    CheckBox
-      id: LootQuickLootCheck
-      anchors.right: parent.right
-      anchors.bottom: parent.bottom
-      margin-bottom: 35
-      !text: tr('Loot when Quick Looting')
-
-      text-auto-resize: true
+      @onSetup: |
+        if modules.game_quickloot.QuickLoot.data.filter == 2 then
+          self:setText("Loot when Quick Looting")
+        else
+          self:setText('Skip when Quick Looting')
+        end
 
   Button
     id: ManageButton

--- a/modules/game_quickloot/quickloot.lua
+++ b/modules/game_quickloot/quickloot.lua
@@ -421,6 +421,9 @@ function QuickLoot.Define()
         end
         QuickLoot.show()
         QuickLoot.loadFilterItems()
+        if QuickLoot.data.filter == 2 and not quickLootController.ui.filters.accepted:isChecked() then
+            quickLootController.ui.filters.accepted:onClick()
+        end
     end
 
     function QuickLoot.show()


### PR DESCRIPTION
# Description

Checkbox for adding to quick loot accepted list in cyclopedia items tab

## Behavior
![image](https://github.com/user-attachments/assets/1cf0a63d-95b5-4249-86b7-7821ac8157a0)

## Type of change
  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested
  - [X] Skip when Quick Looting Test
 1. Manage Loot Containers 
 2. Select 'Skipped Loot' filter
 3. Click 'ADD TO SKIPPED LOOT LIST' button
 4. Select an item from cyclopedia list
 5. Checkbox 'Skip when Quick Looting' is present
  - [X] Loot when Quick Looting Test
 1. Manage Loot Containers 
 2. Select 'Accepted Loot' filter
 3. Click 'ADD TO ACCEPTED LOOT LIST' button
 4. Select an item from cyclopedia list
 5. Checkbox 'Loot when Quick Looting' is present

**Test Configuration**:
  - Server Version: Canary
  - Client: OTC Redemption
  - Operating System: Windows 10

## Checklist
  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
