### PR TITLE
improve: refactor `things.lua` to Controller System and add feature fallback logic for `loadDat`

### DIFF
--- a/modules/game_things/things.lua
+++ b/modules/game_things/things.lua
@@ -28,6 +28,7 @@ local function tryLoadDatWithFallbacks(datPath)
         { 1, 2, 3 }
     }
 
+    g_logger.setLevel(5)
     for _, combo in ipairs(combinations) do
         for _, idx in ipairs(combo) do
             g_game.enableFeature(featureFlags[idx])
@@ -37,6 +38,7 @@ local function tryLoadDatWithFallbacks(datPath)
             return true
         end
     end
+    g_logger.setLevel(1)
 
     return false
 end

--- a/modules/game_things/things.lua
+++ b/modules/game_things/things.lua
@@ -1,17 +1,7 @@
-filename = nil
-loaded = false
+ThingsLoaderController = Controller:new()
 
-function init()
-    connect(g_game, {
-        onClientVersionChange = load
-    })
-end
-
-function terminate()
-    disconnect(g_game, {
-        onClientVersionChange = load
-    })
-end
+local filename = nil
+local loaded = false
 
 function setFileName(name)
     filename = name
@@ -21,7 +11,37 @@ function isLoaded()
     return loaded
 end
 
-function load(version)
+local function tryLoadDatWithFallbacks(datPath)
+    if g_things.loadDat(datPath) then
+        return true
+    end
+
+    local featureFlags = {
+        GameSpritesU32,
+        GameEnhancedAnimations,
+        GameIdleAnimations
+    }
+
+    local combinations = {
+        { 1 }, { 2 }, { 3 },
+        { 1, 2 }, { 1, 3 }, { 2, 3 },
+        { 1, 2, 3 }
+    }
+
+    for _, combo in ipairs(combinations) do
+        for _, idx in ipairs(combo) do
+            g_game.enableFeature(featureFlags[idx])
+        end
+
+        if g_things.loadDat(datPath) then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function load(version)
     local errorList = {}
 
     if version >= 1281 and not g_game.getFeature(GameLoadSprInsteadProtobuf) then
@@ -42,16 +62,18 @@ function load(version)
             sprPath = resolvepath('/data/things/' .. version .. '/Tibia')
         end
 
-        if not g_things.loadDat(datPath) then
+        if not tryLoadDatWithFallbacks(datPath) then
             errorList[#errorList + 1] = tr('Unable to load dat file, please place a valid dat in \'%s.dat\'', datPath)
         end
+
         if not g_sprites.loadSpr(sprPath) then
             errorList[#errorList + 1] = tr('Unable to load spr file, please place a valid spr in \'%s.spr\'', sprPath)
         end
         if g_game.getFeature(GameLoadSprInsteadProtobuf) and version >= 1281 then
             local staticPath = resolvepath(string.format('/things/%d/appearances', version))
             if not g_things.loadAppearances(staticPath) then
-                g_logger.warning(string.format("[game_things.load()] Couldn't load /things/%d/appearances.dat, possible packets error.", version))
+                g_logger.warning(string.format(
+                    "[game_things.load()] Couldn't load /things/%d/appearances.dat, possible packets error.", version))
             end
         end
     end
@@ -65,19 +87,18 @@ function load(version)
         return
     end
 
-    -- loading client files failed, show an error
     local messageBox = displayErrorBox(tr('Error'), table.concat(errorList, "\n"))
     addEvent(function()
         messageBox:raise()
         messageBox:focus()
     end)
 
-    disconnect(g_game, {
-        onClientVersionChange = load
-    })
     g_game.setClientVersion(0)
     g_game.setProtocolVersion(0)
-    connect(g_game, {
+end
+
+function ThingsLoaderController:onInit()
+    self:registerEvents(g_game, {
         onClientVersionChange = load
     })
 end

--- a/modules/game_things/things.lua
+++ b/modules/game_things/things.lua
@@ -28,7 +28,6 @@ local function tryLoadDatWithFallbacks(datPath)
         { 1, 2, 3 }
     }
 
-    g_logger.setLevel(5)
     for _, combo in ipairs(combinations) do
         for _, idx in ipairs(combo) do
             g_game.enableFeature(featureFlags[idx])
@@ -38,7 +37,6 @@ local function tryLoadDatWithFallbacks(datPath)
             return true
         end
     end
-    g_logger.setLevel(1)
 
     return false
 end
@@ -64,9 +62,11 @@ local function load(version)
             sprPath = resolvepath('/data/things/' .. version .. '/Tibia')
         end
 
+        g_logger.setLevel(5)
         if not tryLoadDatWithFallbacks(datPath) then
             errorList[#errorList + 1] = tr('Unable to load dat file, please place a valid dat in \'%s.dat\'', datPath)
         end
+        g_logger.setLevel(1)
 
         if not g_sprites.loadSpr(sprPath) then
             errorList[#errorList + 1] = tr('Unable to load spr file, please place a valid spr in \'%s.spr\'', sprPath)

--- a/modules/game_things/things.otmod
+++ b/modules/game_things/things.otmod
@@ -4,5 +4,5 @@ Module
   reloadable: false
   sandboxed: true
   scripts: [things]
-  @onLoad: init()
-  @onUnload: terminate()
+  @onLoad: ThingsLoaderController:init()
+  @onUnload: ThingsLoaderController:terminate()


### PR DESCRIPTION
### Summary

This pull request introduces two major improvements to the `things.lua` module:

---

### 1. Controller System Refactor

The script is now structured using the OTClient Controller System by Mehah.

#### 🔄 Changes:
- Replaces global `init()` / `terminate()` with `ThingsLoaderController:onInit()` and `:onTerminate()`.
- Uses `self:registerEvents(...)` to automatically manage event connections and disconnections.
- Improves code modularity and readability.

## ⚙️ Add Fallback Logic for `loadDat` with Dynamic Feature Combinations

### Overview

This update improves the robustness of the asset loading system by adding automatic fallback logic when loading the `.dat` file fails. The loader will now attempt to enable various combinations of client features required for proper `.dat` parsing in newer client versions.

---

### 🔁 Fallback Strategy

If the first attempt to load the `.dat` file using `g_things.loadDat(path)` fails, the system retries using combinations of the following features:

- `GameSpritesU32`
- `GameEnhancedAnimations`
- `GameIdleAnimations`

#### Attempt Order:
1. **No features**
2. **Single features** (each one individually)
3. **Pairs of features**
4. **All three features together**

This ensures broad compatibility across different OTClient setups, especially for custom or newer client versions.
