### PR TITLE
perf: replace mutex with atomic in async sprite loading and fix black tile issue

### DIFF
--- a/src/client/spriteappearances.h
+++ b/src/client/spriteappearances.h
@@ -35,6 +35,13 @@ enum class SpriteLayout
     TWO_BY_TWO = 3
 };
 
+enum class SpriteLoadState
+{
+    NONE,
+    LOADING,
+    LOADED
+};
+
 class SpriteSheet
 {
 public:
@@ -67,7 +74,7 @@ public:
     int lastId = 0;
 
     SpriteLayout spriteLayout = SpriteLayout::ONE_BY_ONE;
-    std::mutex m_mutex;
+    std::atomic<SpriteLoadState> m_loadingState = SpriteLoadState::NONE;
     std::unique_ptr<uint8_t[]> data;
     std::string file;
 };

--- a/src/client/spritemanager.h
+++ b/src/client/spritemanager.h
@@ -73,12 +73,20 @@ public:
     bool isLoaded() { return m_loaded; }
 
 private:
-     struct FileStream_m {
-         FileStreamPtr file;
-         std::mutex mutex;
+    enum class SpriteLoadState
+    {
+        NONE,
+        LOADING,
+        LOADED
+    };
 
-         FileStream_m(FileStreamPtr f) : file(std::move(f)) {}
-     };
+    struct FileStream_m
+    {
+        FileStreamPtr file;
+        std::atomic<SpriteLoadState> m_loadingState = SpriteLoadState::NONE;
+
+        FileStream_m(FileStreamPtr f) : file(std::move(f)) {}
+    };
 
     void load();
     FileStreamPtr getSpriteFile() const {

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -724,13 +724,14 @@ void ThingType::loadTexture(const int animationPhase)
                     if (!useCustomImage) {
                         if (protobufSupported) {
                             const uint32_t spriteIndex = getSpriteIndex(-1, -1, spriteMask ? 1 : l, x, y, z, animationPhase);
-                            const auto& spriteImage = g_sprites.getSpriteImage(m_spritesIndex[spriteIndex]);
+                            auto spriteId = m_spritesIndex[spriteIndex];
+                            const auto& spriteImage = g_sprites.getSpriteImage(spriteId);
 
-                            if (!spriteImage)
+                            if (spriteId != 0 && !spriteImage)
                                 return;
 
                             // verifies that the first block in the lower right corner is transparent.
-                            if (spriteImage->hasTransparentPixel()) {
+                            if (!spriteImage || spriteImage->hasTransparentPixel()) {
                                 fullImage->setTransparentPixel(true);
                             }
 
@@ -748,13 +749,14 @@ void ThingType::loadTexture(const int animationPhase)
                             for (int h = 0; h < m_size.height(); ++h) {
                                 for (int w = 0; w < m_size.width(); ++w) {
                                     const uint32_t spriteIndex = getSpriteIndex(w, h, spriteMask ? 1 : l, x, y, z, animationPhase);
-                                    const auto& spriteImage = g_sprites.getSpriteImage(m_spritesIndex[spriteIndex]);
+                                    auto spriteId = m_spritesIndex[spriteIndex];
+                                    const auto& spriteImage = g_sprites.getSpriteImage(spriteId);
 
-                                    if (!spriteImage)
+                                    if (spriteId != 0 && !spriteImage)
                                         return;
 
                                     // verifies that the first block in the lower right corner is transparent.
-                                    if (h == 0 && w == 0 && spriteImage->hasTransparentPixel()) {
+                                    if (h == 0 && w == 0 && (!spriteImage || spriteImage->hasTransparentPixel())) {
                                         fullImage->setTransparentPixel(true);
                                     }
 

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -681,9 +681,7 @@ const TexturePtr& ThingType::getTexture(const int animationPhase)
             m_loading = false;
         };
 
-        if (g_game.getLocalPlayer() && g_game.getLocalPlayer()->isPendingGame())
-            g_dispatcher.asyncEvent(std::move(action));
-        else g_asyncDispatcher.detach_task(std::move(action));
+        g_asyncDispatcher.detach_task(std::move(action));
     }
 
     return m_textureNull;
@@ -728,8 +726,11 @@ void ThingType::loadTexture(const int animationPhase)
                             const uint32_t spriteIndex = getSpriteIndex(-1, -1, spriteMask ? 1 : l, x, y, z, animationPhase);
                             const auto& spriteImage = g_sprites.getSpriteImage(m_spritesIndex[spriteIndex]);
 
+                            if (!spriteImage)
+                                return;
+
                             // verifies that the first block in the lower right corner is transparent.
-                            if (!spriteImage || spriteImage->hasTransparentPixel()) {
+                            if (spriteImage->hasTransparentPixel()) {
                                 fullImage->setTransparentPixel(true);
                             }
 
@@ -749,8 +750,11 @@ void ThingType::loadTexture(const int animationPhase)
                                     const uint32_t spriteIndex = getSpriteIndex(w, h, spriteMask ? 1 : l, x, y, z, animationPhase);
                                     const auto& spriteImage = g_sprites.getSpriteImage(m_spritesIndex[spriteIndex]);
 
+                                    if (!spriteImage)
+                                        return;
+
                                     // verifies that the first block in the lower right corner is transparent.
-                                    if (h == 0 && w == 0 && (!spriteImage || spriteImage->hasTransparentPixel())) {
+                                    if (h == 0 && w == 0 && spriteImage->hasTransparentPixel()) {
                                         fullImage->setTransparentPixel(true);
                                     }
 

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -460,7 +460,7 @@ public:
     PLAYER_ACTION getDefaultAction() { return m_defaultAction; }
 
     uint16_t getClassification() { return m_upgradeClassification; }
-    std::vector<uint32_t> getSprites() { return m_spritesIndex; }
+    const auto& getSprites() { return m_spritesIndex; }
 
     // additional
     float getOpacity() { return m_opacity; }


### PR DESCRIPTION
This update removes the use of `std::mutex` during asynchronous sprite loading and replaces it with an `std::atomic` variable to improve performance and reduce contention between threads.  
Additionally, a bug causing black tiles to appear due to synchronization issues has been identified and fixed.

## Changes
- Replaced `mutex` with `atomic` for concurrent sprite read access
- Improved performance and loading stability under high concurrency
- Fixed visual glitch where tiles were rendered black during async sprite access