### PR TITLE
fix: m_effects order

### DIFF
--- a/modules/gamelib/ui/uicreaturebutton.lua
+++ b/modules/gamelib/ui/uicreaturebutton.lua
@@ -198,7 +198,6 @@ function UICreatureButton:resetState()
     self.isFollowed = false
     if self.creature then
         self.creature:hideStaticSquare()
-        self.creature = nil
     end
     self:getChildById('creature'):setBorderWidth(0)
     self:getChildById('label'):setColor(CreatureButtonColors.onIdle.notHovered)

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -122,8 +122,8 @@ void Tile::drawLight(const Point& dest, const LightViewPtr& lightView) {
     drawCreature(dest, Otc::DrawLights, true, drawElevation, lightView);
 
     if (m_effects) {
-        for (const auto& effet : *m_effects)
-            effet->draw(dest - drawElevation * g_drawPool.getScaleFactor(), false, lightView);
+        for (const auto& effect : *m_effects)
+            effect->draw(dest - drawElevation * g_drawPool.getScaleFactor(), false, lightView);
     }
 
     drawAttachedLightEffect(dest, lightView);
@@ -265,7 +265,7 @@ void Tile::addThing(const ThingPtr& thing, int stackPos)
             }
         }
 
-        if (newEffect->isTopEffect())
+        if (!newEffect->isTopEffect())
             m_effects->insert(m_effects->begin(), newEffect);
         else
             m_effects->emplace_back(newEffect);


### PR DESCRIPTION
### **posible fix (cc: mehah)**


---------------------------

<img width="407" height="100" alt="image" src="https://github.com/user-attachments/assets/d1bd34b1-050f-42cd-aa96-605c529db04b" />

The Sudden Death Rune sends 2 effects in the following order parseMagicEffect:



| order parseMagicEffect | Id 	| Img|
|---------|---------	|------	|
| 1|         18	|    <img width="32" height="32" alt="sprite_223397" src="https://github.com/user-attachments/assets/7585bba9-85b4-454e-ad0a-e4a4d21176c1" />  	|
|2|         39	|    <img width="32" height="32" alt="sprite_223388" src="https://github.com/user-attachments/assets/ef4a8127-6efb-482d-8f94-afd6703638b8" />  	|

OTCR sorts them incorrectly in m_effects compared to the CipSoft client.
In the CipSoft client, effect 39 is drawn first and then 18 (so 18 appears on top of 39).

Neither effect has the top effect flag,
but in OTCR, 18 is drawn first and 39 appears on top, which is incorrect (cipsoft style).



there is an error in the order (“it is like the z-axis.”)


| cipsoft 	| OTCR 	|
|---------	|------	|
|    <img width="77" height="85" alt="cipsfotasd" src="https://github.com/user-attachments/assets/5e116f9e-32af-45ce-8997-db70290c1d80" />     	|   <img width="77" height="85" alt="otcrasd" src="https://github.com/user-attachments/assets/a1929699-5a8f-413e-9c09-b54444e0a945" />   	|

<table>
  <thead>
    <tr>
      <th>cipsoft</th>
      <th>OTCR Main</th>
      <th>OTCR PR</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <video src="https://github.com/user-attachments/assets/76368ef8-a54c-425c-82d9-80ccb496ce19" controls width="300"></video>
      </td>
      <td>
        <video src="https://github.com/user-attachments/assets/c0a7366e-4f2c-49fe-8fa5-9d9a6fcf1039" controls width="300"></video>
      </td>
      <td>
        <video src="https://github.com/user-attachments/assets/eff5ef9a-6886-4b14-a588-17bb3f9d381f" controls width="300"></video>
      </td>
    </tr>
  </tbody>
</table>

also i tested the flag and it is working as expected.

<img width="654" height="295" alt="image" src="https://github.com/user-attachments/assets/43e8a7e3-5ac7-4613-9ce5-d41dfa742af7" />

test in 10.98
