### PR TITLE
perf: item expiry/charges rendering in C++ UIItem

### DIFF
--- a/data/styles/10-items.otui
+++ b/data/styles/10-items.otui
@@ -9,21 +9,6 @@ Item < UIItem
   $disabled:
     color: #646464
 
-  Label
-    id: duration
-    anchors.bottom: parent.bottom
-    anchors.left: parent.left
-    phantom: true
-    font: "verdana-11px-rounded"
-
-  Label
-    id: charges
-    anchors.top: parent.top
-    anchors.left: parent.left
-    phantom: true
-    text-auto-resize: true
-    font: "verdana-11px-rounded"
-
   UIWidget
     id: tier
     size: 10 9

--- a/modules/game_containers/containers.lua
+++ b/modules/game_containers/containers.lua
@@ -607,11 +607,9 @@ function sortContainerItems(container, sortMode)
                 
                 ItemsDatabase.setRarityItem(itemWidget, itemData.item)
                 ItemsDatabase.setTier(itemWidget, itemData.item)
-                if modules.client_options.getOption('showExpiryInContainers') then
-                    ItemsDatabase.setCharges(itemWidget, itemData.item)
-                    ItemsDatabase.setDuration(itemWidget, itemData.item)
-                end
-                
+                itemWidget:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInContainers'))
+                itemWidget:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInContainers'))
+
                 local itemName = "unnamed"
                 local success, result = pcall(function()
                     if itemData.item.getName and type(itemData.item.getName) == "function" then
@@ -749,10 +747,8 @@ function refreshContainerItems(container)
         itemWidget:setItem(container:getItem(slot))
         ItemsDatabase.setRarityItem(itemWidget, container:getItem(slot))
         ItemsDatabase.setTier(itemWidget, container:getItem(slot))
-        if modules.client_options.getOption('showExpiryInContainers') then
-            ItemsDatabase.setCharges(itemWidget, container:getItem(slot))
-            ItemsDatabase.setDuration(itemWidget, container:getItem(slot))
-        end
+        itemWidget:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInContainers'))
+        itemWidget:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInContainers'))
     end
 
     if container:hasPages() then
@@ -1053,10 +1049,8 @@ function onContainerOpen(container, previousContainer)
         itemWidget:setItem(container:getItem(slot))
         ItemsDatabase.setRarityItem(itemWidget, container:getItem(slot))
         ItemsDatabase.setTier(itemWidget, container:getItem(slot))
-        if modules.client_options.getOption('showExpiryInContainers') then
-            ItemsDatabase.setCharges(itemWidget, container:getItem(slot))
-            ItemsDatabase.setDuration(itemWidget, container:getItem(slot))
-        end
+        itemWidget:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInContainers'))
+        itemWidget:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInContainers'))
         itemWidget:setMargin(0)
         itemWidget.position = container:getSlotPosition(slot)
 
@@ -1169,10 +1163,8 @@ function onContainerUpdateItem(container, slot, item, oldItem)
     end
     local itemWidget = container.itemsPanel:getChildById('item' .. slot)
     itemWidget:setItem(item)
-    if modules.client_options.getOption('showExpiryInContainers') then
-        ItemsDatabase.setCharges(itemWidget, container:getItem(slot))
-        ItemsDatabase.setDuration(itemWidget, container:getItem(slot))
-    end
+    itemWidget:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInContainers'))
+    itemWidget:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInContainers'))
     
     -- Note: Removed automatic re-sorting to prevent interference with manual item movement
     -- Sorting should only happen when explicitly requested by the user

--- a/modules/game_inventory/inventory.lua
+++ b/modules/game_inventory/inventory.lua
@@ -1,9 +1,7 @@
 local iconTopMenu = nil
 
 local inventoryShrink = false
-local itemSlotsWithDuration = {}
-local updateSlotsDurationEvent = nil
-local DURATION_UPDATE_INTERVAL = 1000
+
 local pvpModeRadioGroup = nil 
 local monkMirrorItem = nil
 
@@ -89,65 +87,6 @@ local function updateMonkMirrorItem(leftItem)
     end
 end
 
-local function formatDuration(duration)
-    return string.format("%dm%02d", duration / 60, duration % 60)
-end
-
-local function stopEvent()
-    if updateSlotsDurationEvent then
-        removeEvent(updateSlotsDurationEvent)
-        updateSlotsDurationEvent = nil
-    end
-end
-
-local function updateSlotsDuration()
-    -- @ prevent :
-    if not g_game.isOnline() or next(itemSlotsWithDuration) == nil then
-        stopEvent()
-        return
-    end
-    -- @
-
-    if not modules.client_options.getOption('showExpiryInInvetory') then
-        stopEvent()
-        local ui = getInventoryUi()
-        for slot, itemDurationReg in pairs(itemSlotsWithDuration) do
-            local getSlotInfo = getSlotPanelBySlot[slot]
-            if getSlotInfo then
-                local slotPanel = getSlotInfo(ui)
-                if slotPanel and slotPanel.item then
-                    slotPanel.item.duration:setText("")
-                end
-            end
-        end
-        return
-    end
-
-    local currTime = g_clock.seconds()
-    local ui = getInventoryUi()
-    local hasItemsWithDuration = false
-
-    for slot, itemDurationReg in pairs(itemSlotsWithDuration) do
-        local item = itemDurationReg.item
-        if item and item:getDurationTime() > 0 then
-            hasItemsWithDuration = true
-            local durationTimeLeft = math.max(0, itemDurationReg.timeEnd - currTime)
-            local getSlotInfo = getSlotPanelBySlot[slot]
-            if getSlotInfo then
-                local slotPanel = getSlotInfo(ui)
-                if slotPanel and slotPanel.item then
-                    slotPanel.item.duration:setText(formatDuration(durationTimeLeft))
-                end
-            end
-        end
-    end
-
-    if hasItemsWithDuration then
-        updateSlotsDurationEvent = scheduleEvent(updateSlotsDuration, DURATION_UPDATE_INTERVAL)
-    else
-        stopEvent()
-    end
-end
 
 local function walkEvent()
     if modules.client_options.getOption('autoChaseOverride') then
@@ -203,29 +142,9 @@ local function inventoryEvent(player, slot, item, oldItem)
     toggler:setEnabled(not item)
     slotPanel.item:setWidth(34)
     slotPanel.item:setHeight(34)
-    slotPanel.item.duration:setText("")
-    slotPanel.item.charges:setText("")
-    if g_game.getFeature(GameThingClock) then
-        if item and item:getDurationTime() > 0 then
-            if not itemSlotsWithDuration[slot] or itemSlotsWithDuration[slot].item ~= item then
-                itemSlotsWithDuration[slot] = {
-                    item = item,
-                    timeEnd = g_clock.seconds() + item:getDurationTime()
-                }
-            end
-            if modules.client_options.getOption('showExpiryInInvetory') then
-                if not updateSlotsDurationEvent then
-                    updateSlotsDuration()
-                end
-            end
-        else
-            itemSlotsWithDuration[slot] = nil
-        end
-    end
     
-    if modules.client_options.getOption('showExpiryInInvetory') then
-        ItemsDatabase.setCharges(slotPanel.item, item)
-    end
+    slotPanel.item:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInInvetory'))
+    slotPanel.item:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInInvetory'))
     ItemsDatabase.setTier(slotPanel.item, item)
 
     if slot == InventorySlotLeft then
@@ -427,7 +346,6 @@ function inventoryController:onGameStart()
 end
 
 function inventoryController:onGameEnd()
-    stopEvent()
     monkMirrorItem = nil
 
     local lastCombatControls = g_settings.getNode('LastCombatControls')
@@ -566,9 +484,6 @@ function getSlot5()
 end
 
 function reloadInventory()
-    if modules.client_options.getOption('showExpiryInInvetory') then
-        updateSlotsDuration()
-    end
     
     for slot, getSlotInfo in pairs(getSlotPanelBySlot) do
         local ui = getInventoryUi()

--- a/modules/gamelib/items.lua
+++ b/modules/gamelib/items.lua
@@ -194,35 +194,4 @@ function ItemsDatabase.setTier(widget, item, isSmall)
     widget.tier:setVisible(true)
 end
 
-function ItemsDatabase.setCharges(widget, item, style)
-    if not g_game.getFeature(GameThingCounter) or not widget then
-        return
-    end
 
-    if item and item:getCharges() > 0 then
-        widget.charges:setText(item:getCharges())
-    else
-        widget.charges:setText("")
-    end
-
-    if style then
-        widget:setStyle(style)
-    end
-end
-
-function ItemsDatabase.setDuration(widget, item, style)
-    if not g_game.getFeature(GameThingClock) or not widget then
-        return
-    end
-
-    if item and item:getDurationTime() > 0 then
-        local durationTimeLeft = item:getDurationTime()
-        widget.duration:setText(string.format("%dm%02d", durationTimeLeft / 60, durationTimeLeft % 60))
-    else
-        widget.duration:setText("")
-    end
-
-    if style then
-        widget:setStyle(style)
-    end
-end

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -444,8 +444,8 @@ void Item::serializeItem(const OutputBinaryTreePtr& out)
 void Item::setDurationTime(uint32_t duration)
 {
     m_duration = duration;
-    m_decaying = false;
-    m_durationEnd = 0;
+    if (m_decaying)
+        m_durationEnd = g_clock.millis() + static_cast<int64_t>(m_duration) * 1000;
 }
 
 void Item::setDecaying(bool decaying)
@@ -456,6 +456,8 @@ void Item::setDecaying(bool decaying)
     if (decaying) {
         m_durationEnd = g_clock.millis() + static_cast<int64_t>(m_duration) * 1000;
     } else {
+        const int64_t remaining_ms = m_durationEnd - g_clock.millis();
+        m_duration = static_cast<uint32_t>(std::max<int64_t>(0, (remaining_ms + 999) / 1000));
         m_durationEnd = 0;
     }
 }

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -441,4 +441,38 @@ void Item::serializeItem(const OutputBinaryTreePtr& out)
 
 #endif
 
