### PR TITLE
fix: animation phase durations and frame groups

### DIFF
--- a/src/client/animator.cpp
+++ b/src/client/animator.cpp
@@ -41,6 +41,21 @@ void Animator::unserializeAppearance(const appearances::SpriteAnimation& animati
         m_phaseDurations.emplace_back(phase.duration_min(), phase.duration_max());
     }
 
+    // Replace zero-duration phases with the first non-zero duration found.
+    // Zero durations in protobuf data cause instant phase cycling (1ms per phase),
+    // making the animation appear broken. The missing duration inherits from its neighbours.
+    {
+        int fallbackMin = 0, fallbackMax = 0;
+        for (const auto& [mn, mx] : m_phaseDurations) {
+            if (mn > 0 || mx > 0) { fallbackMin = mn; fallbackMax = mx; break; }
+        }
+        if (fallbackMin > 0 || fallbackMax > 0) {
+            for (auto& [mn, mx] : m_phaseDurations) {
+                if (mn == 0 && mx == 0) { mn = fallbackMin; mx = fallbackMax; }
+            }
+        }
+    }
+
     m_phase = getStartPhase();
 
     assert(m_animationPhases == static_cast<int>(m_phaseDurations.size()));

--- a/src/client/animator.cpp
+++ b/src/client/animator.cpp
@@ -41,18 +41,15 @@ void Animator::unserializeAppearance(const appearances::SpriteAnimation& animati
         m_phaseDurations.emplace_back(phase.duration_min(), phase.duration_max());
     }
 
-    // Replace zero-duration phases with the first non-zero duration found.
-    // Zero durations in protobuf data cause instant phase cycling (1ms per phase),
-    // making the animation appear broken. The missing duration inherits from its neighbours.
+    // Replace zero-duration phases so they don't cause instant cycling (1ms per phase).
+    // Use the first non-zero duration found; fall back to 1ms if every phase is zero.
     {
-        int fallbackMin = 0, fallbackMax = 0;
+        int fallbackMin = 1, fallbackMax = 1;
         for (const auto& [mn, mx] : m_phaseDurations) {
             if (mn > 0 || mx > 0) { fallbackMin = mn; fallbackMax = mx; break; }
         }
-        if (fallbackMin > 0 || fallbackMax > 0) {
-            for (auto& [mn, mx] : m_phaseDurations) {
-                if (mn == 0 && mx == 0) { mn = fallbackMin; mx = fallbackMax; }
-            }
+        for (auto& [mn, mx] : m_phaseDurations) {
+            if (mn == 0 && mx == 0) { mn = fallbackMin; mx = fallbackMax; }
         }
     }
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -1205,7 +1205,10 @@ uint16_t Creature::getCurrentAnimationPhase(const bool mount)
         const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;
         if (animationPeriod <= 0) return 0;
 
-        return static_cast<uint16_t>((g_clock.millis() % animationPeriod) / ticksPerFrame);
+        // When a static idle frame group exists (no idleAnimator but idle sprites are present),
+        // skip over the idle phase(s) so animateAlways only cycles through the moving frames.
+        const int idlePhases = thingType->getIdleAnimationPhases();
+        return static_cast<uint16_t>(idlePhases + (g_clock.millis() % animationPeriod) / ticksPerFrame);
     }
 
     return isDisabledWalkAnimation() ? 0 : m_walkAnimationPhase;

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -117,13 +117,21 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
         }
 
         // When frame groups have different pattern dimensions (e.g. idle patternX=1 vs moving patternX=4),
