### PR TITLE
fix: bot chase targeting

### DIFF
--- a/mods/game_bot/functions/player.lua
+++ b/mods/game_bot/functions/player.lua
@@ -61,7 +61,7 @@ end
 context.changeOutfit = context.setOutfit
 context.setSpeed = function(value) context.player:setSpeed(value) end
 
-context.walk = function(dir) return modules.game_interface.smartWalk(dir) end
+context.walk = function(dir) return modules.game_walk.smartWalk(dir) end
 context.turn = function(dir) return g_game.turn(dir) end
 
 -- game releated

--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -127,7 +127,7 @@ local function addWalkEvent(dir, delay)
 end
 
 --- Initiates a smart walk in the given direction.
-local function smartWalk(dir)
+function smartWalk(dir)
     addWalkEvent(dir)
 end
 


### PR DESCRIPTION
# Description

Using chase for bot targets resulted in execution error
![image](https://github.com/user-attachments/assets/6fc21c9e-1a3b-429f-8fe2-495411b9b841)

## Behavior

### **Actual**

![image](https://github.com/user-attachments/assets/cc436784-5d18-4caa-ab4d-5072861c4708)

### **Expected**

Should chase target

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Add monster to targeting and enable chase

**Test Configuration**:

  - Server Version: Canary 13.40
  - Client: OTC Mehah
  - Operating System: Windows 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
