### PR TITLE
fix: UI creature sizes outfits

### DIFF
--- a/data/styles/40-outfitwindow.otui
+++ b/data/styles/40-outfitwindow.otui
@@ -109,7 +109,6 @@ SelectionButton < Panel
     id: outfit
     anchors.centerIn: parent
     size: 64 64
-    margin-bottom: 10
     phantom: true
   
   Panel

--- a/data/styles/40-outfitwindow.otui
+++ b/data/styles/40-outfitwindow.otui
@@ -51,7 +51,6 @@ PresetButton < Panel
     id: creature
     anchors.centerIn: parent
     size: 64 64
-    margin-bottom: 10
     phantom: true
   
   Label
@@ -307,7 +306,7 @@ OutfitWindow < MainWindow
       UICreature
         id: UIfamiliar
         anchors.centerIn: parent
-        size: 256 256
+        size: 64 64
         @onSetup: |
           if not g_game.getFeature(GamePlayerFamiliars) then
             self:hide()
@@ -316,14 +315,11 @@ OutfitWindow < MainWindow
       UICreature
         id: creature
         anchors.centerIn: parent
-        size: 256 256
+        size: 64 64
       
       Panel
         id: bars
-        anchors.horizontalCenter: prev.horizontalCenter
-        anchors.top: prev.top
-        margin-top: 47
-        margin-left: 28
+        anchors.centerIn: parent
         size: 300 32
 
         Label

--- a/data/styles/40-outfitwindow.otui
+++ b/data/styles/40-outfitwindow.otui
@@ -317,10 +317,15 @@ OutfitWindow < MainWindow
         id: creature
         anchors.centerIn: parent
         size: 64 64
+        margin-top: 26
+        margin-left: -16
       
       Panel
         id: bars
-        anchors.centerIn: parent
+        anchors.horizontalCenter: prev.horizontalCenter
+        anchors.top: prev.top
+        margin-top: 47
+        margin-right: 20
         size: 300 32
 
         Label

--- a/data/styles/40-outfitwindow.otui
+++ b/data/styles/40-outfitwindow.otui
@@ -108,6 +108,7 @@ SelectionButton < Panel
     id: outfit
     anchors.centerIn: parent
     size: 64 64
+    margin-bottom: 10
     phantom: true
   
   Panel

--- a/data/styles/40-outfitwindow.otui
+++ b/data/styles/40-outfitwindow.otui
@@ -109,6 +109,7 @@ SelectionButton < Panel
     id: outfit
     anchors.centerIn: parent
     size: 64 64
+    margin-bottom: 10
     phantom: true
   
   Panel

--- a/modules/client_entergame/characterlist.lua
+++ b/modules/client_entergame/characterlist.lua
@@ -320,7 +320,15 @@ function CharacterList.create(characters, account, otui)
             local outfit = {type = characterInfo.outfitid, head = characterInfo.headcolor, body = characterInfo.torsocolor, legs = characterInfo.legscolor, feet = characterInfo.detailcolor, addons = characterInfo.addonsflags}
             creature:setOutfit(outfit)
             creature:setDirection(2)
+        
             creatureDisplay:setCreature(creature)
+
+            -- Get the creature size from its appearance data
+            creatureDisplay:setPadding(0)
+            -- The creature size is determined by the ThingType of the outfit
+            -- We use a single parameter for setCreatureSize which handles proportional scaling
+            creatureDisplay:setCreatureSize(90) -- Use a base size that will be scaled properly
+            creatureDisplay:setCenter(false) -- Center the creature in the display
 
             local mainCharacter = widget:getChildById('mainCharacter', characterList)
             if characterInfo.main then

--- a/modules/client_entergame/characterlist.lua
+++ b/modules/client_entergame/characterlist.lua
@@ -320,15 +320,8 @@ function CharacterList.create(characters, account, otui)
             local outfit = {type = characterInfo.outfitid, head = characterInfo.headcolor, body = characterInfo.torsocolor, legs = characterInfo.legscolor, feet = characterInfo.detailcolor, addons = characterInfo.addonsflags}
             creature:setOutfit(outfit)
             creature:setDirection(2)
-        
             creatureDisplay:setCreature(creature)
