### PR TITLE
improve: add Boost.Locale for encoding conversions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,6 +192,7 @@ find_package(pugixml CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(httplib CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
+find_package(Boost REQUIRED COMPONENTS locale)
 
 if(APPLE)
   # Required for Physfs
@@ -522,6 +523,7 @@ if(MSVC)
           winmm.lib
           pugixml::pugixml
           fmt::fmt-header-only
+          Boost::locale
   )
 elseif(ANDROID)
   target_include_directories(${PROJECT_NAME}
@@ -570,6 +572,7 @@ elseif(ANDROID)
           log
           pugixml::pugixml
           fmt::fmt-header-only
+          Boost::locale
   )
 
 elseif(WASM)
@@ -624,6 +627,7 @@ elseif(WASM)
           Ogg::ogg
           Vorbis::vorbisfile
           Vorbis::vorbis
+          Boost::locale
   )
 
 
@@ -707,6 +711,7 @@ else() # Linux
           Ogg::ogg
           Vorbis::vorbisfile
           Vorbis::vorbis
+          Boost::locale
   )
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,6 +20,7 @@
     "stduuid",
     "zlib",
     "bshoshany-thread-pool",
+    "boost-locale",
     "fmt",
     {
       "name": "luajit",


### PR DESCRIPTION
Replaced manual UTF-8 and Latin1 conversion logic with Boost.Locale functions in string.cpp for improved reliability and maintainability. Updated CMakeLists.txt and vcpkg.json to require Boost.Locale as a dependency and link it in all supported platforms.
