### PR TITLE
fix: message mode logging in parseTextMessage

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2586,7 +2586,7 @@ void ProtocolGame::parseTextMessage(const InputMessagePtr& msg)
     const Otc::MessageMode mode = Proto::translateMessageModeFromServer(code);
     std::string text;
 
-    g_logger.debug("[ProtocolGame::parseTextMessage] code: {}, mode: {}", code, code);
+    g_logger.debug("[ProtocolGame::parseTextMessage] code: {}, mode: {}", code, mode);
 
     switch (mode) {
         case Otc::MessageChannelManagement:


### PR DESCRIPTION
## Summary
- fix g_logger to log message mode instead of code in ProtocolGame::parseTextMessage