-
-            -- Get the creature size from its appearance data
             creatureDisplay:setPadding(0)
-            -- The creature size is determined by the ThingType of the outfit
-            -- We use a single parameter for setCreatureSize which handles proportional scaling
-            creatureDisplay:setCreatureSize(90) -- Use a base size that will be scaled properly
-            creatureDisplay:setCenter(false) -- Center the creature in the display
 
             local mainCharacter = widget:getChildById('mainCharacter', characterList)
             if characterInfo.main then

--- a/modules/client_entergame/characterlist.lua
+++ b/modules/client_entergame/characterlist.lua
@@ -320,15 +320,7 @@ function CharacterList.create(characters, account, otui)
             local outfit = {type = characterInfo.outfitid, head = characterInfo.headcolor, body = characterInfo.torsocolor, legs = characterInfo.legscolor, feet = characterInfo.detailcolor, addons = characterInfo.addonsflags}
             creature:setOutfit(outfit)
             creature:setDirection(2)
-        
             creatureDisplay:setCreature(creature)
-
-            -- Get the creature size from its appearance data
-            creatureDisplay:setPadding(0)
-            -- The creature size is determined by the ThingType of the outfit
-            -- We use a single parameter for setCreatureSize which handles proportional scaling
-            creatureDisplay:setCreatureSize(90) -- Use a base size that will be scaled properly
-            creatureDisplay:setCenter(false) -- Center the creature in the display
 
             local mainCharacter = widget:getChildById('mainCharacter', characterList)
             if characterInfo.main then

--- a/modules/game_attachedeffects/attachedeffects.lua
+++ b/modules/game_attachedeffects/attachedeffects.lua
@@ -59,18 +59,28 @@ function controller:onTerminate()
 end
 
 function getCategory(id)
-    return AttachedEffectManager.get(id).thingCategory
+    local effect = AttachedEffectManager.get(id)
+    if effect then
+        return effect.thingCategory
+    end
+    return nil
 end
 
 function getTexture(id)
-    if AttachedEffectManager.get(id).thingCategory == 5 then
-        return AttachedEffectManager.get(id).thingId
+    local effect = AttachedEffectManager.get(id)
+    if effect and effect.thingCategory == 5 then
+        return effect.thingId
     end
 end
 
 function getName(id)
     if type(id) == "number" then
-        return AttachedEffectManager.get(id).name
+        local effect = AttachedEffectManager.get(id)
+        if effect then
+            return effect.name
+        else
+            return "None"
+        end
     else
         return "None"
     end
@@ -78,7 +88,12 @@ end
 
 function thingId(id)
     if type(id) == "number" then
-        return AttachedEffectManager.get(id).thingId
+        local effect = AttachedEffectManager.get(id)
+        if effect then
+            return effect.thingId
+        else
+            return "None"
+        end
     else
         return "None"
     end

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -24,6 +24,9 @@ local showFamiliarCheck = nil
 local colorBoxes = {}
 local currentColorBox = nil
 
+local previewCreature = nil
+local previewFamiliar = nil
+
 ignoreNextOutfitWindow = 0
 local floorTiles = 7
 local settingsFile = "/settings/outfit.json"
@@ -535,7 +538,11 @@ function destroy()
         colorBoxes = {}
         currentColorBox = nil
         previewCreature:destroy()
-        previewCreature = nil    
+        previewCreature = nil
+        if previewFamiliar then
+            previewFamiliar:destroy()
+            previewFamiliar = nil
+        end
         if appearanceGroup then
             appearanceGroup:destroy()
             appearanceGroup = nil

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -114,11 +114,6 @@ local function showSelectionList(data, tempValue, tempField, onSelectCallback)
                 button.outfit:setOutfit({
                     type = modules.game_attachedeffects.thingId(itemData[1])
                 })
-                button.outfit:setPadding(-20)
-                button.outfit:setMarginLeft(8)
-                button.outfit:setCenter(true)
-                button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
-
             elseif Category == 2 then
                 button.outfit:setOutfit(previewCreature:getCreature():getOutfit())
                 button.outfit:getCreature():attachEffect(g_attachedEffects.getById(itemData[1]))