+void Item::setDurationTime(uint32_t duration)
+{
+    m_duration = duration;
+    m_decaying = false;
+    m_durationEnd = 0;
+}
+
+void Item::setDecaying(bool decaying)
+{
+    if (m_decaying == decaying) return;
+    m_decaying = decaying;
+
+    if (decaying) {
+        m_durationEnd = g_clock.millis() + static_cast<int64_t>(m_duration) * 1000;
+    } else {
+        m_durationEnd = 0;
+    }
+}
+
+uint32_t Item::getDurationTime() const
+{
+    if (m_decaying) {
+        const auto remaining = m_durationEnd - g_clock.millis();
+        return remaining > 0 ? static_cast<uint32_t>(remaining / 1000) : 0;
+    }
+    return m_duration;
+}
+
+int Item::getClothSlot()
+{
+    auto* type = getThingType();
+    return type ? type->getClothSlot() : 0;
+}
+
 /* vim: set ts=4 sw=4 et :*/

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -86,15 +86,18 @@ public:
     void setColor(const Color& c) { if (m_color != c) m_color = c; }
     void setPosition(const Position& position, uint8_t stackPos = 0) override;
     void setTooltip(const std::string& str) { m_tooltip = str; }
-    void setDurationTime(const uint32_t durationTime) { m_durationTime = durationTime; }
+    void setDurationTime(uint32_t duration);
+    void setDecaying(bool decaying);
     void setCharges(const uint32_t charges) { m_charges = charges; }
     void setTier(const uint8_t tier) { m_tier = tier; }
 
     int getCountOrSubType() { return m_countOrSubType; }
     int getSubType();
     int getCount() { return isStackable() ? m_countOrSubType : 1; }
