### PR TITLE
fix: format loot console tab

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -151,13 +151,13 @@ function displayMessage(mode, text)
 
     if msgtype.consoleTab ~= nil and
         (msgtype.consoleOption == nil or modules.client_options.getOption(msgtype.consoleOption)) then
-        modules.game_console.addText(text, msgtype, tr(msgtype.consoleTab))
-        -- TODO move to game_console
-    end
-
-    if msgtype == MessageSettings.loot then
-        local coloredText = ItemsDatabase.setColorLootMessage(text)
-        modules.game_console.addText(coloredText, msgtype, tr("Server Log"))
+        if msgtype == MessageSettings.loot then
+            local lootColoredText = ItemsDatabase.setColorLootMessage(text)
+            modules.game_console.addText(lootColoredText, msgtype, tr("Server Log"))
+            modules.game_console.addText(lootColoredText, msgtype, tr(msgtype.consoleTab))
+        else
+            modules.game_console.addText(text, msgtype, tr(msgtype.consoleTab))
+        end
     end
 
     if msgtype.screenTarget then


### PR DESCRIPTION
# Description

If the server has a 'Loot' channel, the loot text is showing in its unformatted state.

## Behavior

### **Actual**
![image](https://github.com/user-attachments/assets/b6557217-c67d-4560-9266-030ffafefa4c)

### **Expected**

![image](https://github.com/user-attachments/assets/6c957d95-4a26-4520-a2e8-a4baccc809f3)

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [X] Open Loot channel and kill a monster

**Test Configuration**:

  - Server Version: Canary 13.4
  - Client: OTC Mehah
  - Operating System: Windows 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