@@ -866,10 +861,10 @@ function showOutfits()
         button.outfit:setOutfit(outfit)
         
         local thingType = g_things.getThingType(outfit.type, ThingCategoryCreature)
-        button.outfit:setPadding(-20)
-        button.outfit:setMarginLeft(8)
-        button.outfit:setCenter(true)
-        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
+        button.outfit:setPadding(-8)
+        if thingType:getRealSize() > 0 then
+            button.outfit:setCreatureSize(thingType:getRealSize() + 64)
+        end
 
         local state = outfitData[4]
         if state then
@@ -926,12 +921,10 @@ function showMounts()
         })
 
         local thingType = g_things.getThingType(mountData[1], ThingCategoryCreature)
-        button.outfit:setPadding(-30)
-        button.outfit:setMarginLeft(8)
-        button.outfit:setMarginTop(8)
-        button.outfit:setSize("48 48")
-        button.outfit:setCenter(true)
-        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
+        button.outfit:setPadding(-8)
+        if thingType:getRealSize() > 0 then
+            button.outfit:setCreatureSize(thingType:getRealSize() + 64)
+        end
 
         button.name:setText(mountData[2])
         if tempOutfit.mount == mountData[1] then
@@ -990,19 +983,8 @@ function showFamiliars()
         button.outfit:setOutfit({
             type = familiarData[1]
         })
-        
-        local thingType = g_things.getThingType(familiarData[1], ThingCategoryCreature)
-        
+               
         button.name:setText(familiarData[2])
-        
-        -- Add proper sizing for the 64x64 UICreature
-        button.outfit:setPadding(-30)
-        button.outfit:setMarginLeft(8)
-        button.outfit:setMarginTop(8)
-        button.outfit:setSize("48 48")
-        button.outfit:setCenter(true)
-        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
-        
         if tempOutfit.familiar == familiarData[1] then
             focused = familiarData[1]
         end
@@ -1045,11 +1027,6 @@ function showShaders()
             addons = tempOutfit.addons
         })
 
-        button.outfit:setPadding(-20)
-        button.outfit:setMarginLeft(8)
-        button.outfit:setCenter(true)
-        button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
-
         button.outfit:getCreature():setShader("Outfit - Default")
         button.name:setText("Outfit - Default")
         if tempOutfit.shaders == "Outfit - Default" then
@@ -1068,11 +1045,6 @@ function showShaders()
 
             })
 
-            button.outfit:setPadding(-20)
-            button.outfit:setMarginLeft(8)
-            button.outfit:setCenter(true)
-            button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
-    
             button.outfit:getCreature():setShader(shaderData[2])
 
             button.name:setText(shaderData[2])
@@ -1804,13 +1776,7 @@ function accept()
     end
     if g_game.getFeature(GamePlayerFamiliars) then
         if settings.currentPreset > 0 then
-            -- Check if familiar configuration exists before accessing it
-            if window.configure.familiar and window.configure.familiar.check then
-                settings.presets[settings.currentPreset].familiar = window.configure.familiar.check:isChecked()
-            else
-                -- Default to false if the familiar check doesn't exist
-                settings.presets[settings.currentPreset].familiar = false
-            end
+            settings.presets[settings.currentPreset].familiar = window.configure.familiar.check:isChecked()
         end
     end
     g_game.changeOutfit(tempOutfit)

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -171,6 +171,11 @@ function terminate()
     destroy()
 end
 
+function onOutfitChange(creature, outfit, oldOutfit)
+    -- Dummy function to handle engine callbacks
+    -- This prevents the "luaCallLuaField(onOutfitChange) is being called outside the context of the lua call" warnings
+end
+
 function onMovementChange(checkBox, checked)
     local walkingSpeed = checked and 1000 or 0 
 
@@ -1349,9 +1354,15 @@ function onFamiliarSelect(list, focusedChild, unfocusedChild, reason)
 
         deselectPreset()
 
-        previewFamiliar:setOutfit({
-            type = familiarType
-        })
+        -- Only set outfit if familiarType is valid (not 0/None)
+        if familiarType and familiarType > 0 then
+            previewFamiliar:setOutfit({
+                type = familiarType
+            })
+        else
+            -- Hide/clear the familiar when "None" is selected
+            previewFamiliar:setVisible(false)
+        end
 
         updatePreview()
 

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -714,6 +714,9 @@ function savePreset()
         -- TODO: Try changing square clipping size from Mehah PR
         window.presetsList[presetId].creature:setCreatureSize(thingType:getRealSize())
         window.presetsList[presetId].creature:setCenter(true)
