### PR TITLE
fix: apply wrap (S/T) set before creation in create()

### DIFF
--- a/src/framework/graphics/texture.cpp
+++ b/src/framework/graphics/texture.cpp
@@ -151,9 +151,9 @@ void Texture::setRepeat(const bool repeat)
     if (getProp(Prop::repeat) == repeat)
         return;
 
-    if (!m_id) return;
-
     setProp(Prop::repeat, repeat);
+
+    if (!m_id) return;
 
     bind();
     setupWrap();


### PR DESCRIPTION
## Summary
- update Texture::setRepeat to store repeat flag before checking texture ID
- keep early return when repeat flag unchanged