### PR TITLE
fix: console readonly tab now clears and closes correctly

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -499,6 +499,11 @@ function terminate()
     ownPrivateName = nil
     gameBottomPanel = nil
     Console = nil
+
+    clearReadOnlyTab()
+    if readOnlyModeEnabled then
+        toggleReadOnlyMode()
+    end
 end
 
 function save()
@@ -609,6 +614,11 @@ function clear()
     end
     if g_game.getClientVersion() < 862 then
         Keybind.delete("Dialogs", "Open Rule Violation")
+    end
+
+    clearReadOnlyTab()
+    if readOnlyModeEnabled then
+        toggleReadOnlyMode()
     end
 end
 

--- a/modules/game_console/console.otui
+++ b/modules/game_console/console.otui
@@ -115,7 +115,6 @@ Panel
     ScrollablePanel
       id: panel
       anchors.fill: parent
-      margin-right: 12
       vertical-scrollbar: consoleScrollBarReadOnlyPanel
       image-source: /images/ui/3pixel_frame_borderimage
       image-border: 4
@@ -137,6 +136,7 @@ Panel
       pixels-scroll: true
       margin-top: 4
       margin-bottom: 4
+      margin-right: 4
 
   ConsoleTabBar
     id: consoleTabBar


### PR DESCRIPTION
- "Clear Messages" now works for any tab, not just the active one.
- Readonly panel is cleared and closed on relogin/character switch.
- Refactored clear logic to always target the correct tab and readonly state.