+    elseif not g_game.getFeature(GameWingsAurasEffectsShader) then
+        window.presetsList[presetId].creature:setCreatureSize(thingType:getRealSize() + 32)
+        window.presetsList[presetId].creature:setCenter(true)
     else
         window.presetsList[presetId].creature:setCreatureSize(thingType:getRealSize())
         window.presetsList[presetId].creature:setCenter(true)
@@ -826,6 +829,9 @@ function showPresets()
             if (hasValidAE and presetWidget.creature:getCreatureSize() == 0) then
                 -- TODO: Try changing square clipping size from Mehah PR
                 presetWidget.creature:setCreatureSize(thingType:getRealSize())
+                presetWidget.creature:setCenter(true)
+            elseif not g_game.getFeature(GameWingsAurasEffectsShader) then
+                presetWidget.creature:setCreatureSize(thingType:getRealSize() + 32)
                 presetWidget.creature:setCenter(true)
             else
                 presetWidget.creature:setCreatureSize(thingType:getRealSize())

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -890,14 +890,8 @@ function showOutfits()
         outfit.healthBar = 0
         outfit.effects = 0
         button.outfit:setOutfit(outfit)
-        
-        local thingType = g_things.getThingType(outfit.type, ThingCategoryCreature)
+
         button.outfit:setCenter(true)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize())
-        else
-            button.outfit:setCreatureSize(64)
-        end
 
         local state = outfitData[4]
         if state then

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -119,12 +119,7 @@ local function showSelectionList(data, tempValue, tempField, onSelectCallback)
                 })
                 
                 button.outfit:setMarginBottom(15)
-                local thingType = g_things.getThingType(tempOutfit.type, ThingCategoryCreature)
-                if thingType:getRealSize() > 0 then
-                    button.outfit:setCreatureSize(thingType:getRealSize())
-                else
-                    button.outfit:setCreatureSize(64)
-                end
+                button.outfit:setCenter(true)
 
             elseif Category == 2 then
                 button.outfit:setOutfit(previewCreature:getCreature():getOutfit())
@@ -947,13 +942,7 @@ function showMounts()
             type = mountData[1]
         })
 
-        local thingType = g_things.getThingType(mountData[1], ThingCategoryCreature)
         button.outfit:setCenter(true)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize())
-        else
-            button.outfit:setCreatureSize(64)
-        end
 
         button.name:setText(mountData[2])
         if tempOutfit.mount == mountData[1] then
@@ -1012,18 +1001,10 @@ function showFamiliars()
         button.outfit:setOutfit({
             type = familiarData[1]
         })
-        
-        local thingType = g_things.getThingType(familiarData[1], ThingCategoryCreature)
-        
+                
         button.name:setText(familiarData[2])
-        
-        -- Add proper sizing for the 64x64 UICreature
+
         button.outfit:setCenter(true)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize())
-        else
-            button.outfit:setCreatureSize(64)
-        end
         
         if tempOutfit.familiar == familiarData[1] then
             focused = familiarData[1]
@@ -1067,13 +1048,7 @@ function showShaders()
             addons = tempOutfit.addons
         })
 
-        button.outfit:setMarginBottom(15)
-        local thingType = g_things.getThingType(tempOutfit.type, ThingCategoryCreature)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize())
-        else
-            button.outfit:setCreatureSize(64)
-        end
+        button.outfit:setCenter(true)
 
         button.outfit:getCreature():setShader("Outfit - Default")
         button.name:setText("Outfit - Default")
@@ -1093,13 +1068,7 @@ function showShaders()
 
             })
 
