### PR TITLE
fix: compact stats bar dimension

### DIFF
--- a/data/styles/30-statsbar.otui
+++ b/data/styles/30-statsbar.otui
@@ -477,7 +477,7 @@ TopStatsBarCompactOnTop < UIWidget
     anchors.top: parent.top
     anchors.horizontalCenter: parent.horizontalCenter
     margin-top: 5
-    size: 53 14
+    size: 103 14
     layout:
       type: horizontalBox
 
@@ -1047,7 +1047,7 @@ TopStatsBarCompactOnBottom < UIWidget
     anchors.horizontalCenter: parent.horizontalCenter
     achors.bottom: paren.bottom
     margin-top: 8
-    size: 53 14
+    size: 103 14
     layout:
       type: horizontalBox
 

--- a/modules/game_interface/widgets/statsbar.lua
+++ b/modules/game_interface/widgets/statsbar.lua
@@ -258,8 +258,6 @@ local function loadIcon(bitChanged, content, topmenu)
     end
     icon:setTooltip(tooltip)
     icon:setImageSize(tosize("9 9"))
-    icon:setMarginLeft(1)
-    icon:setMarginRight(-2)
     if topmenu then
         icon:setMarginTop(5)
         icon:setMarginLeft(2)


### PR DESCRIPTION
Should be the same as default dimensions, like rl tibia