+    int getClothSlot();
     std::string getTooltip() { return m_tooltip; }
-    uint32_t getDurationTime() { return m_durationTime; }
+    uint32_t getDurationTime() const;
+    bool isDecaying() const { return m_decaying; }
     uint32_t getCharges() { return m_charges; }
     uint8_t getTier() { return m_tier; }
 
@@ -168,7 +171,9 @@ private:
     void internalDraw(int animationPhase, const Point& dest, const Color& color, bool drawThings, bool replaceColorShader, LightView* lightView = nullptr);
 
     uint16_t m_countOrSubType{ 0 };
-    uint32_t m_durationTime{ 0 };
+    uint32_t m_duration{ 0 };
+    int64_t m_durationEnd{ 0 };
+    bool m_decaying{ false };
     uint32_t m_charges{ 0 };
     uint8_t m_tier{ 0 };
     uint8_t m_phase{ 0 };

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -454,6 +454,9 @@ void LocalPlayer::setInventoryItem(const Otc::InventorySlot inventory, const Ite
     const auto& oldItem = m_inventoryItems[inventory];
     m_inventoryItems[inventory] = item;
 
+    if (item && g_game.getFeature(Otc::GameThingClock) && item->getDurationTime() > 0)
+        item->setDecaying(true);
+
     callLuaField("onInventoryChange", inventory, item, oldItem);
 }
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -454,8 +454,10 @@ void LocalPlayer::setInventoryItem(const Otc::InventorySlot inventory, const Ite
     const auto& oldItem = m_inventoryItems[inventory];
     m_inventoryItems[inventory] = item;
 
-    if (item && g_game.getFeature(Otc::GameThingClock) && item->getDurationTime() > 0)
+    if (item && g_game.getFeature(Otc::GameThingClock) && item->getDurationTime() > 0
+            && item->getClothSlot() == static_cast<int>(inventory)){
         item->setDecaying(true);
+    }
 
     callLuaField("onInventoryChange", inventory, item, oldItem);
 }

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -1064,6 +1064,8 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIItem>("setItem", &UIItem::setItem);
     g_lua.bindClassMemberFunction<UIItem>("setVirtual", &UIItem::setVirtual);
     g_lua.bindClassMemberFunction<UIItem>("setShowCount", &UIItem::setShowCount);
