### PR TITLE
feat: cyclopedia back button

### DIFF
--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -18,6 +18,9 @@ local bosstiary = nil
 local bossSlot = nil
 local ButtonBossSlot = nil
 local ButtonBestiary = nil
+local tabStack = {}
+local previousType = nil
+local windowTypes = {}
 
 function toggle(defaultWindow)
     if not controllerCyclopedia.ui then
@@ -55,6 +58,17 @@ function controllerCyclopedia:onGameStart()
         character = buttonSelection:recursiveGetChildById('character')
         bosstiary = buttonSelection:recursiveGetChildById('bosstiary')
         bossSlot = buttonSelection:recursiveGetChildById('bossSlot')
+
+        windowTypes = {
+            items = { obj = items, func = showItems },
+            bestiary = { obj = bestiary, func = showBestiary },
+            charms = { obj = charms, func = showCharms },
+            map = { obj = map, func = showMap },
+            houses = { obj = houses, func = showHouse },
+            character = { obj = character, func = showCharacter },
+            bosstiary = { obj = bosstiary, func = showBosstiary },
+            bossSlot = { obj = bossSlot, func = showBossSlot }
+        }
 
         g_ui.importStyle("cyclopedia_widgets")
         g_ui.importStyle("cyclopedia_pages")
@@ -219,7 +233,19 @@ function hide()
     if not controllerCyclopedia.ui then
         return
     end
+    resetCyclopediaTabs()
     controllerCyclopedia.ui:hide()
+end
+
+function resetCyclopediaTabs()
+    tabStack = {}
+    controllerCyclopedia.ui.BackButton:setEnabled(false)
+    if previousType then
+        local previousWindow = windowTypes[previousType]
+        previousWindow.obj:enable()
+        previousWindow.obj:setOn(false)
+        previousType = nil;
+    end
 end
 
 function show(defaultWindow)
@@ -234,7 +260,6 @@ function show(defaultWindow)
     controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(g_game.getLocalPlayer():getResourceBalance(1)))
 end
 
-local tabStack = {}
 function toggleBack()
     local previousTab = table.remove(tabStack, #tabStack)
     if #tabStack < 1 then
@@ -244,17 +269,6 @@ function toggleBack()
 end
 
 function SelectWindow(type, isBackButtonPress)
-    local windowTypes = {
-        items = { obj = items, func = showItems },
-        bestiary = { obj = bestiary, func = showBestiary },
-        charms = { obj = charms, func = showCharms },
-        map = { obj = map, func = showMap },
-        houses = { obj = houses, func = showHouse },
-        character = { obj = character, func = showCharacter },
-        bosstiary = { obj = bosstiary, func = showBosstiary },
-        bossSlot = { obj = bossSlot, func = showBossSlot }
-    }
-
     if previousType then
         local previousWindow = windowTypes[previousType]
         previousWindow.obj:enable()

--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -280,23 +280,11 @@ function SelectWindow(type, isBackButtonPress)
 end
 
 function getBosstiary()
-    if not controllerCyclopedia.ui then
-        return
-    end
-    if controllerCyclopedia.ui:isVisible() then
-        return hide()
-    end
-    show()
+    toggle()
     SelectWindow("bosstiary")
 end
 
 function getBossSlot()
-    if not controllerCyclopedia.ui then
-        return
-    end
-    if controllerCyclopedia.ui:isVisible() then
-        return hide()
-    end
-    show()
+    toggle()
     SelectWindow("bossSlot")
 end

--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -236,7 +236,16 @@ function show()
     controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(g_game.getLocalPlayer():getResourceBalance(1)))
 end
 
