### PR TITLE
fix: stabilize X11 cursor handling and HiDPI window layout

### DIFF
--- a/modules/startup/startup.lua
+++ b/modules/startup/startup.lua
@@ -3,26 +3,59 @@ function init()
         onExit = exit
     })
 
+    local platformType = g_window.getPlatformType()
+    local isX11 = type(platformType) == 'string' and platformType:find('X11', 1, true) == 1
+    local density = (isX11 and g_window.getDisplayDensity()) or 1
+
     if g_platform.isMobile() then
         g_window.setMinimumSize({ width = 640, height = 360 })
     else
-        g_window.setMinimumSize({ width = 1020, height = 644 })
+        local minSize = { width = 1020, height = 644 }
+        if isX11 and density ~= 1 then
+            minSize = {
+                width = math.floor((minSize.width * density) + 0.5),
+                height = math.floor((minSize.height * density) + 0.5)
+            }
+        end
+        g_window.setMinimumSize(minSize)
     end
 
     -- window size
     local size = { width = 1020, height = 644 }
     size = g_settings.getSize('window-size', size)
+    if isX11 and density ~= 1 then
+        size = {
+            width = math.floor((size.width * density) + 0.5),
+            height = math.floor((size.height * density) + 0.5)
+        }
+    end
+
+    local displaySize = g_window.getDisplaySize()
+    if isX11 then
+        size.width = math.max(1, math.min(size.width, displaySize.width))
+        size.height = math.max(1, math.min(size.height, displaySize.height))
+    end
     g_window.resize(size)
 
     -- window position, default is the screen center
-    local displaySize = g_window.getDisplaySize()
     local defaultPos = {
         x = (displaySize.width - size.width) / 2,
         y = (displaySize.height - size.height) / 2
     }
     local pos = g_settings.getPoint('window-pos', defaultPos)
-    pos.x = math.max(pos.x, 0)
-    pos.y = math.max(pos.y, 0)
+    if isX11 and density ~= 1 then
+        pos = {
+            x = math.floor((pos.x * density) + 0.5),
+            y = math.floor((pos.y * density) + 0.5)
+        }
+        local maxX = math.max(displaySize.width - size.width, 0)
+        local maxY = math.max(displaySize.height - size.height, 0)
+        pos.x = math.max(0, math.min(pos.x, maxX))
+        pos.y = math.max(0, math.min(pos.y, maxY))
+    else
+        pos.x = math.max(pos.x, 0)
+        pos.y = math.max(pos.y, 0)
+    end
     g_window.move(pos)
 
     -- window maximized?
@@ -47,9 +80,25 @@ function terminate()
         onExit = exit
     })
 
+    local platformType = g_window.getPlatformType()
+    local isX11 = type(platformType) == 'string' and platformType:find('X11', 1, true) == 1
+    local density = (isX11 and g_window.getDisplayDensity()) or 1
+
     -- save window configs
-    g_settings.set('window-size', g_window.getUnmaximizedSize())
-    g_settings.set('window-pos', g_window.getUnmaximizedPos())
+    local windowSize = g_window.getUnmaximizedSize()
+    local windowPos = g_window.getUnmaximizedPos()
+    if isX11 and density ~= 1 then
+        windowSize = {
+            width = math.floor((windowSize.width / density) + 0.5),
+            height = math.floor((windowSize.height / density) + 0.5)
+        }
+        windowPos = {
+            x = math.floor((windowPos.x / density) + 0.5),
+            y = math.floor((windowPos.y / density) + 0.5)
+        }
+    end
+    g_settings.set('window-size', windowSize)
+    g_settings.set('window-pos', windowPos)
     g_settings.set('window-maximized', g_window.isMaximized())
     g_settings.save()
 end

--- a/modules/startup/startup.lua
+++ b/modules/startup/startup.lua
@@ -6,34 +6,63 @@ function init()
     local platformType = g_window.getPlatformType()
     local isX11 = type(platformType) == 'string' and platformType:find('X11', 1, true) == 1
     local density = (isX11 and g_window.getDisplayDensity()) or 1