+    g_lua.bindClassMemberFunction<UIItem>("setShowDuration", &UIItem::setShowDuration);
+    g_lua.bindClassMemberFunction<UIItem>("setShowCharges", &UIItem::setShowCharges);
     g_lua.bindClassMemberFunction<UIItem>("setDisplayCount", &UIItem::setDisplayCount);
     g_lua.bindClassMemberFunction<UIItem>("clearItem", &UIItem::clearItem);
     g_lua.bindClassMemberFunction<UIItem>("getItemId", &UIItem::getItemId);

--- a/src/client/uiitem.cpp
+++ b/src/client/uiitem.cpp
@@ -79,13 +79,13 @@ void UIItem::drawSelf(const DrawPoolType drawPane)
             if (secs > 0) {
                 std::string durationText;
                 if (secs >= 3600) {
-                    durationText = fmt::format("{}h{}m", secs / 3600, (secs % 3600) / 60);
+                    durationText = fmt::format("{}h{:02}m", secs / 3600, (secs % 3600) / 60);
                 } else if (secs >= 60) {
-                    durationText = fmt::format("{}m{}", secs / 60, secs % 60);
+                    durationText = fmt::format("{}m{:02}", secs / 60, secs % 60);
                 } else {
                     durationText = fmt::format("{}s", secs);
                 }
-                countFont->drawText(durationText, Rect(m_rect.topLeft(), m_rect.bottomRight() - Point(2, 0)), Color::white, Fw::AlignBottomRight);
+                countFont->drawText(durationText, Rect(m_rect.topLeft(), m_rect.bottomRight()), Color::white, Fw::AlignBottomLeft);
             }
         }
 

--- a/src/client/uiitem.cpp
+++ b/src/client/uiitem.cpp
@@ -55,25 +55,42 @@ void UIItem::drawSelf(const DrawPoolType drawPane)
         m_item->draw(Point(exactSize - g_gameConfig.getSpriteSize()) + m_item->getDisplacement());
         g_drawPool.releaseFrameBuffer(getPaddingRect(), m_flipDirection);
 
