### PR TITLE
rollback: prepareTextureLoad when loading .dat / .spr #1022

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -534,7 +534,6 @@ void ThingType::unserialize(const uint16_t clientId, const ThingCategory categor
             }
         }
         if (hasDifferentSizes) {
-            g_logger.warning("[{}] g_game.getLocalPlayer():setOutfit({{type={}}})", __FUNCTION__, m_id);
             for (const auto& s : sizes) {
                 m_size.setWidth(std::max<int>(m_size.width(), s.width()));
                 m_size.setHeight(std::max<int>(m_size.height(), s.height()));


### PR DESCRIPTION
Someone reached out to me because they encountered this error  in main repo while using this.

downgrade 15x ( .spr/ .dat ) to 8.6

https://github.com/Levi999x/15.x-with-8.60
https://otland.net/threads/15-x-assest-downgraded-to-8-60-dat-spr-with-all-8-60-sprites-outfits-items-effects.291864



## Main Repo
https://github.com/user-attachments/assets/488fd8b3-1458-4a28-878a-38e51fe71887
### Cause of bug
example id 386
idle/stand **32 x 32**
![image](https://github.com/user-attachments/assets/40574598-347f-4ad6-8bfe-60e2fd01fd5f)
walking change to **64 x64** 
![image](https://github.com/user-attachments/assets/875adb2d-1dee-4f3d-a2d0-fe5c403ddb95)

## This pr
https://github.com/user-attachments/assets/3226317a-bcf7-49f4-9748-66e7422b67ed

## Note 1
This only affects the old .dat and .spr system, not the new Tibia 13+ system (also known as assets, appearance, or protobuf).

Additionally, it only has an impact if the size difference between idle and walking animations exists. A print statement is used to detect and test these cases.

in the specific case of the repository downgrade15-> 8.6

```lua
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=386})
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=552})
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=553})
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=615})
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=976})
WARNING: [ThingType::unserialize] g_game.getLocalPlayer():setOutfit({type=1029})

```


## Note 2
Nekiro was the last to modify ThingType::unserialize. While he was fixing this same error for the assets system, he removed prepareTextureLoad, which previously resolved these issues in .dat and .spr.

The problem was reported....

but this error does not occur by default in the original .dat and .spr files from cipsoft.

for me the problem is in object builder, I think they are bad adaptations of .dat, because they would break the cipsoft client, but people will start to say “in v8 it works”.


------------

Since a long time has passed since the issue, I propose a rollback.
If Nekiro finds another solution, he can modify this PR as long as it remains open.

## Fixes

#1022