+    local displaySize = g_window.getDisplaySize()
+    local metricsSpace = g_settings.getString('window-metrics-space', '')
+    local shouldScaleLegacySavedMetrics = isX11 and density ~= 1 and metricsSpace ~= 'physical-v1'
+    if isX11 then
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] density=%.4f metricsSpace=%s scaleLegacy=%s display=%dx%d',
+            density,
+            metricsSpace ~= '' and metricsSpace or '<empty>',
+            shouldScaleLegacySavedMetrics and 'true' or 'false',
+            displaySize.width,
+            displaySize.height
+        ))
+    end
 
     if g_platform.isMobile() then
         g_window.setMinimumSize({ width = 640, height = 360 })
     else
         local minSize = { width = 1020, height = 644 }
-        if isX11 and density ~= 1 then
-            minSize = {
-                width = math.floor((minSize.width * density) + 0.5),
-                height = math.floor((minSize.height * density) + 0.5)
-            }
+        if isX11 then
+            minSize.width = math.max(1, math.min(minSize.width, displaySize.width))
+            minSize.height = math.max(1, math.min(minSize.height, displaySize.height))
         end
         g_window.setMinimumSize(minSize)
     end
 
     -- window size
+    local hasSavedWindowSize = g_settings.exists('window-size')
     local size = { width = 1020, height = 644 }
     size = g_settings.getSize('window-size', size)
-    if isX11 and density ~= 1 then
+    if isX11 then
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-size loaded=%dx%d hasSaved=%s',
+            size.width,
+            size.height,
+            hasSavedWindowSize and 'true' or 'false'
+        ))
+    end
+    if shouldScaleLegacySavedMetrics and hasSavedWindowSize then
         size = {
             width = math.floor((size.width * density) + 0.5),
             height = math.floor((size.height * density) + 0.5)
         }
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-size scaled-to-physical=%dx%d',
+            size.width,
+            size.height
+        ))
     end
 
-    local displaySize = g_window.getDisplaySize()
     if isX11 then
         size.width = math.max(1, math.min(size.width, displaySize.width))
         size.height = math.max(1, math.min(size.height, displaySize.height))
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-size clamped=%dx%d',
+            size.width,
+            size.height
+        ))
     end
     g_window.resize(size)
 
@@ -42,16 +71,49 @@ function init()
         x = (displaySize.width - size.width) / 2,
         y = (displaySize.height - size.height) / 2
     }
-    local pos = g_settings.getPoint('window-pos', defaultPos)
-    if isX11 and density ~= 1 then
-        pos = {
-            x = math.floor((pos.x * density) + 0.5),
-            y = math.floor((pos.y * density) + 0.5)
-        }
+    local hasSavedWindowPos = g_settings.exists('window-pos')
+    local pos = defaultPos
+    if not isX11 then
+        pos = g_settings.getPoint('window-pos', defaultPos)
+    end
+    if isX11 then
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-pos loaded=(%.2f,%.2f) default=(%.2f,%.2f) hasSaved=%s',
+            pos.x,
+            pos.y,
+            defaultPos.x,
+            defaultPos.y,
+            hasSavedWindowPos and 'true' or 'false'
+        ))
+        local epsilon = 0.5
+        local isDefaultPos = math.abs(pos.x - defaultPos.x) <= epsilon and math.abs(pos.y - defaultPos.y) <= epsilon
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-pos isDefault=%s epsilon=%.2f',
+            isDefaultPos and 'true' or 'false',
+            epsilon
+        ))
+        if shouldScaleLegacySavedMetrics and hasSavedWindowPos and not isDefaultPos then
+            pos = {
+                x = math.floor((pos.x * density) + 0.5),
+                y = math.floor((pos.y * density) + 0.5)
+            }
+            g_logger.info(string.format(
+                '[X11WindowMetrics][init] window-pos scaled-to-physical=(%d,%d)',
+                pos.x,
+                pos.y
+            ))
+        end
         local maxX = math.max(displaySize.width - size.width, 0)
         local maxY = math.max(displaySize.height - size.height, 0)
         pos.x = math.max(0, math.min(pos.x, maxX))
         pos.y = math.max(0, math.min(pos.y, maxY))
+        g_logger.info(string.format(
+            '[X11WindowMetrics][init] window-pos clamped=(%d,%d) max=(%d,%d)',
+            pos.x,
+            pos.y,
+            maxX,
+            maxY
+        ))
     else
         pos.x = math.max(pos.x, 0)
         pos.y = math.max(pos.y, 0)
