### PR TITLE
fix: hidden creatures in drawing logic

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -64,13 +64,15 @@ Creature::~Creature() {
     g_stats.removeCreature();
 }
 
+bool Creature::isHidden() const { return m_type == Proto::CreatureTypeHidden; }
+
 void Creature::onCreate() {
     callLuaField("onCreate");
 }
 
 void Creature::draw(const Point& dest, const bool drawThings, LightView* /*lightView*/)
 {
-    if (!canBeSeen() || !canDraw() || isDead())
+    if (!canBeSeen() || !canDraw() || (isDead() && !isHidden()))
         return;
 
     if (drawThings) {
@@ -161,7 +163,7 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, con
         DEFAULT_COLOR(96, 96, 96),
         NPC_COLOR(0x66, 0xcc, 0xff);
 
-    if (isDead() || !canBeSeen() || !(drawFlags & Otc::DrawCreatureInfo) || !mapRect.isInRange(getPosition()))
+    if (isHidden() || isDead() || !canBeSeen() || !(drawFlags & Otc::DrawCreatureInfo) || !mapRect.isInRange(getPosition()))
         return;
 
     if (g_gameConfig.isDrawingInformationByWidget()) {

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -67,8 +67,8 @@ Creature::~Creature() {
 bool Creature::isHidden() const {
     if (m_type == Proto::CreatureTypeHidden)
         return true;
-    // Old protocol (< 910): healthPercent=0 means health is hidden, not that the creature is dead
-    return g_game.getClientVersion() < 910 && m_healthPercent == 0;
+    // Old protocol (< 1273): healthPercent=0 means health is hidden, not that the creature is dead
+    return g_game.getClientVersion() < 1273 && m_healthPercent == 0;
 }
 
 void Creature::onCreate() {

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -64,7 +64,12 @@ Creature::~Creature() {
     g_stats.removeCreature();
 }
 
-bool Creature::isHidden() const { return m_type == Proto::CreatureTypeHidden; }
+bool Creature::isHidden() const {
+    if (m_type == Proto::CreatureTypeHidden)
+        return true;
+    // Old protocol (< 910): healthPercent=0 means health is hidden, not that the creature is dead
+    return g_game.getClientVersion() < 910 && m_healthPercent == 0;
+}
 
 void Creature::onCreate() {
     callLuaField("onCreate");

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -151,6 +151,7 @@ public:
     const Position& getOldPosition() const { return m_oldPosition; }
     bool isInvisible() { return m_outfit.isEffect() && m_outfit.getAuxId() == 13; }
     bool isDead() { return m_healthPercent <= 0; }
+    bool isHidden() const;
     bool isFullHealth() { return m_healthPercent == 100; }
     bool canBeSeen() { return !isInvisible() || isPlayer(); }
     bool isCreature() const override { return true; }


### PR DESCRIPTION


# Description

Add Creature::isHidden() and update drawing behavior to treat hidden creatures specially. Implemented isHidden() in creature.cpp and declared it in creature.h. draw() now only skips drawing for dead creatures when they are not hidden (allowing hidden dead creatures to be rendered), and drawInformation() now returns early for hidden creatures so they don't display UI info.


## Behavior

### **Actual**

<img width="162" height="157" alt="image" src="https://github.com/user-attachments/assets/4c1c8dae-277d-4899-9678-82bef984427c" />



### **Expected**

<img width="162" height="157" alt="image" src="https://github.com/user-attachments/assets/751440d0-d4e5-4e45-8002-bc0d22f763b0" />

## Fixes

#1618

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested
<img width="385" height="115" alt="image" src="https://github.com/user-attachments/assets/37a52c48-c0ca-4f80-816e-34b88166e9a9" />
<img width="314" height="55" alt="image" src="https://github.com/user-attachments/assets/9c0b4bdc-3ffa-4727-b5d5-566111bc113a" />

**Test Configuration**:

  - Server Version: canary 15.00 and 8.60
  - Client: this pr
  - Operating System: windows

## Checklist

  - [x] My code follows the style guidelines of this project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hidden creature rendering. Previously, hidden dead creatures were not rendered. This update corrects the behavior so hidden dead creatures appear properly in the game world. Additionally, information overlays for hidden creatures are now properly suppressed from display, maintaining mechanics integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->