-            button.outfit:setMarginBottom(15)
-            local thingType = g_things.getThingType(tempOutfit.type, ThingCategoryCreature)
-            if thingType:getRealSize() > 0 then
-                button.outfit:setCreatureSize(thingType:getRealSize())
-            else
-                button.outfit:setCreatureSize(64)
-            end
+            button.outfit:setCenter(true)
     
             button.outfit:getCreature():setShader(shaderData[2])
 

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -1226,11 +1226,13 @@ function onPresetSelect(list, focusedChild, unfocusedChild, reason)
         updateAppearanceTexts(tempOutfit)
 
         updateAppearanceText("preset", preset.title)
-        updateAppearanceText("aura", modules.game_attachedeffects.getName(preset.auras))
-        updateAppearanceText("wings", modules.game_attachedeffects.getName(preset.wings))
-        updateAppearanceText("shader", preset.shaders or "Outfit - Default")
-        updateAppearanceText("effects", modules.game_attachedeffects.getName(preset.effects))
-
+        if g_game.getFeature(GameWingsAurasEffectsShader) then
+            updateAppearanceText("aura", modules.game_attachedeffects.getName(preset.auras))
+            updateAppearanceText("wings", modules.game_attachedeffects.getName(preset.wings))
+            updateAppearanceText("shader", preset.shaders or "Outfit - Default")
+            updateAppearanceText("effects", modules.game_attachedeffects.getName(preset.effects))
+        end
+        
         previewCreature:getCreature():clearAttachedEffects()
 
         if settings.showEffects and preset.effects then

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -114,6 +114,11 @@ local function showSelectionList(data, tempValue, tempField, onSelectCallback)
                 button.outfit:setOutfit({
                     type = modules.game_attachedeffects.thingId(itemData[1])
                 })
+                button.outfit:setPadding(-20)
+                button.outfit:setMarginLeft(8)
+                button.outfit:setCenter(true)
+                button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
+
             elseif Category == 2 then
                 button.outfit:setOutfit(previewCreature:getCreature():getOutfit())
                 button.outfit:getCreature():attachEffect(g_attachedEffects.getById(itemData[1]))
@@ -861,10 +866,10 @@ function showOutfits()
         button.outfit:setOutfit(outfit)
         
         local thingType = g_things.getThingType(outfit.type, ThingCategoryCreature)
-        button.outfit:setPadding(-8)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize() + 64)
-        end
+        button.outfit:setPadding(-20)
+        button.outfit:setMarginLeft(8)
+        button.outfit:setCenter(true)
+        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
 
         local state = outfitData[4]
         if state then
@@ -921,10 +926,12 @@ function showMounts()
         })
 
         local thingType = g_things.getThingType(mountData[1], ThingCategoryCreature)
-        button.outfit:setPadding(-8)
-        if thingType:getRealSize() > 0 then
-            button.outfit:setCreatureSize(thingType:getRealSize() + 64)
-        end
+        button.outfit:setPadding(-30)
+        button.outfit:setMarginLeft(8)
+        button.outfit:setMarginTop(8)
+        button.outfit:setSize("48 48")
+        button.outfit:setCenter(true)
+        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
 
         button.name:setText(mountData[2])
         if tempOutfit.mount == mountData[1] then
@@ -983,8 +990,19 @@ function showFamiliars()
         button.outfit:setOutfit({
             type = familiarData[1]
         })
-               
+        
+        local thingType = g_things.getThingType(familiarData[1], ThingCategoryCreature)
+        
         button.name:setText(familiarData[2])
+        
+        -- Add proper sizing for the 64x64 UICreature
+        button.outfit:setPadding(-30)
+        button.outfit:setMarginLeft(8)
+        button.outfit:setMarginTop(8)
+        button.outfit:setSize("48 48")
+        button.outfit:setCenter(true)
+        button.outfit:setCreatureSize(thingType:getRealSize() + 148)
+        
         if tempOutfit.familiar == familiarData[1] then
             focused = familiarData[1]
         end
@@ -1027,6 +1045,11 @@ function showShaders()
             addons = tempOutfit.addons
         })
 
+        button.outfit:setPadding(-20)
+        button.outfit:setMarginLeft(8)
+        button.outfit:setCenter(true)
+        button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
+
         button.outfit:getCreature():setShader("Outfit - Default")
         button.name:setText("Outfit - Default")
         if tempOutfit.shaders == "Outfit - Default" then
@@ -1045,6 +1068,11 @@ function showShaders()
 
             })
 