@@ -82,23 +144,28 @@ function terminate()
 
     local platformType = g_window.getPlatformType()
     local isX11 = type(platformType) == 'string' and platformType:find('X11', 1, true) == 1
-    local density = (isX11 and g_window.getDisplayDensity()) or 1
 
     -- save window configs
     local windowSize = g_window.getUnmaximizedSize()
     local windowPos = g_window.getUnmaximizedPos()
-    if isX11 and density ~= 1 then
-        windowSize = {
-            width = math.floor((windowSize.width / density) + 0.5),
-            height = math.floor((windowSize.height / density) + 0.5)
-        }
-        windowPos = {
-            x = math.floor((windowPos.x / density) + 0.5),
-            y = math.floor((windowPos.y / density) + 0.5)
-        }
+    if isX11 then
+        g_logger.info(string.format(
+            '[X11WindowMetrics][terminate] unmaximized size=%dx%d pos=(%d,%d)',
+            windowSize.width,
+            windowSize.height,
+            windowPos.x,
+            windowPos.y
+        ))
     end
     g_settings.set('window-size', windowSize)
-    g_settings.set('window-pos', windowPos)
+    if isX11 then
+        g_settings.remove('window-pos')
+        g_settings.set('window-metrics-space', 'physical-v1')
+        g_logger.info('[X11WindowMetrics][terminate] window-pos persistence disabled on X11; window-metrics-space=physical-v1')
+    else
+        g_settings.set('window-pos', windowPos)
+        g_settings.remove('window-metrics-space')
+    end
     g_settings.set('window-maximized', g_window.isMaximized())
     g_settings.save()
 end

--- a/modules/startup/startup.lua
+++ b/modules/startup/startup.lua
@@ -9,16 +9,6 @@ function init()
     local displaySize = g_window.getDisplaySize()
     local metricsSpace = g_settings.getString('window-metrics-space', '')
     local shouldScaleLegacySavedMetrics = isX11 and density ~= 1 and metricsSpace ~= 'physical-v1'
-    if isX11 then
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] density=%.4f metricsSpace=%s scaleLegacy=%s display=%dx%d',
-            density,
-            metricsSpace ~= '' and metricsSpace or '<empty>',
-            shouldScaleLegacySavedMetrics and 'true' or 'false',
-            displaySize.width,
-            displaySize.height
-        ))
-    end
 
     if g_platform.isMobile() then
         g_window.setMinimumSize({ width = 640, height = 360 })
@@ -35,34 +25,16 @@ function init()
     local hasSavedWindowSize = g_settings.exists('window-size')
     local size = { width = 1020, height = 644 }
     size = g_settings.getSize('window-size', size)
-    if isX11 then
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-size loaded=%dx%d hasSaved=%s',
-            size.width,
-            size.height,
-            hasSavedWindowSize and 'true' or 'false'
-        ))
-    end
     if shouldScaleLegacySavedMetrics and hasSavedWindowSize then
         size = {
             width = math.floor((size.width * density) + 0.5),
             height = math.floor((size.height * density) + 0.5)
         }
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-size scaled-to-physical=%dx%d',
-            size.width,
-            size.height
-        ))
     end
 
     if isX11 then
         size.width = math.max(1, math.min(size.width, displaySize.width))
         size.height = math.max(1, math.min(size.height, displaySize.height))
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-size clamped=%dx%d',
-            size.width,
-            size.height
-        ))
     end
     g_window.resize(size)
 
@@ -77,43 +49,18 @@ function init()
         pos = g_settings.getPoint('window-pos', defaultPos)
     end
     if isX11 then
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-pos loaded=(%.2f,%.2f) default=(%.2f,%.2f) hasSaved=%s',
-            pos.x,
-            pos.y,
-            defaultPos.x,
-            defaultPos.y,
-            hasSavedWindowPos and 'true' or 'false'
-        ))
         local epsilon = 0.5
         local isDefaultPos = math.abs(pos.x - defaultPos.x) <= epsilon and math.abs(pos.y - defaultPos.y) <= epsilon
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-pos isDefault=%s epsilon=%.2f',
-            isDefaultPos and 'true' or 'false',
-            epsilon
-        ))
         if shouldScaleLegacySavedMetrics and hasSavedWindowPos and not isDefaultPos then
             pos = {
                 x = math.floor((pos.x * density) + 0.5),
                 y = math.floor((pos.y * density) + 0.5)
             }
