### PR TITLE
fix: packets parseTalk

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2348,13 +2348,14 @@ void ProtocolGame::parseMultiUseCooldown(const InputMessagePtr& msg)
 
 void ProtocolGame::parseTalk(const InputMessagePtr& msg)
 {
+    uint32_t statement = 0;
     if (g_game.getFeature(Otc::GameMessageStatements)) {
-        msg->getU32(); // channel statement guid
+        statement = msg->getU32(); // channel statement guid
     }
 
     const auto& name = g_game.formatCreatureName(msg->getString());
 
-    if (g_game.getClientVersion() >= 1281) {
+    if (statement > 0 && g_game.getClientVersion() >= 1281) {
         msg->getU8(); // suffix
     }
 


### PR DESCRIPTION
# Description


## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/2fbe94b2-c3b9-4e01-8016-ad2c0f199c9d)

### **Expected**

![image](https://github.com/user-attachments/assets/7539221a-50fe-4c76-8561-5b1514f6b856)

## Fixes

Discord

## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

![image](https://github.com/user-attachments/assets/7236d0d9-1b04-4fb4-8d8f-17d54202d262)

player:sendChannelMessage("","test", TALKTYPE_CHANNEL_O, 7)

```
ProtocolGame parse message exception (43 bytes, 20 unread, last opcode is 0xaa (170), prev opcode is 0xffffffff (-1), proto: 1340): InputMessage eof reached
ProtocolGame parse message exception (782 bytes, 756 unread, last opcode is 0xaa (170), prev opcode is 0xffffffff (-1), proto: 1340): InputMessage eof reached
```

**Test Configuration**:

  - Server Version: canary 13.40
  - Client: this pr 
  - Operating System: win 11
