### PR TITLE
fix: blessing(Reactive loop) In onGameEnd, g_game:getLocalPlayer() (nil) is executed.

### DIFF
--- a/modules/game_blessing/blessing.html
+++ b/modules/game_blessing/blessing.html
@@ -108,7 +108,7 @@
   <!-- Promotion Status Panel -->
   <div id="promotionPanel" class="promo-panel minipanel" title="Promotion and Premium Status">
     <label id="promotionStatusLabel"></label>
-    <BigPremiumButton id="premium_only" onclick="self:onClickSendStore()" *on="g_game.isOnline() and not g_game:getLocalPlayer():isPremium()">
+    <BigPremiumButton id="premium_only" onclick="self:onClickSendStore()" *on="(g_game:getLocalPlayer() and not g_game:getLocalPlayer():isPremium()) or false">
     </BigPremiumButton>
   </div>
 

--- a/modules/game_blessing/blessing.html
+++ b/modules/game_blessing/blessing.html
@@ -95,7 +95,7 @@
 <Window id="main" class="blessings-window" title="Blessings" onescape="self:close()">
 
   <!-- History Panel (initially hidden) -->
-  <div id="historyPanel" anchor="parent" class="history-panel minipanel" title="History" *visible="self.historyButtonText == 'History'">
+  <div id="historyPanel" anchor="parent" class="history-panel minipanel" title="History" *if="self.historyButtonText == 'History'">
     <div id="historyScrollArea" class="history-scroll">
     </div>
   </div>

--- a/modules/game_blessing/blessing.html
+++ b/modules/game_blessing/blessing.html
@@ -95,20 +95,20 @@
 <Window id="main" class="blessings-window" title="Blessings" onescape="self:close()">
 
   <!-- History Panel (initially hidden) -->
-  <div id="historyPanel" class="history-panel minipanel" title="History" *if="self.historyButtonText == 'History'">
+  <div id="historyPanel" anchor="parent" class="history-panel minipanel" title="History" *visible="self.historyButtonText == 'History'">
     <div id="historyScrollArea" class="history-scroll">
     </div>
   </div>
 
   <!-- Blessing Records Panel -->
-  <div id="blessingsRecordPanel" class="record-panel minipanel" title="Record of Blessings"
+  <div id="blessingsRecordPanel" anchor="parent" class="record-panel minipanel" title="Record of Blessings"
     layout="type: horizontalBox">
   </div>
 
   <!-- Promotion Status Panel -->
   <div id="promotionPanel" class="promo-panel minipanel" title="Promotion and Premium Status">
     <label id="promotionStatusLabel"></label>
-    <BigPremiumButton id="premium_only" onclick="self:onClickSendStore()" *on="not g_game:getLocalPlayer():isPremium()">
+    <BigPremiumButton id="premium_only" onclick="self:onClickSendStore()" *on="g_game.isOnline() and not g_game:getLocalPlayer():isPremium()">
     </BigPremiumButton>
   </div>
 

--- a/modules/game_blessing/blessing.lua
+++ b/modules/game_blessing/blessing.lua
@@ -9,23 +9,18 @@ end
 
 function BlessingController:onGameStart()
     if g_game.getClientVersion() >= 1000 then
-        g_ui.importStyle("style.otui")
-        BlessingController:loadHtml('blessing.html')
-        BlessingController.ui:hide()
         BlessingController:registerEvents(g_game, {
             onUpdateBlessDialog = onUpdateBlessDialog
         })
     else
-        scheduleEvent(function()
+        BlessingController:scheduleEvent(function()
             g_modules.getModule("game_blessing"):unload()
-        end, 100)
+        end, 100, "unloadModule")
     end
 end
 
 function BlessingController:onGameEnd()
-    if g_game.getClientVersion() >= 1000 and BlessingController.ui:isVisible() then
-        BlessingController.ui:hide()
-    end
+    hide()
 end
 
 function BlessingController:close()
@@ -61,29 +56,26 @@ function setBlessingView()
 end
 
 function show()
-    if not BlessingController.ui then
-        return
-    end
+    g_ui.importStyle("style.otui")
+    BlessingController:loadHtml('blessing.html')
     g_game.requestBless()
-    BlessingController.ui:centerIn('parent')
     BlessingController.ui:show()
     BlessingController.ui:raise()
     BlessingController.ui:focus()
     setBlessingView()
+    BlessingController:scheduleEvent(function()
+        BlessingController.ui:centerIn('parent')
+    end, 1, "LazyHtml")
 end
 
 function hide()
-    if not BlessingController.ui then
-        return
+    if BlessingController.ui then
+        BlessingController:unloadHtml()
     end
-    BlessingController.ui:hide()
 end
 
 function toggle()
-    if not BlessingController.ui then
-        return
-    end
-    if BlessingController.ui:isVisible() then
+    if BlessingController.ui and BlessingController.ui:isVisible() then
         hide()
     else
         show()


### PR DESCRIPTION
# Description

I made that bug, oops, sorry.

> Even when doing unloadHtml in onGameEnd, the Reactive loop is executed
## Behavior

### **Actual**

spam error: Reactive loop

```lua
ERROR: lua function callback failed: LUA ERROR:
[string "Controller: game_blessing | blessing.html"]:1: attempt to index a nil value
stack traceback:
	[C]: in function '__index'
	[string "Controller: game_blessing | blessing.html"]:1: in function 'fnc'
	/corelib/ui/uiwidget.lua:148: in function 'fnc'
	/corelib/ui/uiwidget.lua:63: in function 'fnc'
	/corelib/table.lua:316: in function 'remove_if'
	/corelib/ui/uiwidget.lua:58: in function </corelib/ui/uiwidget.lua:57>
```

### **Expected**

Do this and that happens

## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

login, logout = spam bug

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
