### PR TITLE
fix: Unload appearances before loading a new appearance from another version.

### DIFF
--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -148,6 +148,7 @@ bool ThingTypeManager::loadOtml(std::string file)
 bool ThingTypeManager::loadAppearances(const std::string& file)
 {
     try {
+        g_spriteAppearances.unload();
         int spritesCount = 0;
         std::string appearancesFile;
 


### PR DESCRIPTION
I was testing something in several versions and found this bug

## main repo
https://github.com/user-attachments/assets/a55005b7-f6c1-4a9a-9a5f-0b726b29be98

## this pr
https://github.com/user-attachments/assets/c16498ef-efb4-44ba-b74e-8a06221d2702

## how to play, 

select a version that uses protobuf , e.g. 13.10
load the assets with the ok button, in  client_entergame module

-------

go back to client_entergame module
select 13.40
load assets with ok button and bug
![image](https://github.com/user-attachments/assets/7e891551-ad97-4b4e-a83a-95e0803f095d)

![image](https://github.com/user-attachments/assets/7fd6e5cf-d1e9-4cd6-93ab-f30fc9e591f2)
