### PR TITLE
fix: mouse control modes and enhance smart left-click

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -926,8 +926,7 @@ function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, u
                 return true
             elseif useThing then
                 -- Handle interactive items first, without looking at them
-                -- Special handling for usable items with Unpass/Unmove flags
-                if useThing:isUsable() and (useThing:isNotWalkable() or useThing:isNotMoveable()) then
+                if useThing:isUsable() then
                     -- Only use the item, don't look at it
                     if useThing:isContainer() then
                         if useThing:getParentContainer() then
@@ -1105,6 +1104,9 @@ function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, u
                             -- For containers in the world, quickloot
                             g_game.sendQuickLoot(1, useThing)
                             return true
+                        else
+                            g_game.open(useThing)
+                            return true
                         end
                     elseif useThing:isMultiUse() then
                         startUseWith(useThing)
@@ -1203,6 +1205,9 @@ function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, u
                         -- Only handle containers that are in the game world (not in inventory)
                         if g_game.getFeature(GameThingQuickLoot) and modules.game_quickloot then
                             g_game.sendQuickLoot(1, useThing)
+                            return true
+                        else
+                            g_game.open(useThing)
                             return true
                         end
                     end


### PR DESCRIPTION
## Fix mouse interaction logic and improve container handling

### Changes Made:

1. **Simplified usable item logic in Smart Left-Click mode**
   - Removed restrictive condition that only allowed interaction with items having `Unpass` or `Unmove` flags
   - Now allows interaction with all usable items, improving consistency and usability

2. **Added fallback for container opening when QuickLoot is unavailable**
   - Added `g_game.open(useThing)` fallback in both Smart Left-Click and Classic Control modes
   - Ensures containers always open even when QuickLoot module is not available
   - Improves compatibility with servers that don't support QuickLoot feature

### What this fixes:

- **Better item interaction**: More items can now be used directly without unnecessary restrictions
- **Improved robustness**: Containers will always open regardless of QuickLoot availability
- **Enhanced compatibility**: Works correctly on servers without QuickLoot support
- **Consistent behavior**: Same logic applies across different control modes

### Testing:
- Tested container opening with and without QuickLoot module enabled
- Verified Smart Left-Click works with various item types
- Confirmed behavior consistency across Classic Control modes