### PR TITLE
Implement texture atlas

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -386,6 +386,7 @@ if (TOGGLE_FRAMEWORK_GRAPHICS)
           framework/graphics/shader.cpp
           framework/graphics/shaderprogram.cpp
           framework/graphics/texture.cpp
+          framework/graphics/textureatlas.cpp
           framework/graphics/texturemanager.cpp
           framework/graphics/shadermanager.cpp
           framework/platform/win32window.cpp

--- a/src/framework/graphics/drawpoolmanager.cpp
+++ b/src/framework/graphics/drawpoolmanager.cpp
@@ -92,9 +92,13 @@ void DrawPoolManager::addTexturedRect(const Rect& dest, const TexturePtr& textur
         return;
     }
 
+    Rect s = src;
+    if (texture && texture->isInAtlas())
+        s.translate(texture->getAtlasRect().topLeft());
+
     getCurrentPool()->add(color, texture, DrawPool::DrawMethod{
         .type = DrawPool::DrawMethodType::RECT,
-        .dest = dest, .src = src
+        .dest = dest, .src = s
     }, condutor);
 }
 
@@ -105,9 +109,13 @@ void DrawPoolManager::addUpsideDownTexturedRect(const Rect& dest, const TextureP
         return;
     }
 
+    Rect s = src;
+    if (texture && texture->isInAtlas())
+        s.translate(texture->getAtlasRect().topLeft());
+
     getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ .type = DrawPool::DrawMethodType::UPSIDEDOWN_RECT, .dest =
                               dest,
-                              .src = src
+                              .src = s
                           }, condutor);
 }
 
@@ -118,9 +126,13 @@ void DrawPoolManager::addTexturedRepeatedRect(const Rect& dest, const TexturePtr
         return;
     }
 
+    Rect s = src;
+    if (texture && texture->isInAtlas())
+        s.translate(texture->getAtlasRect().topLeft());
+
     getCurrentPool()->add(color, texture, DrawPool::DrawMethod{ .type = DrawPool::DrawMethodType::REPEATED_RECT, .dest =
                               dest,
-                              .src = src
+                              .src = s
                           }, condutor);
 }
 

--- a/src/framework/graphics/texture.cpp
+++ b/src/framework/graphics/texture.cpp
@@ -162,6 +162,9 @@ void Texture::createTexture()
     assert(m_id != 0);
 
     generateHash();
+
+    if (m_image)
+        g_textures.addToAtlas(shared_from_this());
 }
 
 bool Texture::setupSize(const Size& size)

--- a/src/framework/graphics/texture.h
+++ b/src/framework/graphics/texture.h
@@ -24,8 +24,10 @@
 
 #include "declarations.h"
 #include <framework/core/timer.h>
+#include <framework/util/rect.h>
+#include <memory>
 
-class Texture
+class Texture : public std::enable_shared_from_this<Texture>
 {
 public:
     Texture();
@@ -64,6 +66,9 @@ public:
     virtual bool isAnimatedTexture() const { return false; }
     bool setupSize(const Size& size);
 
+    bool isInAtlas() const { return m_inAtlas; }
+    const Rect& getAtlasRect() const { return m_atlasRect; }
+
 protected:
     void bind();
     void setupWrap() const;
@@ -101,6 +106,10 @@ protected:
     void setProp(const Prop prop, const bool v) { if (v) m_props |= prop; else m_props &= ~prop; }
     bool getProp(const Prop prop) const { return m_props & prop; };
 
+    bool m_inAtlas{ false };
+    Rect m_atlasRect;
+
     friend class GarbageCollection;
     friend class TextureManager;
+    friend class TextureAtlas;
 };

--- a/src/framework/graphics/textureatlas.cpp
+++ b/src/framework/graphics/textureatlas.cpp
@@ -1,0 +1,41 @@
+#include "textureatlas.h"
+#include "graphics.h"
+
+TextureAtlas::TextureAtlas(const Size& size) : m_size(size)
+{
+    m_texture = std::make_shared<Texture>(size);
+    m_texture->setSmooth(true);
+}
+
+bool TextureAtlas::addTexture(const TexturePtr& texture, Rect& atlasRect)
+{
+    if (!texture || !texture->m_image)
+        return false;
+
+    const Size& size = texture->m_image->getSize();
+
+    if (size.width() > m_size.width() || size.height() > m_size.height())
+        return false;
+
+    if (m_nextPos.x + size.width() > m_size.width()) {
+        m_nextPos.x = 0;
+        m_nextPos.y += m_rowHeight;
+        m_rowHeight = 0;
+    }
+
+    if (m_nextPos.y + size.height() > m_size.height())
+        return false;
+
+    atlasRect = Rect(m_nextPos, size);
+    m_nextPos.x += size.width();
+    m_rowHeight = std::max(m_rowHeight, size.height());
+
+    m_texture->bind();
+    glTexSubImage2D(GL_TEXTURE_2D, 0, atlasRect.x(), atlasRect.y(), size.width(), size.height(), GL_RGBA, GL_UNSIGNED_BYTE, texture->m_image->getPixelData());
+
+    texture->m_inAtlas = true;
+    texture->m_atlasRect = atlasRect;
+
+    return true;
+}
+

--- a/src/framework/graphics/textureatlas.h
+++ b/src/framework/graphics/textureatlas.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "texture.h"
+#include <framework/util/rect.h>
+
+class TextureAtlas
+{
+public:
+    explicit TextureAtlas(const Size& size = {2048, 2048});
+
+    bool addTexture(const TexturePtr& texture, Rect& atlasRect);
+
+    TexturePtr getAtlasTexture() const { return m_texture; }
+
+private:
+    TexturePtr m_texture;
+    Size m_size;
+    Point m_nextPos{0,0};
+    int m_rowHeight{0};
+};
+

--- a/src/framework/graphics/texturemanager.h
+++ b/src/framework/graphics/texturemanager.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "texture.h"
+#include "textureatlas.h"
 #include <framework/core/declarations.h>
 
 class TextureManager
@@ -43,12 +44,18 @@ public:
     const Matrix3* getMatrixById(uint16_t id);
     uint16_t getMatrixId(const Size& size, bool upsidedown);
 
+    TexturePtr getAtlasTexture() { return m_atlas.getAtlasTexture(); }
+    bool addToAtlas(const TexturePtr& texture, Rect& rect) { return m_atlas.addTexture(texture, rect); }
+    bool addToAtlas(const TexturePtr& texture) { Rect r; return m_atlas.addTexture(texture, r); }
+
 private:
     std::unordered_map<std::string, TexturePtr> m_textures;
     std::vector<AnimatedTexturePtr> m_animatedTextures;
     TexturePtr m_emptyTexture;
     ScheduledEventPtr m_liveReloadEvent;
     std::shared_mutex m_mutex;
+
+    TextureAtlas m_atlas;
 
     struct
     {


### PR DESCRIPTION
## Summary
- add `TextureAtlas` class to manage shared texture space
- track atlas membership inside `Texture`
- insert textures into atlas when GL IDs are generated
- draw from atlas in DrawPool and DrawPoolManager
- include new source file in build system
