### PR TITLE
fix: build workflows

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -51,7 +51,7 @@ jobs:
           vcpkgGitCommitId: ${{ steps.vcpkg-step.outputs.vcpkgGitCommitId }}
 
       - name: Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.31.6
 
       - name: Cache CMake build directory
         uses: actions/cache@v4

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -55,7 +55,7 @@ jobs:
           vcpkgJsonIgnores: "['**/vcpkg/**', '**/browser/overlay-ports/**']"
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@main
+        uses: lukka/get-cmake@v3.31.6
 
       - name: Run CMake
         uses: lukka/run-cmake@main

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,7 @@ jobs:
           vcpkgJsonIgnores: "['**/vcpkg/**', '**/browser/overlay-ports/**']"
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@main
+        uses: lukka/get-cmake@v3.31.6
 
       - name: Run CMake
         uses: lukka/run-cmake@main


### PR DESCRIPTION
# Description

Updates the workflows to use cmake v3.31.6, as v4+ is currently causing issues with vcpkg.
We might need to revisit this if vcpkg updates.