### PR TITLE
fix: "Show Expiry In Inventory" typo

### DIFF
--- a/modules/client_options/styles/interface/interface.otui
+++ b/modules/client_options/styles/interface/interface.otui
@@ -123,7 +123,7 @@ UIWidget
       id: showExpiryInInvetory
       anchors.top: frames.bottom
       margin-top: 5
-      !text: tr('Show Expiry In Invetory')
+      !text: tr('Show Expiry In Inventory')
       !tooltip: tr('Check this box to see how much time or how many charges are left \non your equipped items')
 
     OptionCheckBoxMarked


### PR DESCRIPTION
# Description

Fixed "Show Expiry In Invetory" typo


## Behavior

### **Actual**

There is a typo in "Show Expiry In Invetory" sentence
![image](https://github.com/user-attachments/assets/0c3fe7e4-40a5-419f-a2ed-e56c492126d4)
### **Expected**

 "Show Expiry In Inventory" 

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
