### PR TITLE
fix: vBot targeting in versions lower than 910

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3425,10 +3425,13 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type) cons
             uint8_t creatureType;
             if (g_game.getClientVersion() >= 910) {
                 creatureType = msg->getU8();
-            } else if (id >= Proto::PlayerStartId && id < Proto::PlayerEndId) {
-                creatureType = Proto::CreatureTypePlayer;
             } else {
-                creatureType = Proto::CreatureTypeNpc;
+                if (id >= Proto::PlayerStartId && id < Proto::PlayerEndId)
+                    creatureType = Proto::CreatureTypePlayer;
+                else if (id >= Proto::MonsterStartId && id < Proto::MonsterEndId)
+                    creatureType = Proto::CreatureTypeMonster;
+                else
+                    creatureType = Proto::CreatureTypeNpc;
             }
 
             uint32_t masterId = 0;


### PR DESCRIPTION
The client assumes by default that all creatures that are not players will be NPCs. This affects vBot because, if they are NPCs, vbot are not considered target candidates.
(only applies to versions lower than 910)

https://github.com/mehah/otclient/blob/ab7d912d80535c0b923a7d1570563d0469772484/src/client/protocolgameparse.cpp#L3425-L3432

## vbot 
In this if condition, the creature will always be an **NPC** and **never a monster** (on servers running versions lower than 910.)
 
https://github.com/mehah/otclient/blob/ab7d912d80535c0b923a7d1570563d0469772484/mods/game_bot/default_configs/vBot_4.8/targetbot/target.lua#L61-L62

![image](https://github.com/user-attachments/assets/4f39de3f-83e2-4809-a0c9-208f0c040d46)

![image](https://github.com/user-attachments/assets/96cb4d86-6488-4962-941a-80078fe8138b)
![image](https://github.com/user-attachments/assets/3c0a4684-2cff-4a97-819b-407c808a2654)

# 8.6
### main repo 
is "waiting", because vbot thinks monsters are npc.
![image](https://github.com/user-attachments/assets/0fdb5209-0049-4475-8989-7398ec11c1e6)

### this pr
![image](https://github.com/user-attachments/assets/a9ea73d1-baf0-4192-b471-5741ff4be423)
