### PR TITLE
fix: concoction cyclopedia

### DIFF
--- a/modules/game_cyclopedia/tab/character/character.lua
+++ b/modules/game_cyclopedia/tab/character/character.lua
@@ -592,7 +592,7 @@ function Cyclopedia.loadCharacterCombatStats(data, mitigation, additionalSkillsA
     end
     UI.CombatStats.reductionNone:destroyChildren()
 
-    if  (next(combatsArray) == nil) then
+    if (next(combatsArray) == nil) then
         UI.CombatStats.reductionNone:setVisible(true)
     else
         UI.CombatStats.reductionNone:setVisible(true)
@@ -628,6 +628,22 @@ function Cyclopedia.loadCharacterCombatStats(data, mitigation, additionalSkillsA
                 widget.name:setText(element.id)
             end
             widget:setMarginLeft(13)
+        end
+    end
+
+    -- concoctions
+    UI.CombatStats.concoctionPanel:destroyChildren()
+    if concoctionsArray or next(concoctionsArray) ~= nil then
+        for i = 1, #concoctionsArray do
+            local widget = g_ui.createWidget("CharacterGridItem", UI.CombatStats.concoctionPanel)
+            local itemId = concoctionsArray[i][1]
+            widget:setId("concoction_" .. itemId)
+            widget.item:setItemId(itemId)
+            widget.item:setVirtual(true)
+            local minutes = concoctionsArray[i][2] / 60
+            local itemName = widget.item:getItem():getMarketData().name
+            widget.item:setTooltip(string.format("%s: %.0f minutes", itemName, minutes))
+            widget.amount:setVisible(false)
         end
     end
 

--- a/modules/game_cyclopedia/tab/character/character.otui
+++ b/modules/game_cyclopedia/tab/character/character.otui
@@ -709,16 +709,37 @@ UIWidget
       anchors.top: reduction.bottom
       anchors.left: reduction.left
       anchors.right: separator.right
-
-      color: #f00303
-      background-color: #355d89
-      shader: Map - Party
       margin-left: 10
       margin-top: 10
       size: 232 233
       layout:
         type: verticalBox
         fit-children: true
+    HorizontalSeparator
+      anchors.top: prev.bottom
+      anchors.left: reduction.left
+      anchors.right: separator.right
+      margin-right: 10
+
+    CharacterSkillBase
+      id: concoction
+      anchors.top: prev.bottom
+      anchors.left: parent.left
+      anchors.right: separator.right
+      margin-top: 1
+      SkillNameLabel
+        !text: tr('Concoctions:')
+        color: #C0C0C0  
+    CharacterSkillBase
+      id: concoctionPanel
+      anchors.top: prev.bottom
+      anchors.left: parent.left
+      anchors.right: separator.right
+
+      layout:
+        type: grid
+        cell-size: 32 32
+        flow: true
 
     CharacterSkillBase
       id: criticalHit

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4367,7 +4367,7 @@ void ProtocolGame::parseCyclopediaCharacterInfo(const InputMessagePtr& msg)
             std::vector<std::tuple<uint16_t, uint16_t>> concoctionsArray;
 
             for (auto i = 0; i < concoctionsCount; ++i) {
-                const uint16_t concoctionFirst = msg->getU8();
+                const uint16_t concoctionFirst = msg->getU16();
                 const uint16_t concoctionSecond = msg->getU16();
                 concoctionsArray.emplace_back(concoctionFirst, concoctionSecond);
             }


### PR DESCRIPTION
# Description

fix packet error + UI display  concoctions

`/i 36736` in canary an check cyclopedia

## Behavior

### **Actual**

packet error + no information displayed

### **Expected**

![image](https://github.com/user-attachments/assets/c59ebbf3-47c4-46f9-973e-099b3d7fe1c9)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I didn't know that existed xd

`/i 36736`
check cyclopedia characters:

**Test Configuration**:

  - Server Version: 13.40
  - Client: this pr
  - Operating System: w11


