### PR TITLE
fix: 0xD0 payload + server-side quest tracker persistence for current protocol

### DIFF
--- a/modules/corelib/ui/uipopupmenu.lua
+++ b/modules/corelib/ui/uipopupmenu.lua
@@ -97,6 +97,7 @@ function UIPopupMenu:addCheckBox(text, checked, callback)
     checkBox:setText(text)
     checkBox:setChecked(checked or false)
     checkBox.onClick = function()
+        checkBox:setChecked(not checkBox:isChecked())
         self:destroy()
         callback(checkBox, checkBox:isChecked())
     end

--- a/modules/game_questlog/game_questlog.lua
+++ b/modules/game_questlog/game_questlog.lua
@@ -40,6 +40,8 @@ local currentQuestId = nil  -- Track the currently selected quest ID
 local missionToQuestMap = {} -- Map missionId to questId for navigation
 local isNavigating = false   -- Flag to prevent checkbox events during navigation
 local isUpdatingCheckbox = false  -- Flag to prevent recursive checkbox events
+local isReceivingQuestTracker = false -- Prevent stale local cache from being sent while applying server tracker data
+local questTrackerSettingsLoaded = false
 local questLogCache = {
     items = {},
     completed = 0,
@@ -54,6 +56,7 @@ local COLORS = {
     SELECTED = "#585858"
 }
 local file = "/settings/questtracking.json"
+local settingsDirectory = "/settings/"
 
 --[[=================================================
 =               Local Functions                     =
@@ -84,53 +87,6 @@ local function removeNumber(key, id)
     end
 end
 
--- Auto-untrack completed quests by checking all tracked quests
-local function autoUntrackCompletedQuests()
-    if not settings.autoUntrackCompleted or not settings[namePlayer] or not trackerMiniWindow then
-        return
-    end
-    
-    local removedMissionIds = {}
-    
-    -- Check all tracked missions for completion status
-    if trackerMiniWindow.contentsPanel and trackerMiniWindow.contentsPanel.list then
-        for i = trackerMiniWindow.contentsPanel.list:getChildCount(), 1, -1 do
-            local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildByIndex(i)
-            if trackerLabel and trackerLabel.description then
-                local description = trackerLabel.description:getText()
-                local missionId = tonumber(trackerLabel:getId())
-                
-                -- Check if the mission is completed based on description text
-                local isCompleted = description and (
-                    string.find(string.lower(description), "%(completed%)") or
-                    (string.find(string.lower(description), "complete") and 
-                     (string.find(string.lower(description), "quest") or string.find(string.lower(description), "mission")))
-                )
-                
-                if isCompleted then
-                    table.insert(removedMissionIds, missionId)
-                    
-                    -- Remove from settings
-                    removeNumber(namePlayer, missionId)
-                    
-                    -- Remove from tracker display
-                    trackerLabel:destroy()
-                end
-            end
-        end
-    end
-    
-    if #removedMissionIds > 0 then
-        -- Update tracker layout
-        if trackerMiniWindow.contentsPanel and trackerMiniWindow.contentsPanel.list then
-            trackerMiniWindow.contentsPanel.list:getLayout():update()
-        end
-        
-        -- Save the updated settings
-        save()
-    end
-end
-
 local function load()
     if g_resources.fileExists(file) then
         local status, result = pcall(function()
@@ -145,26 +101,91 @@ local function load()
     end
 end
 
+local function ensureQuestTrackerState()
+    if g_game.getClientVersion() < 1280 then
+        return false
+    end
+
+    if not namePlayer or namePlayer == "" then
+        local characterName = g_game.getCharacterName()
+        if not characterName or characterName == "" then
+            return false
+        end
+
+        namePlayer = characterName:lower()
+    end
+
+    if not questTrackerSettingsLoaded then
+        settings = load() or {}
+        questTrackerSettingsLoaded = true
+
+        g_logger.debug(string.format(
+            "[QuestTracker] loaded local cache player=%s missions=%d autoTrack=%s autoUntrack=%s",
+            namePlayer,
+            settings[namePlayer] and #settings[namePlayer] or 0,
+            settings.autoTrackNewQuests == true and "true" or "false",
+            settings.autoUntrackCompleted == true and "true" or "false"
+        ))
+    end
+
+    if settings.autoTrackNewQuests == nil then
+        settings.autoTrackNewQuests = false
+    end
+    if settings.autoUntrackCompleted == nil then
+        settings.autoUntrackCompleted = false
+    end
+    if not settings[namePlayer] then
+        settings[namePlayer] = {}
+    end
+
+    return true
+end
+
 local function save()
+    if not namePlayer or namePlayer == "" then
+        g_logger.debug("[QuestTracker] skipped local cache save without player name")
+        return false
+    end
+
     local status, result = pcall(function()
         return json.encode(settings, 2)
     end)
     if not status then
-        return g_logger.error("Error while saving profile settings. Data won't be saved. Details: " .. result)
+        g_logger.error("Error while saving quest tracker settings. Data won't be saved. Details: " .. result)
+        return false
     end
     if result:len() > 100 * 1024 * 1024 then
-        return g_logger.error("Something went wrong, file is above 100MB, won't be saved")
+        g_logger.error("Something went wrong, quest tracker settings file is above 100MB, won't be saved")
+        return false
+    end
+
+    if not g_resources.directoryExists(settingsDirectory) then
+        g_resources.makeDir(settingsDirectory)
     end
     
-    -- Safely attempt to write the file, ignoring errors during logout
-    local writeStatus, writeError = pcall(function()
+    local writeStatus, writeResult = pcall(function()
         return g_resources.writeFileContents(file, result)
     end)
     
     if not writeStatus then
-        -- Log the error but don't spam the console during normal logout
-        g_logger.debug("Could not save quest log settings during logout: " .. tostring(writeError))
+        g_logger.error("Could not save quest tracker settings: " .. tostring(writeResult))
+        return false
     end
+
+    if not writeResult then
+        g_logger.error("Could not save quest tracker settings: writeFileContents returned false")
+        return false
+    end
+
+    g_logger.debug(string.format(
+        "[QuestTracker] saved local cache player=%s missions=%d autoTrack=%s autoUntrack=%s",
+        namePlayer or "",
+        namePlayer and settings[namePlayer] and #settings[namePlayer] or 0,
+        settings.autoTrackNewQuests == true and "true" or "false",
+        settings.autoUntrackCompleted == true and "true" or "false"
+    ))
+
+    return true
 end
 
 local sortFunctions = {
@@ -201,11 +222,42 @@ local sortFunctions = {
 }
 
 local function sendQuestTracker(listToMap)
-    local map = {}
-    for _, entry in ipairs(listToMap) do
-        map[entry[1]] = entry[2]
+    if not ensureQuestTrackerState() then
+        g_logger.debug("[QuestTracker] skipped 0xD0 send before local cache was loaded")
+        return
     end
-    g_game.sendRequestTrackerQuestLog(map)
+
+    local missionIds = {}
+    local added = {}
+
+    for _, entry in ipairs(listToMap or {}) do
+        local missionId = tonumber(entry[1])
+        if missionId and not added[missionId] then
+            missionIds[#missionIds + 1] = missionId
+            added[missionId] = true
+
+            if #missionIds >= 255 then
+                break
+            end
+        end
+    end
+
+    local extra = math.random(0, 0xff)
+
+    g_logger.debug(string.format(
+        "[QuestTracker] sending 0xD0 payload count=%d autoTrack=%s autoUntrack=%s extra=0x%02X",
+        #missionIds,
+        settings.autoTrackNewQuests == true and "true" or "false",
+        settings.autoUntrackCompleted == true and "true" or "false",
+        extra
+    ))
+
+    g_game.sendRequestTrackerQuestLog(
+        missionIds,
+        settings.autoTrackNewQuests == true,
+        settings.autoUntrackCompleted == true,
+        extra
+    )
 end
 
 local function rebuildTrackerFromSettings()
@@ -213,38 +265,21 @@ local function rebuildTrackerFromSettings()
         return
     end
     
-    -- Clear existing tracker items
     trackerMiniWindow.contentsPanel.list:destroyChildren()
     
-    -- Recreate tracker items from our settings
     for i, entry in ipairs(settings[namePlayer]) do
         local missionId, missionName, missionDescription, questId = unpack(entry)
         
-        -- Try to get questId from our mapping if not in settings
         if not questId or questId == 0 then
             questId = missionToQuestMap[tonumber(missionId)] or 0
         end
         
         local trackerLabel = g_ui.createWidget('QuestTrackerLabel', trackerMiniWindow.contentsPanel.list)
         trackerLabel:setId(tostring(missionId))
-        trackerLabel.questId = questId  -- Store questId for navigation
-        trackerLabel.missionId = missionId   -- Store missionId for navigation
-        -- Use description if available, fallback to name
+        trackerLabel.questId = questId
+        trackerLabel.missionId = missionId
         trackerLabel.description:setText(missionDescription or missionName)
-        
-        -- If we don't have questId, request quest tracker to get updated data from server
-        if not questId or questId == 0 then
-            -- Missing questId, will be updated by server
-        end
     end
-    
-    -- Request server to send complete tracker data to fill in missing questIds
-    if settings[namePlayer] and #settings[namePlayer] > 0 then
-        sendQuestTracker(settings[namePlayer])
-    end
-    
-    -- Check for completed quests to auto-untrack
-    scheduleEvent(autoUntrackCompletedQuests, 1000) -- Delay to ensure tracker is fully loaded
 end
 
 local function findQuestIdForMission(missionId)
@@ -530,14 +565,39 @@ end
 =                        miniWindows                     =
 =================================================== ]] --
 function onOpenTracker()
-    buttonQuestLogTrackerButton:setOn(true)
+    if buttonQuestLogTrackerButton then
+        buttonQuestLogTrackerButton:setOn(true)
+    end
 end
 
 function onCloseTracker()
-    buttonQuestLogTrackerButton:setOn(false)
+    if buttonQuestLogTrackerButton then
+        buttonQuestLogTrackerButton:setOn(false)
+    end
+end
+
+local function isCompletedMissionText(text)
+    if not text then
+        return false
+    end
+
+    return string.find(string.lower(text), "%(completed%)") ~= nil
+end
+
+local function ensureQuestTrackerButton()
+    if buttonQuestLogTrackerButton then
+        return
+    end
+
+    buttonQuestLogTrackerButton = modules.game_mainpanel.addToggleButton("QuestLogTracker",
+        tr("Open QuestLog Tracker"), "/images/options/button_questlog_tracker", function()
+            questLogController:toggleMiniWindowsTracker()
+        end, false, 1001)
 end
 
 local function showQuestTracker()
+    ensureQuestTrackerButton()
+
     if trackerMiniWindow then
         toggleTracker()
         return
@@ -624,6 +684,7 @@ local function showQuestTracker()
                     -- Clear the settings and mapping
                     table.clear(settings[namePlayer])
                     table.clear(missionToQuestMap)  -- Clear the mapping as well
+                    save()
                     sendQuestTracker(settings[namePlayer])
                     
                     -- Clear the tracker display
@@ -648,176 +709,66 @@ local function showQuestTracker()
                     -- Update layouts
                     trackerMiniWindow.contentsPanel.list:getLayout():enableUpdates()
                     trackerMiniWindow.contentsPanel.list:getLayout():update()
-                    -- Save the cleared settings
-                    save()
                 end
             end)
             menu:addOption('Remove completed quests', function()
-                if settings[namePlayer] then
-                    -- Store the mission IDs that are being removed for checkbox updates
-                    local removedMissionIds = {}
-                    local completedMissionIds = {}
-                    
-                    -- Check for completed missions by looking for "(completed)" in their names/descriptions
-                    -- and also check the isComplete property if available
-                    for i, entry in ipairs(settings[namePlayer]) do
-                        local missionId, missionName, missionDescription, questId = unpack(entry)
-                        
-                        local isCompleted = false
-                        
-                        -- Method 1: Check for "(completed)" string in mission name
-                        if missionName and string.find(string.lower(missionName), "%(completed%)") then
-                            isCompleted = true
-                        end
-                        
-                        -- Method 2: Check for "(completed)" string in mission description
-                        if not isCompleted and missionDescription and string.find(string.lower(missionDescription), "%(completed%)") then
-                            isCompleted = true
-                        end
-                        
-                        -- Method 3: Check tracker label text for "(completed)"
-                        if not isCompleted and trackerMiniWindow and trackerMiniWindow.contentsPanel and trackerMiniWindow.contentsPanel.list then
-                            local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildById(tostring(missionId))
-                            if trackerLabel and trackerLabel.description then
-                                local trackerText = trackerLabel.description:getText()
-                                if trackerText and string.find(string.lower(trackerText), "%(completed%)") then
-                                    isCompleted = true
-                                end
-                            end
-                        end
-                        
-                        -- Method 4: Check if we can find the mission in the quest log and check its completion status
-                        if not isCompleted and questId and UITextList.questLogList then
-                            local questItem = UITextList.questLogList:getChildById(tostring(questId))
-                            if questItem then
-                                -- Temporarily click the quest to load its missions
-                                questItem:onClick()
-                                
-                                -- Check if mission is loaded and has isComplete property
-                                scheduleEvent(function()
-                                    if UITextList.questLogLine and UITextList.questLogLine:hasChildren() then
-                                        local missionItem = UITextList.questLogLine:getChildById(tostring(missionId))
-                                        if missionItem then
-                                            -- Check mission text for "(completed)"
-                                            local missionText = missionItem:getText()
-                                            if missionText and string.find(string.lower(missionText), "%(completed%)") then
-                                                table.insert(removedMissionIds, missionId)
-                                                table.insert(completedMissionIds, missionId)
-                                            elseif missionItem.isComplete then
-                                                table.insert(removedMissionIds, missionId)
-                                                table.insert(completedMissionIds, missionId)
-                                            end
-                                        end
-                                    end
-                                    
-                                    -- Process removal after checking all missions
-                                    if i == #settings[namePlayer] then
-                                        scheduleEvent(function()
-                                            processCompletedMissionRemoval()
-                                        end, 100)
-                                    end
-                                end, 50)
-                            end
-                        end
-                        
-                        -- If we found completion through methods 1-3, mark for removal immediately
-                        if isCompleted then
-                            table.insert(removedMissionIds, missionId)
-                            table.insert(completedMissionIds, missionId)
-                        end
-                    end
-                    
-                    -- If we found completed missions without needing to load quest data, process removal
-                    if #removedMissionIds > 0 then
-                        scheduleEvent(function()
-                            processCompletedMissionRemoval()
-                        end, 100)
-                    else
-                    end
-                    
-                    -- Function to process the actual removal
-                    function processCompletedMissionRemoval()
-                        if #removedMissionIds > 0 then
-                            -- Remove completed missions from settings
-                            for j = #settings[namePlayer], 1, -1 do
-                                local checkMissionId = settings[namePlayer][j][1]
-                                for _, removedId in ipairs(removedMissionIds) do
-                                    if checkMissionId == removedId then
-                                        table.remove(settings[namePlayer], j)
-                                        break
-                                    end
-                                end
-                            end
-                            
-                            -- Remove from mission mapping
-                            for _, missionId in ipairs(removedMissionIds) do
-                                if missionToQuestMap[tonumber(missionId)] then
-                                    missionToQuestMap[tonumber(missionId)] = nil
-                                end
-                            end
-                            
-                            -- Send updated tracker state to server
-                            sendQuestTracker(settings[namePlayer])
-                            
-                            -- Remove completed missions from tracker display
-                            for _, missionId in ipairs(removedMissionIds) do
-                                local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildById(tostring(missionId))
-                                if trackerLabel then
-                                    trackerLabel:destroy()
-                                end
-                            end
-                            
-                            -- Update the checkbox in Quest Log window if it's open and a completed mission is selected
-                            if questLogController.ui and questLogController.ui:isVisible() then
-                                if UITextList.questLogLine and UITextList.questLogLine:hasChildren() then
-                                    -- Update checkbox for any currently selected mission if it was a completed one
-                                    if UITextList.questLogLine:getFocusedChild() then
-                                        local currentMissionId = tonumber(UITextList.questLogLine:getFocusedChild():getId())
-                                        for _, removedId in ipairs(removedMissionIds) do
-                                            if currentMissionId == removedId then
-                                                isUpdatingCheckbox = true
-                                                UICheckBox.showInQuestTracker:setChecked(false)
-                                                isUpdatingCheckbox = false
-                                                break
-                                            end
-                                        end
-                                    end
-                                end
-                            end
-                            
-                            -- Update layouts
-                            trackerMiniWindow.contentsPanel.list:getLayout():enableUpdates()
-                            trackerMiniWindow.contentsPanel.list:getLayout():update()
-                            
-                            -- Save the updated settings
-                            save()
+                if not settings[namePlayer] then
+                    return
+                end
+
+                local removedMissionIds = {}
+
+                for i = #settings[namePlayer], 1, -1 do
+                    local missionId, missionName, missionDescription = unpack(settings[namePlayer][i])
+                    local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildById(tostring(missionId))
+                    local trackerText = trackerLabel and trackerLabel.description and trackerLabel.description:getText() or nil
+
+                    if isCompletedMissionText(missionName) or isCompletedMissionText(missionDescription) or isCompletedMissionText(trackerText) then
+                        removedMissionIds[#removedMissionIds + 1] = missionId
+                        table.remove(settings[namePlayer], i)
+                        missionToQuestMap[tonumber(missionId)] = nil
+
+                        if trackerLabel then
+                            trackerLabel:destroy()
                         end
                     end
                 end
+
+                if #removedMissionIds == 0 then
+                    return
+                end
+
+                if questLogController.ui and questLogController.ui:isVisible() and UITextList.questLogLine and UITextList.questLogLine:hasChildren() then
+                    local focusedChild = UITextList.questLogLine:getFocusedChild()
+                    if focusedChild then
+                        local currentMissionId = tonumber(focusedChild:getId())
+                        for _, removedId in ipairs(removedMissionIds) do
+                            if currentMissionId == removedId then
+                                isUpdatingCheckbox = true
+                                UICheckBox.showInQuestTracker:setChecked(false)
+                                isUpdatingCheckbox = false
+                                break
+                            end
+                        end
+                    end
+                end
+
+                trackerMiniWindow.contentsPanel.list:getLayout():enableUpdates()
+                trackerMiniWindow.contentsPanel.list:getLayout():update()
+
+                save()
+                sendQuestTracker(settings[namePlayer])
             end)
             menu:addSeparator()
             menu:addCheckBox('Automatically track new quests', settings.autoTrackNewQuests or false, function(widget, checked)
                 settings.autoTrackNewQuests = checked
                 save()
+                sendQuestTracker(settings[namePlayer] or {})
             end)
             menu:addCheckBox('Automatically untrack completed quests', settings.autoUntrackCompleted or false, function(widget, checked)
                 settings.autoUntrackCompleted = checked
                 save()
-                
-                -- Start/stop periodic auto-untrack check
-                if checked then
-                    -- Start periodic check
-                    scheduleEvent(function()
-                        local function periodicAutoUntrack()
-                            autoUntrackCompletedQuests()
-                            -- Schedule next check
-                            if settings.autoUntrackCompleted then
-                                scheduleEvent(periodicAutoUntrack, 30000) -- 30 seconds
-                            end
-                        end
-                        periodicAutoUntrack()
-                    end, 1000) -- Start after 1 second
-                end
+                sendQuestTracker(settings[namePlayer] or {})
             end)
 
             menu:display(mousePos)
@@ -837,25 +788,12 @@ local function showQuestTracker()
     trackerMiniWindow:setup()
     
     -- Rebuild tracker from saved settings when first created
-    if settings[namePlayer] and #settings[namePlayer] > 0 then
+    if not isReceivingQuestTracker and settings[namePlayer] and #settings[namePlayer] > 0 then
         rebuildTrackerFromSettings()
     end
     
     toggleTracker()
-    
-    -- Set up periodic auto-untrack check (every 30 seconds)
-    if settings.autoUntrackCompleted then
-        scheduleEvent(function()
-            local function periodicAutoUntrack()
-                autoUntrackCompletedQuests()
-                -- Schedule next check
-                if settings.autoUntrackCompleted then
-                    scheduleEvent(periodicAutoUntrack, 30000) -- 30 seconds
-                end
-            end
-            periodicAutoUntrack()
-        end, 5000) -- Start after 5 seconds
-    end
+
 end
 
 --[[=================================================
@@ -902,24 +840,6 @@ local function onQuestLine(questId, questMissions)
         itemCat.description = missionDescription
         setupQuestItemClickHandler(itemCat, false)
         categoryColor = categoryColor == COLORS.BASE_1 and COLORS.BASE_2 or COLORS.BASE_1
-        
-        -- Auto-track new quests if the setting is enabled
-        if settings.autoTrackNewQuests and not isIdInTracker(namePlayer, missionId) then
-            -- Check if this mission appears to be new (not completed)
-            local isCompleted = missionDescription and (
-                string.find(string.lower(missionDescription), "%(completed%)") or
-                string.find(string.lower(missionDescription), "complete") and string.find(string.lower(missionDescription), "quest")
-            )
-            
-            if not isCompleted then
-                -- Add the mission to tracker
-                addUniqueIdQuest(namePlayer, questId, missionId, missionName, missionDescription)
-                save()
-                
-                -- Rebuild tracker to show the new quest
-                rebuildTrackerFromSettings()
-            end
-        end
     end
     
     -- Auto-select the first mission but prevent checkbox updates during this automatic selection
@@ -938,124 +858,90 @@ local function onQuestLine(questId, questMissions)
 end
 
 local function onQuestTracker(remainingQuests, missions)
-    if not trackerMiniWindow then
-        showQuestTracker()
-    end
-    
-    -- Don't clear the tracker if we have locally tracked quests
-    -- The server response might not include all our tracked quests
-    if not missions or type(missions[1]) ~= "table" then
-        -- If server sends empty response, rebuild from our local settings
-        if settings[namePlayer] and #settings[namePlayer] > 0 then
-            -- Keep existing tracker items that match our local settings
-            return
-        end
-        trackerMiniWindow.contentsPanel.list:destroyChildren()
+    if not ensureQuestTrackerState() then
         return
     end
-    
-    -- Only update tracker items that are actually in our local tracked list
-    for index, mission in ipairs(missions) do
+
+    if not trackerMiniWindow then
+        isReceivingQuestTracker = true
+        showQuestTracker()
+        isReceivingQuestTracker = false
+    end
+
+    trackerMiniWindow.contentsPanel.list:destroyChildren()
+    table.clear(settings[namePlayer])
+    table.clear(missionToQuestMap)
+
+    if not missions then
+        save()
+        return
+    end
+
+    for _, mission in ipairs(missions) do
         local questId, missionId, questName, missionName, missionDesc = unpack(mission)
-        
-        -- Update the mission to quest mapping (always update this)
-        missionToQuestMap[tonumber(missionId)] = tonumber(questId)
-        
-        -- Check if this mission is actually being tracked by the user
-        local isTracked = false
-        if settings[namePlayer] then
-            for _, entry in ipairs(settings[namePlayer]) do
-                if entry[1] == tonumber(missionId) then
-                    isTracked = true
-                    break
-                end
-            end
-        end
-        
-        if isTracked then
-            local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildById(tostring(missionId))
-            
-            if not trackerLabel then
-                -- Create new tracker label if it doesn't exist and is tracked
-                trackerLabel = g_ui.createWidget('QuestTrackerLabel', trackerMiniWindow.contentsPanel.list)
-                trackerLabel:setId(tostring(missionId))
-            else
-                -- Updating existing tracker label
-            end
-            
-            -- Store navigation data (always update with server data)
+        questId = tonumber(questId) or 0
+        missionId = tonumber(missionId)
+
+        if missionId then
+            missionToQuestMap[missionId] = questId
+            settings[namePlayer][#settings[namePlayer] + 1] = {missionId, missionName, missionDesc or missionName, questId}
+
+            local trackerLabel = g_ui.createWidget('QuestTrackerLabel', trackerMiniWindow.contentsPanel.list)
+            trackerLabel:setId(tostring(missionId))
             trackerLabel.questId = questId
             trackerLabel.missionId = missionId
-            
-            -- Update the description from server data
             trackerLabel.description:setText(missionDesc or missionName)
-            
-            -- Update our local settings with the full description and questId
-            for i, entry in ipairs(settings[namePlayer]) do
-                if entry[1] == tonumber(missionId) then
-                    -- Update the stored description and questId with server data
-                    settings[namePlayer][i] = {tonumber(missionId), missionName, missionDesc or missionName, questId}
-                    break
-                end
-            end
-            save() -- Save the updated data
-        else
-            -- Ignoring non-tracked mission from server
         end
     end
-    
-    -- Check for completed quests to auto-untrack after processing all missions
-    if settings.autoUntrackCompleted then
-        scheduleEvent(autoUntrackCompletedQuests, 500) -- Short delay to ensure all updates are processed
-    end
+
+    save()
 end
 
 local function onUpdateQuestTracker(questId, missionId, questName, missionName, missionDesc)
-    if not trackerMiniWindow then
+    if not ensureQuestTrackerState() then
         return
     end
-    
+
+    if not trackerMiniWindow then
+        isReceivingQuestTracker = true
+        showQuestTracker()
+        isReceivingQuestTracker = false
+    end
+
+    questId = tonumber(questId) or 0
+    missionId = tonumber(missionId)
+    if not missionId then
+        return
+    end
+
+    missionToQuestMap[missionId] = questId
+
     local trackerLabel = trackerMiniWindow.contentsPanel.list:getChildById(tostring(missionId))
-    if trackerLabel then
-        trackerLabel.description:setText(missionDesc or missionName)
-        
-        -- Ensure navigation data is set
-        trackerLabel.questId = questId
-        trackerLabel.missionId = missionId
-        
-        -- Update our local settings with the updated description
-        if settings[namePlayer] then
-            for i, entry in ipairs(settings[namePlayer]) do
-                if entry[1] == tonumber(missionId) then
-                    settings[namePlayer][i] = {tonumber(missionId), missionName, missionDesc or missionName, questId}
-                    save() -- Save the updated description
-                    break
-                end
-            end
-        end
-        
-        -- Auto-untrack completed quests if the setting is enabled
-        if settings.autoUntrackCompleted then
-            local isCompleted = missionDesc and (
-                string.find(string.lower(missionDesc), "%(completed%)") or
-                (string.find(string.lower(missionDesc), "complete") and 
-                 (string.find(string.lower(missionDesc), "quest") or string.find(string.lower(missionDesc), "mission")))
-            )
-            
-            if isCompleted then
-                -- Remove from settings
-                removeNumber(namePlayer, missionId)
-                save()
-                
-                -- Remove from tracker display
-                trackerLabel:destroy()
-                
-                -- Update tracker layout
-                trackerMiniWindow.contentsPanel.list:getLayout():update()
-            end
+    if not trackerLabel then
+        trackerLabel = g_ui.createWidget('QuestTrackerLabel', trackerMiniWindow.contentsPanel.list)
+        trackerLabel:setId(tostring(missionId))
+    end
+
+    trackerLabel.questId = questId
+    trackerLabel.missionId = missionId
+    trackerLabel.description:setText(missionDesc or missionName)
+
+    local updated = false
+    for i, entry in ipairs(settings[namePlayer]) do
+        if entry[1] == missionId then
+            settings[namePlayer][i] = {missionId, missionName, missionDesc or missionName, questId}
+            updated = true
+            break
         end
     end
+
+    if not updated then
+        settings[namePlayer][#settings[namePlayer] + 1] = {missionId, missionName, missionDesc or missionName, questId}
+    end
+
+    save()
 end
+
 --[[=================================================
 =               onCall otui / html                  =
 =================================================== ]] --
@@ -1100,16 +986,17 @@ function questLogController:onCheckChangeQuestTracker(event)
     if isUpdatingCheckbox then
         return
     end
-    
-    -- Make sure we have a player name
-    if not namePlayer or namePlayer == "" then
-        namePlayer = g_game.getCharacterName():lower()
+
+    if not ensureQuestTrackerState() then
+        return
     end
     
     -- Make sure tracker window exists
     if not trackerMiniWindow then
         showQuestTracker()
-        return
+        if not trackerMiniWindow then
+            return
+        end
     end
     
     -- Make sure we have a selected mission
@@ -1179,10 +1066,10 @@ function questLogController:onCheckChangeQuestTracker(event)
     end
     
     -- Send updated tracker state to server and save
+    save()
     if settings[namePlayer] then
         sendQuestTracker(settings[namePlayer])
     end
-    save()
 end
 
 function questLogController:onFilterQuestLog(event)
@@ -1237,12 +1124,11 @@ function onQuestLogMousePress(widget, mousePos, mouseButton)
     menu:addOption(tr('remove'), function()
         local missionId = widget:getParent():getId()  -- This is actually the missionId, not questId
         removeNumber(namePlayer, missionId)
+        save()
         if settings[namePlayer] then
             sendQuestTracker(settings[namePlayer])
         end
         widget:getParent():destroy()
-        -- Save the settings after removal
-        save()
         
         -- Also remove from the mapping
         if missionToQuestMap[tonumber(missionId)] then
@@ -1253,7 +1139,9 @@ function onQuestLogMousePress(widget, mousePos, mouseButton)
         if UITextList.questLogLine:hasChildren() and UITextList.questLogLine:getFocusedChild() then
             local currentId = UITextList.questLogLine:getFocusedChild():getId()
             if tostring(currentId) == tostring(missionId) then
+                isUpdatingCheckbox = true
                 UICheckBox.showInQuestTracker:setChecked(false)
+                isUpdatingCheckbox = false
             end
         end
     end)
@@ -1406,36 +1294,21 @@ end
 
 function questLogController:onGameStart()
     if g_game.getClientVersion() >= 1280 then
-        namePlayer = g_game.getCharacterName():lower()
-        settings = load() or {}
-        
-        -- Initialize default auto-tracking settings if they don't exist
-        if settings.autoTrackNewQuests == nil then
-            settings.autoTrackNewQuests = false
+        if not ensureQuestTrackerState() then
+            return
         end
-        if settings.autoUntrackCompleted == nil then
-            settings.autoUntrackCompleted = false
-        end
-        
-        -- Initialize the player's settings if they don't exist
-        if not settings[namePlayer] then
-            settings[namePlayer] = {}
-        end
-        
-        if settings[namePlayer] then
-            sendQuestTracker(settings[namePlayer])
-        end
-        if not buttonQuestLogTrackerButton then
-            buttonQuestLogTrackerButton = modules.game_mainpanel.addToggleButton("QuestLogTracker",
-                tr("Open QuestLog Tracker"), "/images/options/button_questlog_tracker", function()
-                    questLogController:toggleMiniWindowsTracker()
-                end, false, 1001)
-        end
+
+        ensureQuestTrackerButton()
+
         if trackerMiniWindow then
             trackerMiniWindow:setupOnStart()
             -- Rebuild tracker from saved settings
             rebuildTrackerFromSettings()
         end
+
+        -- Send local tracker cache on login, matching the official client behavior.
+        -- The server reconciles this payload during the initial sync window.
+        sendQuestTracker(settings[namePlayer])
     else
         UICheckBox.showInQuestTracker:setVisible(false)
         questLogController.ui.buttonsPanel.trackerButton:setVisible(false)
@@ -1452,4 +1325,6 @@ function questLogController:onGameEnd()
     end
     -- Clear the mission to quest mapping
     missionToQuestMap = {}
+    questTrackerSettingsLoaded = false
+    namePlayer = ""
 end

--- a/modules/game_questlog/game_questlog.lua
+++ b/modules/game_questlog/game_questlog.lua
@@ -42,6 +42,7 @@ local isNavigating = false   -- Flag to prevent checkbox events during navigatio
 local isUpdatingCheckbox = false  -- Flag to prevent recursive checkbox events
 local isReceivingQuestTracker = false -- Prevent stale local cache from being sent while applying server tracker data
 local questTrackerSettingsLoaded = false
+local saveTimer = nil
 local questLogCache = {
     items = {},
     completed = 0,
@@ -186,6 +187,17 @@ local function save()
     ))
 
     return true
+end
+
+local function deferredSave()
+    if saveTimer then
+        saveTimer:cancel()
+    end
+
+    saveTimer = scheduleEvent(function()
+        saveTimer = nil
+        save()
+    end, 500)
 end
 
 local sortFunctions = {
@@ -894,7 +906,7 @@ local function onQuestTracker(remainingQuests, missions)
         end
     end
 
-    save()
+    deferredSave()
 end
 
 local function onUpdateQuestTracker(questId, missionId, questName, missionName, missionDesc)
@@ -939,7 +951,7 @@ local function onUpdateQuestTracker(questId, missionId, questName, missionName, 
         settings[namePlayer][#settings[namePlayer] + 1] = {missionId, missionName, missionDesc or missionName, questId}
     end
 
-    save()
+    deferredSave()
 end
 
 --[[=================================================

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2097,12 +2097,18 @@ void Game::requestGetRewardDaily(const uint8_t bonusShrine, const std::map<uint1
     m_protocolGame->sendGetRewardDaily(bonusShrine, items);
 }
 
-void Game::sendRequestTrackerQuestLog(const std::map<uint16_t, std::string>& quests)
+void Game::sendRequestTrackerQuestLog(const std::vector<uint16_t>& missionIds, const bool autoTrackNewQuests, const bool autoUntrackCompletedQuests, const uint8_t extra)
 {
-    if (!canPerformGameAction())
+    if (!canPerformGameAction()) {
         return;
+    }
 
-    m_protocolGame->sendRequestTrackerQuestLog(quests);
+    m_protocolGame->sendRequestTrackerQuestLog(
+        missionIds,
+        autoTrackNewQuests,
+        autoUntrackCompletedQuests,
+        extra
+    );
 }
 
 void Game::processCyclopediaCharacterOffenceStats(const CyclopediaCharacterOffenceStats& data)

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -449,7 +449,7 @@ public:
     void sendOpenRewardWall();
     void requestOpenRewardHistory();
     void requestGetRewardDaily(const uint8_t bonusShrine, const std::map<uint16_t, uint8_t>& items);
-    void sendRequestTrackerQuestLog(const std::map<uint16_t, std::string>& quests);
+    void sendRequestTrackerQuestLog(const std::vector<uint16_t>& missionIds, bool autoTrackNewQuests, bool autoUntrackCompletedQuests, uint8_t extra = 0x2A);
     void processCyclopediaCharacterOffenceStats(const CyclopediaCharacterOffenceStats& data);
     void processCyclopediaCharacterDefenceStats(const CyclopediaCharacterDefenceStats& data);
     void processCyclopediaCharacterMiscStats(const CyclopediaCharacterMiscStats& data);

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -99,7 +99,7 @@ public:
     void sendCancelAttackAndFollow();
     void sendRefreshContainer(uint8_t containerId);
     void sendRequestBless();
-    void sendRequestTrackerQuestLog(const std::map<uint16_t, std::string>& quests);
+    void sendRequestTrackerQuestLog(const std::vector<uint16_t>& missionIds, bool autoTrackNewQuests, bool autoUntrackCompletedQuests, uint8_t extra);
     void sendRequestOutfit();
     void sendTyping(bool typing);
     void sendChangeOutfit(const Outfit& outfit);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3175,11 +3175,11 @@ void ProtocolGame::parseQuestTracker(const InputMessagePtr& msg)
             const uint8_t missionCount = msg->getU8();
             std::vector<std::tuple<uint16_t, uint16_t, std::string, std::string, std::string>> missions;
             for (uint8_t i = 0; i < missionCount; ++i) {
-                uint8_t questId = 0;
+                const uint16_t missionId = msg->getU16();
+                uint16_t questId = 0;
                 if (g_game.getClientVersion() >= 1410) {
                     questId = msg->getU16();
                 }
-                const uint16_t missionId = msg->getU16();
                 const std::string& questName = msg->getString();
                 const std::string& missionName = msg->getString();
                 const std::string& missionDesc = msg->getString();
@@ -3188,7 +3188,7 @@ void ProtocolGame::parseQuestTracker(const InputMessagePtr& msg)
             return g_lua.callGlobalField("g_game", "onQuestTracker", remainingQuests, missions);
         }
         case 0: {
-            uint8_t questId = 0;
+            uint16_t questId = 0;
             if (g_game.getClientVersion() >= 1410) {
                 questId = msg->getU16();
             }

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -767,17 +767,21 @@ void ProtocolGame::sendRequestBless()
     send(msg);
 }
 
-void ProtocolGame::sendRequestTrackerQuestLog(const std::map<uint16_t, std::string>& quests)
+void ProtocolGame::sendRequestTrackerQuestLog(const std::vector<uint16_t>& missionIds, const bool autoTrackNewQuests, const bool autoUntrackCompletedQuests, const uint8_t extra)
 {
     const auto msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientRequestTrackerQuestLog);
-    msg->addU8(static_cast<uint8_t>(quests.size()));
-    for (const auto& [questId, questName] : quests) {
-        msg->addU16(questId);
-        if (g_game.getClientVersion() >= 1410) {
-            msg->addString(questName);
-        }
+    const auto missionCount = missionIds.size() > 255 ? 255 : missionIds.size();
+    msg->addU8(static_cast<uint8_t>(missionCount));
+
+    for (size_t i = 0; i < missionCount; ++i) {
+        msg->addU16(missionIds[i]);
     }
+
+    msg->addU8(autoTrackNewQuests ? 1 : 0);
+    msg->addU8(autoUntrackCompletedQuests ? 1 : 0);
+    msg->addU8(extra);
+
     send(msg);
 }
 

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -782,9 +782,11 @@ void ProtocolGame::sendRequestTrackerQuestLog(const std::vector<uint16_t>& missi
         msg->addU16(missionIds[i]);
     }
 
-    msg->addU8(autoTrackNewQuests ? 1 : 0);
-    msg->addU8(autoUntrackCompletedQuests ? 1 : 0);
-    msg->addU8(extra);
+    if (g_game.getClientVersion() >= 1410) {
+        msg->addU8(autoTrackNewQuests ? 1 : 0);
+        msg->addU8(autoUntrackCompletedQuests ? 1 : 0);
+        msg->addU8(extra);
+    }
 
     send(msg);
 }

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -29,6 +29,10 @@
 #include "thingtype.h"
 #include "framework/util/crypt.h"
 
+#ifndef USE_PRECOMPILED_HEADERS
+#include <algorithm>
+#endif
+
 void ProtocolGame::onSend() {}
 void ProtocolGame::sendExtendedOpcode(const uint8_t opcode, const std::string& buffer)
 {
@@ -771,7 +775,7 @@ void ProtocolGame::sendRequestTrackerQuestLog(const std::vector<uint16_t>& missi
 {
     const auto msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientRequestTrackerQuestLog);
-    const auto missionCount = missionIds.size() > 255 ? 255 : missionIds.size();
+    const auto missionCount = std::min(missionIds.size(), static_cast<size_t>(255));
     msg->addU8(static_cast<uint8_t>(missionCount));
 
     for (size_t i = 0; i < missionCount; ++i) {


### PR DESCRIPTION
## Summary

This PR updates the OTClient quest tracker to behave closer to the official Tibia client and to work correctly with Canary server-side quest tracker persistence.

It focuses on:

- sending the official `0xD0` quest tracker payload format;
- sending auto-track and auto-untrack toggle states to the server;
- keeping manual add/remove actions on the client;
- letting the server own persistence, auto-track and auto-untrack behavior;
- treating the server response as the source of truth for the tracker UI;
- preserving a local auxiliary cache so the client can send its initial tracker sync on login, matching the official client behavior.

This PR does not include a full Quest Tracker UI redesign or a general UI refactor. The current focus is protocol compatibility, state synchronization and responsibility separation between client and server. I will handle broader UI improvements and visual/UX cleanup in a separate future PR.

## Official `0xD0` Payload

The previous OTClient quest tracker request used a map-like payload based on:

```cpp
std::map<uint16_t, std::string>
```

and could send `questName` / string data per mission.

Testing with the official Tibia client and Canary showed that the client request payload should be:

```text
[count]
[missionId u16] x count
[autoTrackNewQuests]
[autoUntrackCompletedQuests]
[extra byte]
```

The OTClient now sends:

- mission count;
- tracked `missionId` list;
- `Automatically track new quests` state;
- `Automatically untrack completed quests` state;
- trailing extra byte.

The old `missionId -> questName` payload was removed.

## Protocol / C++ Changes

Updated `sendRequestTrackerQuestLog` to receive:

```cpp
std::vector<uint16_t> missionIds
bool autoTrackNewQuests
bool autoUntrackCompletedQuests
uint8_t extra
```

Updated files:

```text
modules/corelib/ui/uipopupmenu.lua
modules/game_questlog/game_questlog.lua
src/client/game.cpp
src/client/game.h
src/client/protocolgame.h
src/client/protocolgameparse.cpp
src/client/protocolgamesend.cpp
```

The C++ sender now writes the tracker request as:

```text
0xD0
mission count
mission ids
auto-track toggle
auto-untrack toggle
extra byte
```

The mission count is clamped to `255`, matching the `U8` count used by the protocol.

## Lua Quest Tracker Changes

Updated:

```text
modules/game_questlog/game_questlog.lua
```

The Lua `sendQuestTracker` function now:

- builds a list of `missionId`;
- deduplicates mission IDs;
- limits the list to `255` entries;
- sends the current auto-track and auto-untrack toggle values;
- sends a variable extra byte using `math.random(0, 0xff)`;
- ensures the local quest tracker player state is initialized before sending.

The extra byte is still ignored by the server logic, but it is sent explicitly because it is part of the expected payload size.

## Toggle Handling

The tracker menu toggles now send their state to the server:

```text
Automatically track new quests
Automatically untrack completed quests
```

The server can now persist these options instead of relying on local client cache.

Also fixed `UIPopupMenu:addCheckBox`, which previously did not toggle the checkbox state before calling the callback.

The fix preserves the project style:

```lua
checkBox:setChecked(not checkBox:isChecked())
self:destroy()
callback(checkBox, checkBox:isChecked())
```

## Initial Login Sync and Local Cache

The official Tibia client sends its local quest tracker cache to the server shortly after login.

The OTClient now keeps this behavior:

```text
login
load local tracker cache
send 0xD0 with cached missions and toggle states
server reconciles during the initial sync window
```

The local cache is not the authority of the tracker. It exists to provide the first client-side sync payload on login, while the server remains responsible for reconciliation and persistence.

Additional protections were added so the local cache is not saved under an invalid empty player key:

- local player state is initialized before applying tracker data;
- `namePlayer`, `settings`, default toggle values and `settings[namePlayer]` are guaranteed before tracker save/send/apply flows;
- `save()` skips writing if the player name is not available;
- `save()` validates the result of the local file write;
- `onOpenTracker` and `onCloseTracker` guard against `buttonQuestLogTrackerButton` being nil during early login tracker events.

A local save failure does not block sending the update to the server. The server is the authoritative tracker state; the local cache is only used to feed the initial sync on the next login.

## Server as Tracker Source of Truth

The OTClient no longer treats `settings[namePlayer]` as the authoritative tracker state.

The server response now drives the visual tracker state:

- `onQuestTracker` rebuilds the tracker UI from the server payload;
- `onQuestTracker` clears the local tracker when the server sends an empty list;
- `onUpdateQuestTracker` creates or updates missions received from the server;
- `settings[namePlayer]` is now only a local auxiliary cache.

The old behavior where the client cache could overwrite or filter server tracker data was removed.

## Client / Server Responsibility Split

The client is responsible for:

- manual add/remove of tracked missions selected by the player;
- sending tracker state and toggle changes to the server;
- rendering the tracker UI;
- keeping auxiliary visual cache;
- sending the local cache on login so the server can reconcile it.

The server is responsible for:

- tracker persistence;
- initial sync reconciliation;
- auto-track behavior;
- auto-untrack behavior;
- restoring tracked missions after login;
- deciding the final tracker state.

## Auto-Track / Auto-Untrack Cleanup

Removed client-side automatic tracking when opening quest lines.

Removed client-side automatic untracking based on mission text or description.

The local `autoUntrackCompletedQuests` function was removed after becoming unused.

This prevents the client from competing with the server-side auto-track and auto-untrack logic.

## Manual Remove Completed Quests

The manual `Remove completed quests` option was kept because it is an explicit player action.

The implementation was simplified:

- removed async schedules;
- removed internal quest line clicks;
- removed fragile delayed removal flow;
- removes completed entries using the available tracker/cache text;
- sends the updated mission list to the server.

## Quest Tracker Parse Adjustments

The server-to-client quest tracker parse was adjusted to respect the Canary / official behavior where `missionId` is read first.

The OTClient preserves the validated mission order:

```text
missionId
questId
questName
missionName
missionDesc
```

when applicable.

This keeps the OTClient aligned with the server and official client behavior.

## UI Scope Notice

This PR intentionally does not attempt to redesign or fully clean up the Quest Tracker UI.

Some visual structure, layout behavior and broader UX details are left unchanged on purpose to keep this PR focused and reviewable.

I plan to handle broader Quest Tracker UI improvements in a separate follow-up PR.

## Test Plan

- [ ] Login with an empty tracker and confirm no errors.
- [ ] Add a mission manually to the quest tracker and confirm the server receives `0xD0`.
- [ ] Remove a mission manually and confirm the server receives the updated mission list.
- [ ] Toggle `Automatically track new quests` and confirm the server receives `autoTrack=true/false`.
- [ ] Toggle `Automatically untrack completed quests` and confirm the server receives `autoUntrack=true/false`.
- [ ] Confirm the local cache is saved under the correct player key.
- [ ] Confirm the client sends its local tracker cache on login.
- [ ] Confirm the server reconciles the initial client cache during login.
- [ ] Confirm the tracker remains restored after logout/login when using Canary server-side persistence.
- [ ] Confirm the client renders missions received from the server.
- [ ] Confirm `onQuestTracker` clears the tracker when the server sends an empty list.
- [ ] Confirm `onUpdateQuestTracker` creates or updates missions received from the server.
- [ ] Confirm local client auto-track no longer adds missions by itself.
- [ ] Confirm local client auto-untrack no longer removes missions automatically.
- [ ] Confirm manual `Remove completed quests` removes completed visible/cache entries and sends the updated list.
- [ ] Confirm the client does not resend stale cache when only rebuilding the tracker UI.
- [ ] Confirm payload count is limited to `255`.
- [ ] Confirm the server receives `count`, mission list, `autoTrack`, `autoUntrack`, and extra byte.

## Testing Environment

- Server: Canary - Version 3.4.2
- Client: OTClient
- Reference behavior: official Tibia client
- OS: Windows 11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Popup menu checkboxes now reliably toggle and report their state.
  * Quest tracker initializes, saves and syncs more reliably; auto-track/untrack preferences persist and apply correctly.
  * Mini-window “Remove completed quests” consistently clears completed entries and updates the tracker UI.

* **Refactor**
  * Tracker sync and local state handling simplified for more consistent, efficient communication and UI rebuilding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/otclient/pull/1711)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->