### PR TITLE
fix: Loading textures without transparency in DirectX

### DIFF
--- a/src/framework/graphics/texture.cpp
+++ b/src/framework/graphics/texture.cpp
@@ -223,12 +223,15 @@ void Texture::setupPixels(const int level, const Size& size, const uint8_t* pixe
 ) const
 {
     GLenum format = 0;
+    GLenum internalFormat = GL_R8;
     switch (channels) {
         case 4:
             format = GL_RGBA;
+            internalFormat = GL_RGBA;
             break;
         case 3:
             format = GL_RGB;
+            internalFormat = GL_RGB;
             break;
         case 2:
             format = GL_LUMINANCE_ALPHA;
@@ -237,8 +240,6 @@ void Texture::setupPixels(const int level, const Size& size, const uint8_t* pixe
             format = GL_LUMINANCE;
             break;
     }
-
-    GLenum internalFormat = GL_RGBA;
 
 #ifdef OPENGL_ES
     //TODO


### PR DESCRIPTION
# Description

Loading non-transparent textures (so 3 or less channels) doesn't work with DirectX, this will fix it by adjusting internal format value based on channels.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
