### PR TITLE
fix http timeout problems

### DIFF
--- a/modules/corelib/http.lua
+++ b/modules/corelib/http.lua
@@ -1,5 +1,5 @@
 HTTP = {
-  timeout = 60,
+  timeout = 2,
   websocketTimeout = 15,
   agent = "Mozilla/5.0",
   imageId = 1000,

--- a/src/framework/net/protocolhttp.cpp
+++ b/src/framework/net/protocolhttp.cpp
@@ -24,6 +24,7 @@
 #include <framework/util/crypt.h>
 
 #include <utility>
+#include <openssl/ssl.h>
 
 #include "protocolhttp.h"
 
@@ -58,7 +59,7 @@ void Http::terminate()
 int Http::get(const std::string& url, int timeout)
 {
     if (!timeout) // lua is not working with default values
-        timeout = 5;
+        timeout = 2;
     int operationId = m_operationId++;
 
     asio::post(m_ios, [&, url, timeout, operationId] {
@@ -90,7 +91,7 @@ int Http::get(const std::string& url, int timeout)
 int Http::post(const std::string& url, const std::string& data, int timeout, bool isJson, bool checkContentLength)
 {
     if (!timeout) // lua is not working with default values
-        timeout = 5;
+        timeout = 2;
     if (data.empty()) {
         g_logger.error("Invalid post request for {}, empty data, use get instead", url);
         return -1;
@@ -126,7 +127,7 @@ int Http::post(const std::string& url, const std::string& data, int timeout, boo
 int Http::download(const std::string& url, const std::string& path, int timeout)
 {
     if (!timeout) // lua is not working with default values
-        timeout = 5;
+        timeout = 2;
 
     int operationId = m_operationId++;
     asio::post(m_ios, [&, url, path, timeout, operationId] {
@@ -166,7 +167,7 @@ int Http::download(const std::string& url, const std::string& path, int timeout)
 int Http::ws(const std::string& url, int timeout)
 {
     if (!timeout) // lua is not working with default values
-        timeout = 5;
+        timeout = 2;
     int operationId = m_operationId++;
 
     asio::post(m_ios, [&, url, timeout, operationId] {
@@ -239,20 +240,31 @@ void HttpSession::start()
     instance_uri = parseURI(m_url);
     const asio::ip::tcp::resolver::query query_resolver(instance_uri.domain, instance_uri.port);
 
+    m_timer.expires_after(std::chrono::seconds(m_timeout));
+    m_timer.async_wait([sft = shared_from_this()](const std::error_code& ec) { sft->onTimeout(ec); });
+
     if (m_result->postData == "") {
-        m_request.append("GET " + instance_uri.query + " HTTP/1.1\r\n");
+        m_request.append("GET " + instance_uri.query + " HTTP/1.0\r\n");
         m_request.append("Host: " + instance_uri.domain + "\r\n");
         m_request.append("User-Agent: " + m_agent + "\r\n");
         m_request.append("Accept: */*\r\n");
+        m_request.append("Accept-Language: en-US,en;q=0.9\r\n");
+        m_request.append("Accept-Encoding: identity\r\n");
+        m_request.append("Cache-Control: no-cache\r\n");
+        m_request.append("Connection: close\r\n");
         for (const auto& ch : m_custom_header) {
             m_request.append(ch.first + ch.second + "\r\n");
         }
-        m_request.append("Connection: close\r\n\r\n");
+        m_request.append("\r\n");
     } else {
-        m_request.append("POST " + instance_uri.query + " HTTP/1.1\r\n");
+        m_request.append("POST " + instance_uri.query + " HTTP/1.0\r\n");
         m_request.append("Host: " + instance_uri.domain + "\r\n");
         m_request.append("User-Agent: " + m_agent + "\r\n");
         m_request.append("Accept: */*\r\n");
+        m_request.append("Accept-Language: en-US,en;q=0.9\r\n");
+        m_request.append("Accept-Encoding: identity\r\n");
+        m_request.append("Cache-Control: no-cache\r\n");
+        m_request.append("Connection: close\r\n");
         for (const auto& ch : m_custom_header) {
             m_request.append(ch.first + ch.second + "\r\n");
         }
@@ -262,13 +274,11 @@ void HttpSession::start()
             m_request.append("Content-Type: application/x-www-form-urlencoded\r\n");
         }
         m_request.append("Content-Length: " + std::to_string(m_result->postData.size()) + "\r\n");
-        m_request.append("Connection: close\r\n\r\n");
+        m_request.append("\r\n");
         m_request.append(m_result->postData);
     }
 
-    m_resolver.async_resolve(
-        query_resolver,
-        [sft = shared_from_this()](
+    m_resolver.async_resolve(instance_uri.domain, instance_uri.port, [sft = shared_from_this()](
         const std::error_code& ec, asio::ip::tcp::resolver::iterator iterator) {
         sft->on_resolve(ec, std::move(iterator));
     });
@@ -282,73 +292,91 @@ void HttpSession::on_resolve(const std::error_code& ec, asio::ip::tcp::resolver:
     }
 
     std::error_code _ec;
+
+    // Try to find IPv4 addresses first
+    asio::ip::tcp::resolver::iterator end;
+    asio::ip::tcp::resolver::iterator ipv4_it = end;
+    auto current = iterator;
+
+    while (current != end) {
+        if (!current->endpoint().address().is_v6()) {
+            ipv4_it = current;
+            break;
+        }
+        ++current;
+    }
+
+    // If no IPv4 found, use the original iterator (IPv6)
+    const auto& endpoint_to_use = (ipv4_it != end) ? ipv4_it : iterator;
+
+    g_logger.debug("Attempting connection to: {}:{}", instance_uri.domain, instance_uri.port);
+    
     if (instance_uri.port == "443") {
-        while (iterator != asio::ip::tcp::resolver::iterator()) {
-            m_ssl.lowest_layer().close();
-            m_ssl.lowest_layer().connect(*iterator++, _ec);
-            if (!_ec) {
-                const std::error_code __ec;
-                on_connect(__ec);
-                break;
-            }
-        }
+        // For HTTPS, use the SSL stream's underlying socket
+        m_ssl.lowest_layer().async_connect(*endpoint_to_use, [sft = shared_from_this()](
+            const std::error_code& ec) {
+            sft->on_connect(ec);
+        });
     } else {
-        while (iterator != asio::ip::tcp::resolver::iterator()) {
-            m_socket.close();
-            m_socket.connect(*iterator++, _ec);
-            if (!_ec) {
-                const std::error_code __ec;
-                on_connect(__ec);
-                break;
-            }
-        }
+        // For HTTP, use the regular socket
+        m_socket.async_connect(*endpoint_to_use, [sft = shared_from_this()](
+            const std::error_code& ec) {
+            sft->on_connect(ec);
+        });
     }
-
-    if (_ec) {
-        onError("HttpSession unable to resolve " + m_url + ": " + ec.message());
-        return;
-    }
-
-    m_timer.cancel();
-    m_timer.expires_after(std::chrono::seconds(m_timeout));
-    m_timer.async_wait([sft = shared_from_this()](const std::error_code& ec) {sft->onTimeout(ec); });
 }
 
 void HttpSession::on_connect(const std::error_code& ec)
 {
     if (ec) {
+        g_logger.error("TCP connection failed: {}", ec.message());
         onError("HttpSession unable to connect " + m_url + ": " + ec.message());
         return;
     }
 
+    g_logger.debug("TCP connection established to: {}:{}", instance_uri.domain, instance_uri.port);
+
     if (instance_uri.port == "443") {
-        m_ssl.set_verify_mode(asio::ssl::verify_peer);
-        m_ssl.set_verify_callback([](bool, const asio::ssl::verify_context&) { return true; });
+        g_logger.debug("Starting SSL handshake...");
+        m_ssl.set_verify_mode(asio::ssl::verify_none);
+        m_ssl.set_verify_callback([](bool, const asio::ssl::verify_context&) {
+            return true;
+        });
+        
+        // Set SNI (Server Name Indication)
         if (!SSL_set_tlsext_host_name(m_ssl.native_handle(), instance_uri.domain.c_str())) {
             const std::error_code _ec{ static_cast<int>(ERR_get_error()), asio::error::get_ssl_category() };
+            g_logger.error("Failed to set SNI hostname: {}", _ec.message());
             onError("HttpSession on SSL_set_tlsext_host_name unable to handshake " + m_url + ": " + _ec.message());
             return;
         }
+        
+        g_logger.debug("SNI hostname set to: {}", instance_uri.domain);
 
         m_ssl.async_handshake(asio::ssl::stream_base::client,
                               [sft = shared_from_this()](const std::error_code& ec) {
             if (ec) {
+                g_logger.error("SSL handshake failed: {} (category: {})", ec.message(), ec.category().name());
                 sft->onError("HttpSession unable to handshake " + sft->m_url + ": " + ec.message());
                 return;
             }
+            g_logger.debug("SSL handshake completed successfully");
             sft->on_write();
         });
     } else {
+        g_logger.debug("HTTP connection (non-SSL), proceeding with request");
         on_write();
     }
 
-    m_timer.cancel();
     m_timer.expires_after(std::chrono::seconds(m_timeout));
     m_timer.async_wait([sft = shared_from_this()](const std::error_code& ec) {sft->onTimeout(ec); });
 }
 
 void HttpSession::on_write()
 {
+    g_logger.debug("Sending HTTP request to: {}:{}", instance_uri.domain, instance_uri.port);
+    g_logger.debug("Request headers: {}", m_request.substr(0, std::min<size_t>(m_request.length(), size_t(200))));
+    
     if (instance_uri.port == "443") {
         async_write(m_ssl, asio::buffer(m_request), [sft = shared_from_this()]
         (const std::error_code& ec, const size_t bytes) { sft->on_request_sent(ec, bytes); });
@@ -357,7 +385,6 @@ void HttpSession::on_write()
         (const std::error_code& ec, const size_t bytes) {sft->on_request_sent(ec, bytes); });
     }
 
-    m_timer.cancel();
     m_timer.expires_after(std::chrono::seconds(m_timeout));
     m_timer.async_wait([sft = shared_from_this()](const std::error_code& ec) {sft->onTimeout(ec); });
 }
@@ -365,29 +392,46 @@ void HttpSession::on_write()
 void HttpSession::on_request_sent(const std::error_code& ec, size_t /*bytes_transferred*/)
 {
     if (ec) {
+        g_logger.error("Failed to send HTTP request: {}", ec.message());
         onError("HttpSession error on sending request " + m_url + ": " + ec.message());
         return;
     }
+
+    g_logger.debug("HTTP request sent successfully, waiting for response...");
 
     if (instance_uri.port == "443") {
         async_read_until(
             m_ssl, m_response, "\r\n\r\n",
             [this](const std::error_code& ec, const size_t size) {
             if (ec) {
+                g_logger.error("Failed to read HTTP headers: {}", ec.message());
                 onError("HttpSession error receiving header " + m_url + ": " + ec.message());
                 return;
             }
+            g_logger.debug("HTTP headers received ({} bytes)", size);
             std::string header(
                 buffers_begin(m_response.data()),
                 buffers_begin(m_response.data()) + size);
             m_response.consume(size);
 
-            const size_t pos = header.find("Content-Length: ");
-            if (pos != std::string::npos) {
+            // Check for Content-Length
+            const size_t contentLengthPos = header.find("Content-Length: ");
+            if (contentLengthPos != std::string::npos) {
                 const size_t len = std::strtoul(
-                    header.c_str() + pos + sizeof("Content-Length: ") - 1,
+                    header.c_str() + contentLengthPos + sizeof("Content-Length: ") - 1,
                     nullptr, 10);
-                m_result->size = len - m_response.size();
+                m_result->size = len;
+                g_logger.debug("Content-Length: {}", len);
+            } else {
+                // Check for Transfer-Encoding: chunked
+                const size_t transferEncodingPos = header.find("Transfer-Encoding: chunked");
+                if (transferEncodingPos != std::string::npos) {
+                    g_logger.debug("Server using chunked transfer encoding");
+                    m_result->size = 0; // Unknown size for chunked
+                } else {
+                    g_logger.warning("No Content-Length or Transfer-Encoding found in headers");
+                    m_result->size = 0; // Unknown size
+                }
             }
 
             async_read(m_ssl, m_response,
@@ -430,7 +474,6 @@ void HttpSession::on_request_sent(const std::error_code& ec, size_t /*bytes_tran
         });
     }
 
-    m_timer.cancel();
     m_timer.expires_after(std::chrono::seconds(m_timeout));
     m_timer.async_wait([sft = shared_from_this()](const std::error_code& ec) {sft->onTimeout(ec); });
 }
@@ -441,6 +484,7 @@ void HttpSession::on_read(const std::error_code& ec, const size_t bytes_transfer
         m_timer.cancel();
         const auto& data = m_response.data();
         m_result->response.append(buffers_begin(data), buffers_end(data));
+		g_logger.debug("HTTP response received ({} bytes): {}", m_result->response.size(), m_result->response);
         m_result->finished = true;
         m_callback(m_result);
     };
@@ -456,7 +500,12 @@ void HttpSession::on_read(const std::error_code& ec, const size_t bytes_transfer
     if (stdext::millis() > m_last_progress_update) {
         m_result->speed = (sum_bytes_speed_response) / ((stdext::millis() - (m_last_progress_update - 100)));
 
-        m_result->progress = (static_cast<double>(sum_bytes_response) / m_result->size) * 100;
+        if (m_result->size > 0) {
+            m_result->progress = (static_cast<double>(sum_bytes_response) / m_result->size) * 100;
+        } else {
+            // For chunked encoding or unknown size, just show bytes received
+            m_result->progress = std::min<int>(static_cast<double>(sum_bytes_response / 1024), 100.0); // Show KB received, max 100%
+        }
         m_last_progress_update = stdext::millis() + 100;
         sum_bytes_speed_response = 0;
         m_callback(m_result);
@@ -524,7 +573,9 @@ void HttpSession::close()
 void HttpSession::onTimeout(const std::error_code& ec)
 {
     if (!ec) {
-        onError(fmt::format("HttpSession ontimeout {}", ec.message()));
+        // Timer expired - this is an actual timeout
+        g_logger.error("HttpSession timeout after {} seconds", m_timeout);
+        onError("HttpSession timeout after " + std::to_string(m_timeout) + " seconds");
     }
 }
 

--- a/src/framework/net/protocolhttp.h
+++ b/src/framework/net/protocolhttp.h
@@ -80,6 +80,14 @@ public:
     {
         assert(m_callback != nullptr);
         assert(m_result != nullptr);
+        
+        // Configure SSL context properly
+        m_context.set_default_verify_paths();
+        m_context.set_verify_mode(asio::ssl::verify_none);
+        m_context.set_options(asio::ssl::context::default_workarounds |
+                              asio::ssl::context::no_sslv2 |
+                              asio::ssl::context::no_sslv3 |
+                              asio::ssl::context::single_dh_use);
     };
     void start();
     void cancel() const { onError("canceled"); }
@@ -101,7 +109,7 @@ private:
     asio::steady_timer m_timer;
     ParsedURI instance_uri;
 
-    asio::ssl::context m_context{ asio::ssl::context::tlsv12_client };
+    asio::ssl::context m_context{ asio::ssl::context::sslv23_client };
     asio::ssl::stream<asio::ip::tcp::socket> m_ssl{ m_service, m_context };
 
     std::string m_request;
@@ -168,7 +176,7 @@ private:
     bool m_handshake_complete{ false };
     ParsedURI instance_uri;
 
-    asio::ssl::context m_context{ asio::ssl::context::tlsv12_client };
+    asio::ssl::context m_context{ asio::ssl::context::sslv23_client };
     asio::ssl::stream<asio::ip::tcp::socket> m_ssl{ m_service, m_context };
 
     std::queue<std::string> m_sendQueue;
@@ -234,7 +242,7 @@ private:
     std::unordered_map<int, HttpResult_ptr> m_operations;
     std::unordered_map<int, std::shared_ptr<WebsocketSession>> m_websockets;
     std::unordered_map<std::string, HttpResult_ptr> m_downloads;
-    std::string m_userAgent = "Mozilla/5.0";
+    std::string m_userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
     std::unordered_map<std::string, std::string> m_custom_header;
 };
 


### PR DESCRIPTION
# Description

- fixed some errors with http client
- we are now requesting HTTP 1.0, because we do not support chunked encoding
- lowered timeouts a bit
- there are problems with ipv6 too, so we will now just look for ipv4 to use instead
- added debug logs to identify problems faster

## Behavior

### **Actual**

transfer-encoding: chunked is not supported and we send that we support HTTP 1.1 which is incorrect.
timeout doesn't work at all, if response doesn't finish it will never resolve, thus the http thread is stuck and never finishes

### **Expected**

Should properly parse json responses and thread should not get stuck.

## Fixes

#1198
#1242

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
