### PR TITLE
fix: add guards to prevent errors in postCacheInfo function fixes #1034

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -310,10 +310,12 @@ end
 
 function EnterGame.postCacheInfo()
     local requestType = 'cacheinfo'
+
     local onRecvInfo = function(message, err)
+        -- Guard: if UI is destroyed, do nothing
+        if not enterGame then return end
 
         if err then
-            -- onError(nil, 'Bad Request. Game_entergame postCacheInfo1 ', 400)
             reportRequestWarning(requestType, "Bad Request. Game_entergame postCacheInfo1")
             return
         end
@@ -335,13 +337,15 @@ function EnterGame.postCacheInfo()
             return
         end
 
+        -- Guard: check modules.client_topmenu still exists
+        if not modules or not modules.client_topmenu then return end
+
         modules.client_topmenu.setPlayersOnline(response.playersonline)
         modules.client_topmenu.setDiscordStreams(response.discord_online)
         modules.client_topmenu.setYoutubeStreams(response.gamingyoutubestreams)
         modules.client_topmenu.setYoutubeViewers(response.gamingyoutubeviewer)
         modules.client_topmenu.setLinkYoutube(response.youtube_link)
         modules.client_topmenu.setLinkDiscord(response.discord_link)
-
     end
 
     HTTP.post(Services.status, json.encode({

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -633,7 +633,17 @@ function EnterGame.tryHttpLogin(clientVersion, httpLogin)
     G.requestId = math.random(1)
 
     local http = LoginHttp.create()
-    http:httpLogin(host, path, G.port, G.account, G.password, G.requestId, httpLogin)
+        http:httpLogin(host, path, G.port, G.account, G.password, G.requestId, httpLogin)
+        connect(loadBox, {
+            onCancel = function(msgbox)
+                loadBox = nil
+                G.requestId = 0
+                if http and http.cancel then
+                    http:cancel()
+                end
+                EnterGame.show()
+            end
+        })
 end
 
 function printTable(t)

--- a/src/framework/net/httplogin.h
+++ b/src/framework/net/httplogin.h
@@ -59,6 +59,8 @@ public:
                                   const std::string& email,
                                   const std::string& password);
 
+    void cancel();
+
     enum Result : int { Success = 200, Error = -1 };
 
 private:
@@ -66,4 +68,5 @@ private:
     std::string worlds;
     std::string session;
     std::string errorMessage;
+    std::atomic<bool> cancelled;
 };


### PR DESCRIPTION
# Description

Add a guard verification to avoid crashing the client on the cancelled HTTP request login.

https://github.com/user-attachments/assets/14a08808-6c9b-4805-bc00-89f7f843166e



https://github.com/user-attachments/assets/c539de43-6c56-49f3-9122-187391646390


Forcing to receive JSON errors:
<img width="1262" height="678" alt="image" src="https://github.com/user-attachments/assets/83d88218-b672-48ee-be7e-7529807bce02" />

https://github.com/user-attachments/assets/24cd8d06-1809-419a-8971-e5d169a2f67d



## Behavior

### **Actual**

Do this and that doesn't happen

### **Expected**

Do this and that happens

## Fixes

#1034 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
