### PR TITLE
fix: #1060 event after an onDragLeave in a UIMiniWindow

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -249,6 +249,7 @@ function UIMiniWindow:onDragLeave(droppedWidget, mousePos)
             self.movedWidget = nil
         end
     end
+    return true
 end
 
 function UIMiniWindow:onDragMove(mousePos, mouseMoved)


### PR DESCRIPTION
# POSIBLE FIX



main repo
![antes](https://github.com/user-attachments/assets/a439bac1-6f05-46dc-9445-f8ef0696e513)

this pr
![despoues](https://github.com/user-attachments/assets/4ab44fb9-0a7d-4f8f-9bd9-04c205f58a81)


https://github.com/mehah/otclient/issues/1060