-function SelectWindow(type)
+local tabStack = {}
+function toggleBack()
+    local previousTab = table.remove(tabStack, #tabStack)
+    if #tabStack < 1 then
+        controllerCyclopedia.ui.BackButton:setEnabled(false)
+    end
+    SelectWindow(previousTab, true)
+end
+
+function SelectWindow(type, isBackButtonPress)
     local windowTypes = {
         items = { obj = items, func = showItems },
         bestiary = { obj = bestiary, func = showBestiary },
@@ -249,8 +258,13 @@ function SelectWindow(type)
     }
 
     if previousType then
-        previousType.obj:enable()
-        previousType.obj:setOn(false)
+        local previousWindow = windowTypes[previousType]
+        previousWindow.obj:enable()
+        previousWindow.obj:setOn(false)
+        if not isBackButtonPress then
+            table.insert(tabStack, previousType)
+            controllerCyclopedia.ui.BackButton:setEnabled(true)
+        end
     end
     contentContainer:destroyChildren()
 
@@ -258,7 +272,7 @@ function SelectWindow(type)
     if window then
         window.obj:setOn(true)
         window.obj:disable()
-        previousType = window
+        previousType = type
         if window.func then
             window.func(contentContainer)
         end

--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -19,14 +19,14 @@ local bossSlot = nil
 local ButtonBossSlot = nil
 local ButtonBestiary = nil
 
-function toggle()
+function toggle(defaultWindow)
     if not controllerCyclopedia.ui then
         return
     end
     if controllerCyclopedia.ui:isVisible() then
         return hide()
     end
-    show()
+    show(defaultWindow)
 end
 
 controllerCyclopedia = Controller:new()
@@ -38,12 +38,12 @@ end
 function controllerCyclopedia:onGameStart()
     if g_game.getClientVersion() >= 1310 then
         CyclopediaButton = modules.game_mainpanel.addToggleButton('CyclopediaButton', tr('Cyclopedia'),
-            '/images/options/cooldowns', toggle, false, 7)
+            '/images/options/cooldowns', function() toggle("items") end, false, 7)
         ButtonBossSlot = modules.game_mainpanel.addToggleButton("bossSlot", tr("Open Boss Slots dialog"),
-            "/images/options/ButtonBossSlot", getBossSlot, false, 20)
+            "/images/options/ButtonBossSlot", function() toggle("bossSlot") end, false, 20)
         CyclopediaButton:setOn(false)
         ButtonBestiary = modules.game_mainpanel.addToggleButton("bosstiary", tr("Open Bosstiary dialog"),
-            "/images/options/ButtonBosstiary", getBosstiary, false, 17)
+            "/images/options/ButtonBosstiary", function() toggle("bosstiary") end, false, 17)
 
         contentContainer = controllerCyclopedia.ui:recursiveGetChildById('contentContainer')
         buttonSelection = controllerCyclopedia.ui:recursiveGetChildById('buttonSelection')
@@ -114,8 +114,7 @@ function controllerCyclopedia:onGameStart()
         end
 
         trackerMiniWindow.cyclopediaButton.onClick = function(widget, mousePos, mouseButton)
-            toggle()
-            SelectWindow("bestiary")
+            toggle("bestiary")
             return true
         end
 
@@ -155,8 +154,7 @@ function controllerCyclopedia:onGameStart()
 
         trackerMiniWindowBosstiary.cyclopediaButton.onClick =
             function(widget, mousePos, mouseButton)
-                toggle()
-                SelectWindow("bosstiary")
+                toggle("bosstiary")
                 return true
             end
 
@@ -224,7 +222,7 @@ function hide()
     controllerCyclopedia.ui:hide()
 end
 
-function show()
+function show(defaultWindow)
     if not controllerCyclopedia.ui or not CyclopediaButton then
         return
     end
@@ -232,7 +230,7 @@ function show()
     controllerCyclopedia.ui:show()
     controllerCyclopedia.ui:raise()
     controllerCyclopedia.ui:focus()
-    SelectWindow("items")
+    SelectWindow(defaultWindow, false)
     controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(g_game.getLocalPlayer():getResourceBalance(1)))
 end
 
@@ -277,14 +275,4 @@ function SelectWindow(type, isBackButtonPress)
             window.func(contentContainer)
         end
     end
-end
-
-function getBosstiary()
-    toggle()
-    SelectWindow("bosstiary")
-end
-
-function getBossSlot()
-    toggle()
-    SelectWindow("bossSlot")
 end

--- a/modules/game_cyclopedia/game_cyclopedia.otui
+++ b/modules/game_cyclopedia/game_cyclopedia.otui
@@ -226,6 +226,8 @@ MainWindow
     //font: verdana-bold-8px-antialiased
     text-offset: 0 -1
     color: #C0C0C0
+    enabled: false
+    @onClick: toggleBack()
   HorizontalSeparator
     id: BottomSep
     anchors.bottom: CloseButton.top


### PR DESCRIPTION
# Description

Added logic for cyclopedia back button to cycle through previous tab history
![image](https://github.com/user-attachments/assets/39285880-fa68-42e3-a09b-3749d63ef77a)

## Behavior

### **Actual**

Currently back button does nothing

### **Expected**

Back button should iterate through tab history LIFO

## Type of change

Please delete options that are not relevant.

  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Click through various tabs to add to stack and then use back button to cycle through history

**Test Configuration**:

  - Server Version: Canary 13.40
  - Client: OTC Redemption
  - Operating System: Windows 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
