### PR TITLE
Fix item duplication on containers with more items than cap

### DIFF
--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -45,15 +45,21 @@ void Container::onAddItem(const ItemPtr& item, int slot)
 {
     slot -= m_firstIndex;
 
-    ++m_size;
+
     // indicates that there is a new item on next page
     if (m_hasPages && slot > m_capacity) {
-        callLuaField("onSizeChange", m_size);
+        callLuaField("onSizeChange", ++m_size);
         return;
     }
 
-    m_items.insert(m_items.begin() + slot, item);
+    if (m_items.size() == m_capacity) {
+        onRemoveItem(m_firstIndex + m_capacity - 1, nullptr);
+        ++m_size;
+    }
 
+    m_items.insert(m_items.begin() + slot, item);
+    ++m_size;
+    
     updateItemsPositions();
 
     callLuaField("onSizeChange", m_size);
@@ -93,9 +99,11 @@ void Container::onUpdateItem(int slot, const ItemPtr& item)
 void Container::onRemoveItem(int slot, const ItemPtr& lastItem)
 {
     slot -= m_firstIndex;
+
+    
+    // indicates that there has been deleted an item on next page
     if (m_hasPages && slot >= static_cast<int>(m_items.size())) {
-        --m_size;
-        callLuaField("onSizeChange", m_size);
+        callLuaField("onSizeChange", --m_size);
         return;
     }
 

--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -45,7 +45,6 @@ void Container::onAddItem(const ItemPtr& item, int slot)
 {
     slot -= m_firstIndex;
 
-
     // indicates that there is a new item on next page
     if (m_hasPages && slot > m_capacity) {
         callLuaField("onSizeChange", ++m_size);
@@ -100,7 +99,6 @@ void Container::onRemoveItem(int slot, const ItemPtr& lastItem)
 {
     slot -= m_firstIndex;
 
-    
     // indicates that there has been deleted an item on next page
     if (m_hasPages && slot >= static_cast<int>(m_items.size())) {
         callLuaField("onSizeChange", --m_size);


### PR DESCRIPTION
# Description

If there is a container without pagination and more items than its capacity, the last item is duplicated when removing items.  This commit fixes it and also make Container::addItem more symmetric with Container::removeItem.


## Behavior

### **Actual**
Add more items to a container than its capacity. Different items to see better the difference.
Remove any of them until when you would had an empty space, but there will be no empty space, just a duplicated last item.
![image](https://github.com/user-attachments/assets/243a445b-2f43-467c-b669-b876c323a07b)

### **Expected**
Only one last item (skull staff)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)