### PR TITLE
fix: game_actionbar send text to current channel tab

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -693,7 +693,11 @@ function setupHotkeys()
                 end
             elseif slot.text then
                 if slot.autoSend then
-                    g_game.talk(slot.text)
+                    if not modules.game_console.isChatEnabled() then
+                        g_game.talk(slot.text)
+                    else
+                        modules.game_console.sendMessage(slot.text)
+                    end
                 else
                     if not modules.game_console.isChatEnabled() then
                         modules.game_console.switchChatOnCall()


### PR DESCRIPTION

## Behavior

### **Actual**

always send to local chat

### **Expected**

send text to the channel you are currently on

## Fixes

<img width="815" height="283" alt="image" src="https://github.com/user-attachments/assets/0de2528e-0279-4fc1-a939-88b3ce054eca" />

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested


  - [ ] Test A

https://github.com/user-attachments/assets/fed9c99f-0e6a-4ddb-b6fc-b288abdee2b6


  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