-        // the sprite index formula breaks because it uses the final (moving) dimensions for all phases.
-        // Expand smaller frame groups to match the final dimensions by repeating sprites.
+        // the sprite index formula breaks. Remap all groups to the maximum dimensions found across
+        // all frame groups: smaller groups repeat their sprites, larger groups are never truncated.
         if (fgInfos.size() > 1) {
+            int tgtX = 1, tgtY = 1, tgtZ = 1, tgtL = 1;
+            for (const auto& fg : fgInfos) {
+                tgtX = std::max(tgtX, fg.numPatternX);
+                tgtY = std::max(tgtY, fg.numPatternY);
+                tgtZ = std::max(tgtZ, fg.numPatternZ);
+                tgtL = std::max(tgtL, fg.layers);
+            }
+
             bool dimensionMismatch = false;
             for (const auto& fg : fgInfos) {
-                if (fg.numPatternX != (int)m_numPatternX || fg.numPatternY != (int)m_numPatternY ||
-                    fg.numPatternZ != (int)m_numPatternZ || fg.layers != (int)m_layers) {
+                if (fg.numPatternX != tgtX || fg.numPatternY != tgtY ||
+                    fg.numPatternZ != tgtZ || fg.layers != tgtL) {
                     dimensionMismatch = true;
                     break;
                 }
@@ -132,14 +140,14 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
             if (dimensionMismatch) {
                 const auto oldIndex = std::move(m_spritesIndex);
                 m_spritesIndex.clear();
-                m_spritesIndex.reserve(m_animationPhases * m_numPatternX * m_numPatternY * m_numPatternZ * m_layers);
+                m_spritesIndex.reserve(m_animationPhases * tgtX * tgtY * tgtZ * tgtL);
 
                 for (const auto& fg : fgInfos) {
                     for (int a = 0; a < fg.phases; ++a) {
-                        for (int z = 0; z < (int)m_numPatternZ; ++z) {
-                            for (int y = 0; y < (int)m_numPatternY; ++y) {
-                                for (int x = 0; x < (int)m_numPatternX; ++x) {
-                                    for (int l = 0; l < (int)m_layers; ++l) {
+                        for (int z = 0; z < tgtZ; ++z) {
+                            for (int y = 0; y < tgtY; ++y) {
+                                for (int x = 0; x < tgtX; ++x) {
+                                    for (int l = 0; l < tgtL; ++l) {
                                         const int srcX = std::min(x, fg.numPatternX - 1);
                                         const int srcY = std::min(y, fg.numPatternY - 1);
                                         const int srcZ = std::min(z, fg.numPatternZ - 1);
@@ -153,6 +161,12 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
                         }
                     }
                 }
+
+                // Update member dimensions to reflect the unified target grid.
+                m_numPatternX = tgtX;
+                m_numPatternY = tgtY;
+                m_numPatternZ = tgtZ;
+                m_layers      = tgtL;
             }
         }
 
@@ -1076,7 +1090,7 @@ bool ThingType::isTall(const bool useRealSize) { return useRealSize ? getRealSiz
 int ThingType::getAnimationPhases() const { return m_animator ? m_animator->getAnimationPhases() : m_animationPhases; }
 int ThingType::getIdleAnimationPhases() const {
     if (m_idleAnimator) return m_idleAnimator->getAnimationPhases();
-    if (m_animator) return m_animationPhases - m_animator->getAnimationPhases();
+    if (m_animator) return std::max(0, m_animationPhases - m_animator->getAnimationPhases());
     return 0;
 }
 

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -65,6 +65,11 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
         m_animationPhases = 0;
         int totalSpritesCount = 0;
 
+        struct FrameGroupInfo {
+            int startIndex, numPatternX, numPatternY, numPatternZ, layers, phases;
+        };
+        std::vector<FrameGroupInfo> fgInfos;
+
         for (const auto& framegroup : appearance.frame_group()) {
             const int frameGroupType = framegroup.fixed_frame_group();
             const auto& spriteInfo = framegroup.sprite_info();
@@ -78,7 +83,8 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
             m_layers = spriteInfo.layers();
             m_opaque = spriteInfo.is_opaque();
 
-            m_animationPhases += std::max<int>(1, spritesPhases.size());
+            const int groupPhases = std::max<int>(1, spritesPhases.size());
+            m_animationPhases += groupPhases;
 
             if (const auto& sheet = g_spriteAppearances.getSheetBySpriteId(spriteInfo.sprite_id(0), false)) {
                 m_size = sheet->getSpriteSize() / g_gameConfig.getSpriteSize();
@@ -95,17 +101,59 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
                     m_idleAnimator = animator;
             }
 
-            const int totalSprites = m_layers * m_numPatternX * m_numPatternY * m_numPatternZ * std::max<int>(1, spritesPhases.size());
+            const int totalSprites = m_layers * m_numPatternX * m_numPatternY * m_numPatternZ * groupPhases;
 
             if (totalSpritesCount + totalSprites > 4096)
                 throw Exception("a thing type has more than 4096 sprites");
 
+            const int fgStartIndex = totalSpritesCount;
             m_spritesIndex.resize(totalSpritesCount + totalSprites);
             for (int j = totalSpritesCount, spriteId = 0; j < (totalSpritesCount + totalSprites); ++j, ++spriteId) {
                 m_spritesIndex[j] = spriteInfo.sprite_id(spriteId);
             }
 
+            fgInfos.push_back({fgStartIndex, (int)m_numPatternX, (int)m_numPatternY, (int)m_numPatternZ, (int)m_layers, groupPhases});
             totalSpritesCount += totalSprites;
+        }
+
+        // When frame groups have different pattern dimensions (e.g. idle patternX=1 vs moving patternX=4),
+        // the sprite index formula breaks because it uses the final (moving) dimensions for all phases.
+        // Expand smaller frame groups to match the final dimensions by repeating sprites.
+        if (fgInfos.size() > 1) {
+            bool dimensionMismatch = false;
+            for (const auto& fg : fgInfos) {
+                if (fg.numPatternX != (int)m_numPatternX || fg.numPatternY != (int)m_numPatternY ||
+                    fg.numPatternZ != (int)m_numPatternZ || fg.layers != (int)m_layers) {
+                    dimensionMismatch = true;
+                    break;
+                }
+            }
+
+            if (dimensionMismatch) {
+                const auto oldIndex = std::move(m_spritesIndex);
+                m_spritesIndex.clear();
+                m_spritesIndex.reserve(m_animationPhases * m_numPatternX * m_numPatternY * m_numPatternZ * m_layers);
+
+                for (const auto& fg : fgInfos) {
+                    for (int a = 0; a < fg.phases; ++a) {
+                        for (int z = 0; z < (int)m_numPatternZ; ++z) {
+                            for (int y = 0; y < (int)m_numPatternY; ++y) {
+                                for (int x = 0; x < (int)m_numPatternX; ++x) {
+                                    for (int l = 0; l < (int)m_layers; ++l) {
+                                        const int srcX = std::min(x, fg.numPatternX - 1);
+                                        const int srcY = std::min(y, fg.numPatternY - 1);
+                                        const int srcZ = std::min(z, fg.numPatternZ - 1);
+                                        const int srcL = std::min(l, fg.layers - 1);
+                                        const int srcIdx = fg.startIndex +
+                                            (((a * fg.numPatternZ + srcZ) * fg.numPatternY + srcY) * fg.numPatternX + srcX) * fg.layers + srcL;
+                                        m_spritesIndex.push_back(oldIndex[srcIdx]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         m_textureData.resize(m_animationPhases);
@@ -1026,6 +1074,11 @@ ThingFlagAttr ThingType::thingAttrToThingFlagAttr(const ThingAttr attr) {
 
 bool ThingType::isTall(const bool useRealSize) { return useRealSize ? getRealSize() > g_gameConfig.getSpriteSize() : getHeight() > 1; }
 int ThingType::getAnimationPhases() const { return m_animator ? m_animator->getAnimationPhases() : m_animationPhases; }
+int ThingType::getIdleAnimationPhases() const {
+    if (m_idleAnimator) return m_idleAnimator->getAnimationPhases();
+    if (m_animator) return m_animationPhases - m_animator->getAnimationPhases();
+    return 0;
+}
 
 int ThingType::getMeanPrice() {
     static constexpr std::array<std::pair<uint32_t, uint32_t>, 3> forcedPrices = { {

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -79,6 +79,7 @@ public:
     int getNumPatternY() { return m_numPatternY; }
     int getNumPatternZ() { return m_numPatternZ; }
     int getAnimationPhases() const;
+    int getIdleAnimationPhases() const;
     Animator* getAnimator() const { return m_animator; }
     Animator* getIdleAnimator() const { return m_idleAnimator; }
 


### PR DESCRIPTION
### **Actual**
https://github.com/user-attachments/assets/085b0dab-dc12-483d-9337-54f05345c495


https://github.com/user-attachments/assets/7d298cae-67cd-46d2-a66c-8fd15b668196


### **Expected**

https://github.com/user-attachments/assets/ee5d6af7-a6fe-4d4b-b271-41a0c9decd56


https://github.com/user-attachments/assets/8ebdd5fb-7839-4294-a30a-e86dbf6f5744


1828
1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed animation phase duration handling to prevent rendering errors during appearance deserialization.
  * Corrected sprite indexing for frame groups with varying pattern dimensions.
  * Improved idle animation phase calculation when certain animator configurations are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->