### PR TITLE
fix: properly animate items in outfits

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -363,7 +363,9 @@ void Creature::internalDraw(Point dest, const Color& color)
             }
 
             int animationPhase = 0;
-            if (animationPhases > 1) {
+            if (auto* animator = getThingType()->getIdleAnimator(); animator && m_outfit.isItem()) {
+                animationPhase = animator->getPhase();
+            } else if (animationPhases > 1) {
                 animationPhase = (g_clock.millis() % (static_cast<long long>(animateTicks) * animationPhases)) / animateTicks;
             }
 


### PR DESCRIPTION
# Description

Fix improperly animated item looktypes

## Behavior

### **Actual**
Item type outfits are animating too slow/fast depending on the item ticks per frame config option and ignores the timings set in .dat.

### **Expected**

Should respect and properly animate taking into consideration dat timings.
Good example of this is bath tub store item from cip tibia.

## Fixes

Probably fix #1077

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