+            button.outfit:setPadding(-20)
+            button.outfit:setMarginLeft(8)
+            button.outfit:setCenter(true)
+            button.outfit:setCreatureSize(g_things.getThingType(tempOutfit.type, ThingCategoryCreature):getRealSize() + 148)
+    
             button.outfit:getCreature():setShader(shaderData[2])
 
             button.name:setText(shaderData[2])
@@ -1776,7 +1804,13 @@ function accept()
     end
     if g_game.getFeature(GamePlayerFamiliars) then
         if settings.currentPreset > 0 then
-            settings.presets[settings.currentPreset].familiar = window.configure.familiar.check:isChecked()
+            -- Check if familiar configuration exists before accessing it
+            if window.configure.familiar and window.configure.familiar.check then
+                settings.presets[settings.currentPreset].familiar = window.configure.familiar.check:isChecked()
+            else
+                -- Default to false if the familiar check doesn't exist
+                settings.presets[settings.currentPreset].familiar = false
+            end
         end
     end
     g_game.changeOutfit(tempOutfit)

--- a/modules/game_outfit/outfit.lua
+++ b/modules/game_outfit/outfit.lua
@@ -828,13 +828,11 @@ function showPresets()
 
             if (hasValidAE and presetWidget.creature:getCreatureSize() == 0) then
                 -- TODO: Try changing square clipping size from Mehah PR
-                presetWidget.creature:setCreatureSize(thingType:getRealSize())
                 presetWidget.creature:setCenter(true)
             elseif not g_game.getFeature(GameWingsAurasEffectsShader) then
                 presetWidget.creature:setCreatureSize(thingType:getRealSize() + 32)
                 presetWidget.creature:setCenter(true)
             else
-                presetWidget.creature:setCreatureSize(thingType:getRealSize())
                 presetWidget.creature:setCenter(true)
             end
 
@@ -1345,7 +1343,7 @@ function onFamiliarSelect(list, focusedChild, unfocusedChild, reason)
         else
             previewCreature:setMarginRight(0)
             previewFamiliar:setMarginLeft(0)
-            window.preview.panel.bars:setMarginRight(0)
+            window.preview.panel.bars:setMarginRight(20)
         end
 
         updateAppearanceText("familiar", focusedChild.name:getText())
@@ -1607,17 +1605,17 @@ function updatePreview()
         previewOutfit.mount = 0
     end
 
-    if not settings.showFamiliar then
+    if not settings.showFamiliar or previewOutfit.familiar == 0 then
         previewOutfit.familiar = 0
         previewCreature:setMarginRight(0)
         previewFamiliar:setMarginLeft(0)
-        window.preview.panel.bars:setMarginRight(0)
-        previewFamiliar:setVisible(settings.showFamiliar)
+        window.preview.panel.bars:setMarginRight(20)
+        previewFamiliar:setVisible(false)
     else
         if previewOutfit.familiar and previewOutfit.familiar > 0 then
             previewFamiliar:setVisible(true)
             previewCreature:setMarginRight(50)
-            window.preview.panel.bars:setMarginRight(50)
+            window.preview.panel.bars:setMarginRight(40)
             previewFamiliar:setCreatureSize(124)
             previewFamiliar:setCenter(true)
             previewFamiliar:setMarginLeft(70)


### PR DESCRIPTION
# Description

Fix Outfits, store and charselect after recent changes. Also fixed a bug where Aura, effects and Shaders were not visible to the previewCreature. 

A small bug is known as the Aura/Effects/Wings that is too large, and the creature's square is clipped. Accepting suggestions. Ready to review.

Fixed a small bug with aura/effects/wings with the old protocol when the feature is not enabled.

Code Cleaned.

##Roadmap tests
- [X] Outfits
- [X] Charselect
- [X] Store

## Need tests
- [X] Canary 1412
- [x] TFS/Canary/others 1098
- [x] Others Lower Versions


https://github.com/user-attachments/assets/5b838d5e-1c70-4893-9bce-1d75c6034f5b


Do this and that doesn't happen

### **Expected**

Do this and that happens

## Fixes

#1334 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: CANARY 1412
  - Client: OTC
  - Operating System: W11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