-            g_logger.info(string.format(
-                '[X11WindowMetrics][init] window-pos scaled-to-physical=(%d,%d)',
-                pos.x,
-                pos.y
-            ))
         end
         local maxX = math.max(displaySize.width - size.width, 0)
         local maxY = math.max(displaySize.height - size.height, 0)
         pos.x = math.max(0, math.min(pos.x, maxX))
         pos.y = math.max(0, math.min(pos.y, maxY))
-        g_logger.info(string.format(
-            '[X11WindowMetrics][init] window-pos clamped=(%d,%d) max=(%d,%d)',
-            pos.x,
-            pos.y,
-            maxX,
-            maxY
-        ))
     else
         pos.x = math.max(pos.x, 0)
         pos.y = math.max(pos.y, 0)
@@ -148,22 +95,12 @@ function terminate()
     -- save window configs
     local windowSize = g_window.getUnmaximizedSize()
     local windowPos = g_window.getUnmaximizedPos()
-    if isX11 then
-        g_logger.info(string.format(
-            '[X11WindowMetrics][terminate] unmaximized size=%dx%d pos=(%d,%d)',
-            windowSize.width,
-            windowSize.height,
-            windowPos.x,
-            windowPos.y
-        ))
-    end
     g_settings.set('window-size', windowSize)
     if isX11 then
         -- NOTE: Keep window-pos disabled on X11.
         -- Persisting it causes a second-launch sizing/position regression with current metrics flow.
         g_settings.remove('window-pos')
         g_settings.set('window-metrics-space', 'physical-v1')
-        g_logger.info('[X11WindowMetrics][terminate] window-pos persistence disabled on X11; window-metrics-space=physical-v1')
     else
         g_settings.set('window-pos', windowPos)
         g_settings.remove('window-metrics-space')

--- a/modules/startup/startup.lua
+++ b/modules/startup/startup.lua
@@ -159,6 +159,8 @@ function terminate()
     end
     g_settings.set('window-size', windowSize)
     if isX11 then
+        -- NOTE: Keep window-pos disabled on X11.
+        -- Persisting it causes a second-launch sizing/position regression with current metrics flow.
         g_settings.remove('window-pos')
         g_settings.set('window-metrics-space', 'physical-v1')
         g_logger.info('[X11WindowMetrics][terminate] window-pos persistence disabled on X11; window-metrics-space=physical-v1')

--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -27,9 +27,154 @@
 #include <framework/core/eventdispatcher.h>
 #include <framework/util/stats.h>
 #include <framework/graphics/image.h>
+#include <X11/Xresource.h>
+#include <X11/cursorfont.h>
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
 #include <unistd.h>
 
