### PR TITLE
fix: battlelist widget with Object Pool

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -160,6 +160,10 @@ function UIMiniWindow:setupOnStart()
         else
             self:open(true)
         end
+    else
+        if self:getId() == "battleWindow" then
+            self:open(true)
+        end
     end
 
     local newParent = self:getParent()

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -20,6 +20,7 @@ local BattleButtonPool = ObjectPool.new(function()
         return widget
     end,
     function(obj)
+        obj:resetObjectPool()
         battlePanel:removeChild(obj)
     end)
 

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -20,7 +20,7 @@ local BattleButtonPool = ObjectPool.new(function()
         return widget
     end,
     function(obj)
-        obj:resetObjectPool()
+        obj:resetState()
         battlePanel:removeChild(obj)
     end)
 

--- a/modules/gamelib/ui/uicreaturebutton.lua
+++ b/modules/gamelib/ui/uicreaturebutton.lua
@@ -192,7 +192,7 @@ function UICreatureButton:updateIcons(icons)
     end
 end
 
-function UICreatureButton:resetObjectPool()
+function UICreatureButton:resetState()
     self.isHovered = false
     self.isTarget = false
     self.isFollowed = false

--- a/modules/gamelib/ui/uicreaturebutton.lua
+++ b/modules/gamelib/ui/uicreaturebutton.lua
@@ -192,3 +192,19 @@ function UICreatureButton:updateIcons(icons)
     end
 end
 
+function UICreatureButton:resetObjectPool()
+    self.isHovered = false
+    self.isTarget = false
+    self.isFollowed = false
+    if self.creature then
+        self.creature:hideStaticSquare()
+        self.creature = nil
+    end
+    self:getChildById('creature'):setBorderWidth(0)
+    self:getChildById('label'):setColor(CreatureButtonColors.onIdle.notHovered)
+    self:getChildById('skull'):setImageSource('')
+    self:getChildById('emblem'):setImageSource('')
+    for i = 1, 3 do
+        self:getChildById('iconsMonsterSlot' .. i):setImageSource('')
+    end
+end


### PR DESCRIPTION
# Description

To ensure that each reused button returns to its default appearance, implement the `resetObjectPool()` function within the `uicreaturebutton`.

With this adjustment, every button released and later retrieved from the ObjectPool will look identical to a newly created one, preventing visual inconsistencies like those described in this issue.  #1245

# Actual
![Image](https://github.com/user-attachments/assets/c79b153f-9c3b-4c8c-84a2-941bd5de3010)

---------------------

>  |+

## fix: battlelist first  login ( without cache)

<img width="673" height="306" alt="image" src="https://github.com/user-attachments/assets/8cad1f7a-0926-4b21-83e1-3254e203b3c6" />
