### PR TITLE
improve: Encryption

### DIFF
--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -237,7 +237,6 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
         std::replace(path.begin(), path.end(), '\\', '/');
         if (path.compare(0, 5, std::string(AY_OBFUSCATE("/bot/"))) == 0) {
             if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
-                g_logger.warning(fullPath);
                 return buffer;
             }
             return "";

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -233,12 +233,16 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
         buffer = buffer.substr(headerSize);
         buffer = decrypt(buffer);
     } else {
-        if (fullPath.find(std::string(AY_OBFUSCATE("/bot/"))) != std::string::npos) {
+        std::string path = fullPath;
+        std::replace(path.begin(), path.end(), '\\', '/');
+        if (path.compare(0, 5, std::string(AY_OBFUSCATE("/bot/"))) == 0) {
             if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
+                g_logger.warning(fullPath);
                 return buffer;
             }
             return "";
         }
+        buffer = "";
     }
 #endif
 


### PR DESCRIPTION

It just fixes the consideration of the absolute bots directory for "customs" and does not consider other directories just because it has "bot" in the string and also fixes a bug, where it was possible to read decrypted files even when encryption was enabled.