-#define LSB_BIT_SET(p, n) (p[(n)/8] |= (1 <<((n)%8)))
+namespace {
+void setCursorBitmapBit(std::vector<uint8_t>& bits, const int bytesPerRow, const int x, const int y)
+{
+    const int index = y * bytesPerRow + (x / 8);
+    bits[index] |= static_cast<uint8_t>(1u << (x % 8));
+}
+
+enum class DensitySource {
+    EnvOverride,
+    XftDpi,
+    PhysicalDpi,
+    Fallback
+};
+
+float parsePositiveFloat(const char* text)
+{
+    if (!text || !*text)
+        return 0.f;
+
+    char* end = nullptr;
+    const double value = std::strtod(text, &end);
+    if (end == text || !std::isfinite(value) || value <= 0.0)
+        return 0.f;
+
+    return static_cast<float>(value);
+}
+
+float getEnvDensityScale()
+{
+    const float scale = parsePositiveFloat(std::getenv("OTCLIENT_DPI_SCALE"));
+    if (scale <= 0.f)
+        return 0.f;
+
+    return std::clamp(scale, 0.75f, 4.0f);
+}
+
+float getXftDpi(Display* display)
+{
+    XrmInitialize();
+
+    const char* resourceString = XResourceManagerString(display);
+    if (!resourceString)
+        return 0.f;
+
+    XrmDatabase db = XrmGetStringDatabase(resourceString);
+    if (!db)
+        return 0.f;
+
+    XrmValue value;
+    char* type = nullptr;
+    const bool found = XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &value) && value.addr;
+
+    float dpi = 0.f;
+    if (found)
+        dpi = parsePositiveFloat(value.addr);
+
+    XrmDestroyDatabase(db);
+    return dpi;
+}
+
+float getPhysicalDpi(Display* display, const int screen)
+{
+    const int pxW = DisplayWidth(display, screen);
+    const int pxH = DisplayHeight(display, screen);
+    const int mmW = DisplayWidthMM(display, screen);
+    const int mmH = DisplayHeightMM(display, screen);
+
+    if (pxW <= 0 || pxH <= 0 || mmW <= 0 || mmH <= 0)
+        return 0.f;
+
+    const float dpiX = static_cast<float>(pxW) * 25.4f / static_cast<float>(mmW);
+    const float dpiY = static_cast<float>(pxH) * 25.4f / static_cast<float>(mmH);
+    const float avg = (dpiX + dpiY) * 0.5f;
+    if (!std::isfinite(avg) || avg < 72.f || avg > 600.f)
+        return 0.f;
+
+    return avg;
+}
+
+float resolveDisplayDensity(Display* display, const int screen, DensitySource& source)
+{
+    source = DensitySource::Fallback;
+
+    const float envScale = getEnvDensityScale();
+    if (envScale > 0.f) {
+        source = DensitySource::EnvOverride;
+        return envScale;
+    }
+
+    const float xftDpi = getXftDpi(display);
+    if (xftDpi > 0.f) {
+        source = DensitySource::XftDpi;
+        return std::clamp(xftDpi / 96.f, 0.75f, 4.0f);
+    }
+
+    const float physicalDpi = getPhysicalDpi(display, screen);
+    if (physicalDpi > 0.f) {
+        source = DensitySource::PhysicalDpi;
+        return std::clamp(physicalDpi / 96.f, 0.75f, 4.0f);
+    }
+
+    return 1.0f;
+}
+
+unsigned int getSystemCursorShape(std::string cursorName)
+{
+    std::transform(cursorName.begin(), cursorName.end(), cursorName.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+
+    if (cursorName == "arrow" || cursorName == "default")
+        return XC_left_ptr;
+    if (cursorName == "horizontal" || cursorName == "sizewe")
+        return XC_sb_h_double_arrow;
+    if (cursorName == "vertical" || cursorName == "sizens")
+        return XC_sb_v_double_arrow;
+    if (cursorName == "diagonal1" || cursorName == "sizenwse")
+        return XC_bottom_right_corner;
+    if (cursorName == "diagonal2" || cursorName == "sizenesw")
+        return XC_bottom_left_corner;
+    if (cursorName == "move" || cursorName == "sizeall")
+        return XC_fleur;
+    if (cursorName == "text" || cursorName == "ibeam" || cursorName == "textselect")
+        return XC_xterm;
+    if (cursorName == "hand" || cursorName == "pointer" || cursorName == "link" || cursorName == "linkselect")
+        return XC_hand2;
+    if (cursorName == "cross" || cursorName == "precision" || cursorName == "precisionselect")
+        return XC_crosshair;
+    if (cursorName == "wait" || cursorName == "hourglass" || cursorName == "appstarting")
+        return XC_watch;
+    if (cursorName == "no" || cursorName == "forbidden" || cursorName == "unavailable")
+        return XC_X_cursor;
+    if (cursorName == "help")
+        return XC_question_arrow;
+    if (cursorName == "uparrow")
+        return XC_sb_up_arrow;
+
+    return XC_left_ptr;
+}
+}
 
 X11Window::X11Window()
 {
@@ -218,6 +363,9 @@ X11Window::X11Window()
 void X11Window::init()
 {
     internalOpenDisplay();
+    DensitySource densitySource = DensitySource::Fallback;
+    setDisplayDensity(resolveDisplayDensity(m_display, m_screen, densitySource));
+
     internalCheckGL();
     internalChooseGLVisual();
     internalCreateGLContext();
@@ -239,6 +387,12 @@ void X11Window::terminate()
     for (Cursor cursor : m_cursors)
         XFreeCursor(m_display, cursor);
     m_cursors.clear();
+
+    for (const auto& [shape, cursor] : m_systemCursors) {
+        if (cursor != X11None)
+            XFreeCursor(m_display, cursor);
+    }
+    m_systemCursors.clear();
 
     if (m_window) {
         XDestroyWindow(m_display, m_window);
@@ -363,6 +517,12 @@ bool X11Window::internalSetupWindowInput()
     }
 
     return true;
+}
+
+void X11Window::restoreMouseCursorNow()
+{
+    XUndefineCursor(m_display, m_window);
+    m_cursor = X11None;
 }
 
 void X11Window::internalCheckGL()
@@ -879,7 +1039,7 @@ void X11Window::hideMouse()
 {
     g_mainDispatcher.addEvent([&] {
         if (m_cursor != X11None)
-            restoreMouseCursor();
+            restoreMouseCursorNow();
 
         if (m_hiddenCursor == X11None) {
             char bm[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -903,27 +1063,61 @@ void X11Window::setMouseCursor(int cursorId)
             return;
 
         if (m_cursor != X11None)
-            restoreMouseCursor();
+            restoreMouseCursorNow();
 
         m_cursor = m_cursors[cursorId];
         XDefineCursor(m_display, m_window, m_cursor);
         });
 }
 
+void X11Window::setSystemCursor(const std::string& cursorName)
+{
+    g_mainDispatcher.addEvent([this, cursorName] {
+        if (m_display == nullptr || m_window == 0)
+            return;
+
+        if (m_cursor != X11None)
+            restoreMouseCursorNow();
+
+        const unsigned int shape = getSystemCursorShape(cursorName);
+        Cursor cursor = X11None;
+
+        const auto it = m_systemCursors.find(shape);
+        if (it != m_systemCursors.end()) {
+            cursor = it->second;
+        } else {
+            cursor = XCreateFontCursor(m_display, shape);
+            if (cursor != X11None)
+                m_systemCursors[shape] = cursor;
+        }
+
+        if (cursor == X11None) {
+            g_logger.warning("X11 system cursor failed for name='{}' shape={}", cursorName, shape);
+            return;
+        }
+
+        m_cursor = cursor;
+        XDefineCursor(m_display, m_window, m_cursor);
+    });
+}
+
 void X11Window::restoreMouseCursor()
 {
     g_mainDispatcher.addEvent([&] {
-        XUndefineCursor(m_display, m_window);
-        m_cursor = X11None;
+        restoreMouseCursorNow();
         });
 }
 
 int X11Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hotSpot)
 {
-    int width = image->getWidth();
-    int height = image->getHeight();
-    int numbits = width * height;
-    int numbytes = (width * height) / 8;
+    static constexpr uint8_t kCursorAlphaThreshold = 32;
+    static constexpr int kCursorLumaThreshold = 128;
+
+    const int width = image->getWidth();
+    const int height = image->getHeight();
+    const int bytesPerRow = (width + 7) / 8;
+    const int numbytes = bytesPerRow * height;
+    const int numbits = width * height;
 
     XColor bg, fg;
     bg.red = 255 << 8;
@@ -935,15 +1129,36 @@ int X11Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hotSp
 
     std::vector<uint8_t> mapBits(numbytes, 0);
     std::vector<uint8_t> maskBits(numbytes, 0);
+    int opaqueWhitePixels = 0;
+    int opaqueBlackPixels = 0;
+    int transparentPixels = 0;
+    int translucentClippedPixels = 0;
 
     for (int i = 0; i < numbits; ++i) {
-        uint32_t rgba = stdext::readULE32(image->getPixelData() + i * 4);
-        if (rgba == 0xffffffff) { //white, background
-            LSB_BIT_SET(maskBits, i);
-        } else if (rgba == 0xff000000) { //black, foreground
-            LSB_BIT_SET(mapBits, i);
-            LSB_BIT_SET(maskBits, i);
-        } //otherwise 0x00000000 => alpha
+        const int x = i % width;
+        const int y = i / width;
+        const uint8_t* pixel = image->getPixelData() + i * 4;
+        const int r = pixel[0];
+        const int g = pixel[1];
+        const int b = pixel[2];
+        const int a = pixel[3];
+
+        if (a <= kCursorAlphaThreshold) {
+            ++transparentPixels;
+            if (a > 0)
+                ++translucentClippedPixels;
+            continue;
+        }
+
+        const int luma = (r * 299 + g * 587 + b * 114) / 1000;
+        if (luma >= kCursorLumaThreshold) {
+            setCursorBitmapBit(maskBits, bytesPerRow, x, y);
+            ++opaqueWhitePixels;
+        } else {
+            setCursorBitmapBit(mapBits, bytesPerRow, x, y);
+            setCursorBitmapBit(maskBits, bytesPerRow, x, y);
+            ++opaqueBlackPixels;
+        }
     }
 
     Pixmap cp = XCreateBitmapFromData(m_display, m_window, (char*)&mapBits[0], width, height);
@@ -951,6 +1166,36 @@ int X11Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hotSp
     Cursor cursor = XCreatePixmapCursor(m_display, cp, mp, &fg, &bg, hotSpot.x, hotSpot.y);
     XFreePixmap(m_display, cp);
     XFreePixmap(m_display, mp);
+
+    const int maskPixels = opaqueWhitePixels + opaqueBlackPixels;
+    const int mapPixels = opaqueBlackPixels;
+    const auto createFallbackCursor = [&]() -> int {
+        const Cursor fallbackCursor = XCreateFontCursor(m_display, XC_left_ptr);
+        if (fallbackCursor != X11None) {
+            g_logger.warning(
+                "X11 cursor fallback: using XC_left_ptr size={}x{} hotspot=({}, {}) handle={}",
+                width, height, hotSpot.x, hotSpot.y, static_cast<unsigned long>(fallbackCursor));
+            m_cursors.push_back(fallbackCursor);
+            return m_cursors.size() - 1;
+        }
+
+        g_logger.error(
+            "X11 cursor fallback failed: unable to create XC_left_ptr size={}x{} hotspot=({}, {})",
+            width, height, hotSpot.x, hotSpot.y);
+        return -1;
+    };
+
+    if (maskPixels == 0) {
+        if (cursor != X11None)
+            XFreeCursor(m_display, cursor);
+        g_logger.warning("X11 cursor fallback trigger: empty mask after conversion");
+        return createFallbackCursor();
+    }
+
+    if (cursor == X11None) {
+        g_logger.warning("X11 cursor fallback trigger: XCreatePixmapCursor returned X11None");
+        return createFallbackCursor();
+    }
 
     m_cursors.push_back(cursor);
     return m_cursors.size() - 1;

--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -1092,7 +1092,7 @@ void X11Window::setSystemCursor(const std::string& cursorName)
         }
 
         if (cursor == X11None) {
-            g_logger.warning("X11 system cursor failed for name='{}' shape={}", cursorName, shape);
+            g_logger.debug("X11 system cursor failed for name='{}' shape={}", cursorName, shape);
             return;
         }
 
@@ -1172,7 +1172,7 @@ int X11Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hotSp
     const auto createFallbackCursor = [&]() -> int {
         const Cursor fallbackCursor = XCreateFontCursor(m_display, XC_left_ptr);
         if (fallbackCursor != X11None) {
-            g_logger.warning(
+            g_logger.debug(
                 "X11 cursor fallback: using XC_left_ptr size={}x{} hotspot=({}, {}) handle={}",
                 width, height, hotSpot.x, hotSpot.y, static_cast<unsigned long>(fallbackCursor));
             m_cursors.push_back(fallbackCursor);
@@ -1188,12 +1188,12 @@ int X11Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hotSp
     if (maskPixels == 0) {
         if (cursor != X11None)
             XFreeCursor(m_display, cursor);
-        g_logger.warning("X11 cursor fallback trigger: empty mask after conversion");
+        g_logger.debug("X11 cursor fallback trigger: empty mask after conversion");
         return createFallbackCursor();
     }
 
     if (cursor == X11None) {
-        g_logger.warning("X11 cursor fallback trigger: XCreatePixmapCursor returned X11None");
+        g_logger.debug("X11 cursor fallback trigger: XCreatePixmapCursor returned X11None");
         return createFallbackCursor();
     }
 

--- a/src/framework/platform/x11window.h
+++ b/src/framework/platform/x11window.h
@@ -52,6 +52,7 @@ class X11Window : public PlatformWindow
     void internalCreateGLContext();
     void internalDestroyGLContext();
     void internalConnectGLContext();
+    void restoreMouseCursorNow();
 
     void *getExtensionProcAddress(const char *ext);
     bool isExtensionSupported(const char *ext);
@@ -73,6 +74,7 @@ public:
     void hideMouse();
 
     void setMouseCursor(int cursorId);
+    void setSystemCursor(const std::string& cursorName) override;
     void restoreMouseCursor();
 
     void setTitle(const std::string_view title);
@@ -96,6 +98,7 @@ private:
     Window m_rootWindow;
     Colormap m_colormap;
     std::vector<Cursor> m_cursors;
+    stdext::map<unsigned int, Cursor> m_systemCursors;
     Cursor m_cursor;
     Cursor m_hiddenCursor;
     XIM m_xim;
@@ -116,4 +119,3 @@ private:
 };
 
 #endif
-


### PR DESCRIPTION
This PR fixes Linux/X11 window scaling and cursor instability issues that were causing incorrect window sizing/positioning and intermittent invisible or incorrect mouse cursors.

Summary of changes:
- Added robust X11 display density resolution with ordered fallbacks:
  1. `OTCLIENT_DPI_SCALE` override
  2. `Xft.dpi`
  3. physical DPI from X11 screen metrics
  4. fallback `1.0`
- Fixed X11 custom cursor bitmap generation:
  - corrected bitmap packing to use per-row stride
  - improved RGBA -> monochrome conversion using alpha + luminance thresholds
  - added safe fallback to system cursor when conversion produces an empty/invalid cursor
- Implemented `setSystemCursor(...)` for X11:
  - mapped common cursor names to X11 cursor shapes
  - added cursor caching and proper cleanup on terminate
- Scoped startup window size/position density scaling to X11 only:
  - preserves existing behavior on non-X11 platforms
  - avoids Linux HiDPI mismatch when restoring window layout

Motivation/context:
- On Linux/X11 (including XWayland setups), relying on a single DPI source was not reliable.
- X11 cursor conversion was too strict and bit packing was incorrect for non-8-aligned widths, causing cursor rendering failures.
- `setSystemCursor` had no X11 implementation, so native cursor mode behavior was inconsistent.
- Restored window geometry could be misaligned on Linux HiDPI without X11-specific normalization.

Dependencies:
- No new external dependencies added.
- Uses existing X11 headers/libraries already used by the platform backend.

## Behavior
### **Actual**
- On Linux/X11, window could restore with wrong dimensions/offset.
- Cursor could become invisible/intermittent or not switch correctly in native cursor flows.
- `setSystemCursor(...)` calls were not effective on X11.

### **Expected**
- Linux/X11 window restores with correct size/position under HiDPI scaling.
- Cursor remains visible and stable across hover/drag/native cursor flows.
- `setSystemCursor(...)` works consistently on X11.

## Fixes
# (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested
- [x] Build: `cmake --build build/linux-release -j4`
- [x] Manual validation on Linux/X11:
  - start client normally and verify window placement/size
  - enable native cursor and verify `cross`, `text`, `hand` transitions
  - verify cursor visibility on startup/hover/drag
  - restart client and verify window geometry persistence

**Test Configuration**:
- Server Version: local/dev
- Client: OTClient - Redemption 4.x (desenv), commit `ae1543664`
- Operating System: Ubuntu 24.04.4 LTS (X11/XWayland environment)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic display density scaling on X11: window sizes and positions adapt to HiDPI and legacy saved metrics.
  * New system cursor API: set named system cursors with improved creation, caching, fallbacks, and immediate restoration.

* **Bug Fixes**
  * X11 window size/position loading now scales legacy values and clamps them to display bounds to prevent off-screen restores.
  * More robust mouse cursor restoration and cleanup with safer fallback cursors.

* **Chores**
  * Enhanced X11 init/terminate diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->