### PR TITLE
fix: isusable() appearance flag in ThingType::applyAppearanceFlags

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -147,6 +147,10 @@ void ThingType::applyAppearanceFlags(const appearances::AppearanceFlags& flags)
         m_flags |= ThingFlagAttrForceUse;
     }
 
+    if (flags.has_usable() && flags.usable()) {
+        m_flags |= ThingFlagAttrUsable;
+    }
+
     if (flags.has_write()) {
         m_flags |= ThingFlagAttrWritable;
         m_maxTextLength = flags.write().max_text_length();


### PR DESCRIPTION


# Description

Respect the 'usable' appearance flag when applying appearance flags: if flags.has_usable() and flags.usable() are true, set ThingFlagAttrUsable on the ThingType (updates src/client/thingtype.cpp). This ensures items marked usable in appearances are flagged appropriately at runtime.


## Behavior

### **Actual**

<img width="512" height="322" alt="image" src="https://github.com/user-attachments/assets/c98af4ae-bf53-45be-b637-023d8f24f7af" />


### **Expected**

<img width="285" height="220" alt="image" src="https://github.com/user-attachments/assets/3ebc4bc9-0774-4787-b6d6-cb026c7f86c6" />


## Fixes

discord

## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usable attribute recognition to ensure in-game objects marked as usable are properly flagged and recognized by the runtime system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->