+        const auto itemCountFont = g_gameConfig.getItemCountFont();
+        const auto& countFont = itemCountFont ? itemCountFont : m_font;
+
         const int displayCount = m_displayCount > 0 ? m_displayCount
                                : (m_item->isStackable() ? m_item->getCount() : 0);
         const bool shouldDrawCount = m_displayCount > 0 ? (displayCount >= 1) : (displayCount > 1);
-        if (m_alwaysShowCount && shouldDrawCount) {
-            const auto itemCountFont = g_gameConfig.getItemCountFont();
-            const auto& countFont = itemCountFont ? itemCountFont : m_font;
-            if (countFont) {
-                static constexpr Color STACK_COLOR(191, 191, 191);
-                const auto count = displayCount;
-                std::string countText;
-                if (count < 1000) {
-                    countText = std::to_string(count);
-                } else if (count < 10000) {
-                    countText = fmt::format("{},{:03d}", count / 1000, count % 1000);
-                } else {
-                    countText = fmt::format("{}K", count / 1000);
-                }
-                countFont->drawText(countText, Rect(m_rect.topLeft(), m_rect.bottomRight() ), STACK_COLOR, Fw::AlignBottomRight);
+        if (countFont && m_alwaysShowCount && shouldDrawCount) {
+            static constexpr Color STACK_COLOR(191, 191, 191);
+            std::string countText;
+            if (displayCount < 1000) {
+                countText = std::to_string(displayCount);
+            } else if (displayCount < 10000) {
+                countText = fmt::format("{},{:03d}", displayCount / 1000, displayCount % 1000);
+            } else {
+                countText = fmt::format("{}K", displayCount / 1000);
             }
+            countFont->drawText(countText, Rect(m_rect.topLeft(), m_rect.bottomRight()), STACK_COLOR, Fw::AlignBottomRight);
+        }
+
+        if (countFont && m_showDuration) {
+            const auto secs = m_item->getDurationTime();
+            if (secs > 0) {
+                std::string durationText;
+                if (secs >= 3600) {
+                    durationText = fmt::format("{}h{}m", secs / 3600, (secs % 3600) / 60);
+                } else if (secs >= 60) {
+                    durationText = fmt::format("{}m{}", secs / 60, secs % 60);
+                } else {
+                    durationText = fmt::format("{}s", secs);
+                }
+                countFont->drawText(durationText, Rect(m_rect.topLeft(), m_rect.bottomRight() - Point(2, 0)), Color::white, Fw::AlignBottomRight);
+            }
+        }
+
+        if (countFont && m_showCharges && m_item->getCharges() > 0) {
+            countFont->drawText(std::to_string(m_item->getCharges()), Rect(m_rect.x() + 2, m_rect.y() + 2, m_rect.width(), m_rect.height()), Color::white, Fw::AlignTopLeft);
         }
 
 #ifdef FRAMEWORK_EDITOR

--- a/src/client/uiitem.h
+++ b/src/client/uiitem.h
@@ -37,6 +37,8 @@ public:
     void setItemVisible(const bool visible) { m_itemVisible = visible; }
     void setItem(const ItemPtr& item);
     void setShowCount(const bool value) { m_alwaysShowCount = value; }
+    void setShowDuration(const bool value) { m_showDuration = value; repaint(); }
+    void setShowCharges(const bool value) { m_showCharges = value; repaint(); }
     void setDisplayCount(int count) { m_displayCount = count; }
     void setVirtual(const bool virt) { m_virtual = virt; }
     void setFlipDirection(const uint8_t direction) { m_flipDirection = direction; repaint(); }
@@ -64,6 +66,8 @@ protected:
     bool m_showId{ false };
     bool m_itemVisible{ true };
     bool m_alwaysShowCount{ true };
+    bool m_showDuration{ false };
+    bool m_showCharges{ false };
     int m_displayCount{ 0 };
     uint8_t m_flipDirection{ 0 }; // 0 = none, 1 = horizontal, 2 = vertical
 };


### PR DESCRIPTION
## Summary

Moves item **duration** and **charges** display from Lua-managed label widgets to native C++ drawing inside `UIItem::drawSelf`, eliminating per-frame Lua event loops and stale-label bookkeeping.

### C++ changes

**`Item` (`item.h` / `item.cpp`)**
- Replaces the static `m_durationTime` field with `m_duration` + `m_durationEnd` + `m_decaying`.
- `setDurationTime(uint32_t)` — stores the server-sent remaining seconds and resets decay state.
- `setDecaying(bool)` — arms/disarms the countdown; when `true`, anchors `m_durationEnd = now + duration * 1000` ms.
- `getDurationTime() const` — returns live remaining seconds while decaying, static value otherwise.
- `getClothSlot()` — safe null-guard wrapper exposed to Lua (Lua already uses `item:getClothSlot()`).

**`LocalPlayer` (`localplayer.cpp`)**
- Calls `item->setDecaying(true)` when a new inventory item has `getDurationTime() > 0` **and** `g_game.getFeature(GameThingClock)` is active, so the countdown starts the moment the item is equipped.

**`UIItem` (`uiitem.h` / `uiitem.cpp`)**
- New flags `m_showDuration` / `m_showCharges` (default `false`), toggled from Lua via `setShowDuration` / `setShowCharges`.
- `drawSelf` resolves `g_gameConfig.getItemCountFont()` **once** and shares it across all three overlays (count, duration, charges).
- Duration format: `Xh Ym` / `Xm Y` / `Xs`, drawn bottom-right in white.
- Charges drawn top-left in white.
- Feature guards live in Lua (`g_game.getFeature(GameThingClock)` / `GameThingCounter`) so no `game.h` dependency in `uiitem.cpp`.

**`luafunctions.cpp`**
- Binds `setShowDuration`, `setShowCharges` to Lua.

### Lua changes

**`modules/gamelib/items.lua`**
- Removes `ItemsDatabase.setDuration` and `ItemsDatabase.setCharges` — no longer needed.

**`modules/game_inventory/inventory.lua`**
- Removes the Lua-side `itemSlotsWithDuration` table, `updateSlotsDurationEvent`, `formatDuration`, `stopEvent`, `updateSlotsDuration`, and the 1-second `scheduleEvent` loop.
- `inventoryEvent` now calls `setShowDuration` / `setShowCharges` with both the option and the feature flag checked.
- Preserves upstream monk mirror item logic (`isPlayerMonk`, `updateMonkMirrorItem`).

**`modules/game_containers/containers.lua`**
- All four item-refresh call sites replaced with `setShowDuration` + `setShowCharges` (feature-guarded).

### UI changes

**`data/styles/10-items.otui`**
- Removes the `duration` and `charges` `Label` children from the `Item` base style — rendering is now done by C++ `drawText`, so the widgets are no longer needed.

## Why

The previous approach maintained a Lua `scheduleEvent` loop that ticked every second for each equipped item with a duration. This meant:
- CPU wakeups even when nothing was visible.
- A separate Lua table tracking item pointers and end-times.
- Label widgets that needed manual clearing on every slot change.

C++ renders the text inline during the existing draw pass with zero extra allocations per frame (format strings are stack-local).

## Feature gating

Duration rendering is **only active** when `g_game.getFeature(GameThingClock)`.  
Charges rendering is **only active** when `g_game.getFeature(GameThingCounter)`.  
Both checks are performed in Lua before calling `setShowDuration`/`setShowCharges`, keeping `UIItem` free of `game.h`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-item controls to show/hide remaining duration and charges
  * Duration and charges rendered as overlays on item icons in inventory and containers
  * More accurate duration/decay tracking for items (improved timing behavior)

* **Bug Fixes / Performance**
  * Removed global expiry polling in favor of per-item updates to reduce overhead

* **Style**
  * Adjusted item UI template affecting default label styling for duration/charges

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/otclient/pull/1712)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->