### PR TITLE
fix: handle default cursor for map interactions

### DIFF
--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -258,17 +258,29 @@ void UIMap::onHoverChange(bool hovered)
 {
     UIWidget::onHoverChange(hovered);
     if (!hovered && m_mapView->hasCursorAnimations() && !g_mouse.isCursorChanged()) {
-        g_window.restoreMouseCursor();
+        const int defaultId = g_mouse.getCursorId("default");
+        if (defaultId != -1)
+            g_window.setMouseCursor(defaultId);
+        else
+            g_window.restoreMouseCursor();
     }
 }
 
 bool UIMap::onMouseMove(const Point& mousePos, const Point& mouseMoved)
 {
     const auto& pos = getPosition(mousePos);
-    if (!pos.isValid())
+    if (!pos.isValid()) {
+        if (isHovered() && m_mapView->hasCursorAnimations() && !g_mouse.isCursorChanged()) {
+            const int defaultId = g_mouse.getCursorId("default");
+            if (defaultId != -1)
+                g_window.setMouseCursor(defaultId);
+            else
+                g_window.restoreMouseCursor();
+        }
         return false;
+    }
 
-    if (m_mapView->getLastMousePosition() != pos) {
+    if (isHovered() && m_mapView->getLastMousePosition() != pos) {
         m_mapView->onMouseMove(pos);
         m_mapView->setLastMousePosition(pos);
     }

--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -254,10 +254,9 @@ void UIMap::onGeometryChange(const Rect& oldRect, const Rect& newRect)
     updateMapSize();
 }
 
-void UIMap::onHoverChange(bool hovered)
+void UIMap::resetCursorToDefault()
 {
-    UIWidget::onHoverChange(hovered);
-    if (!hovered && m_mapView->hasCursorAnimations() && !g_mouse.isCursorChanged()) {
+    if (m_mapView->hasCursorAnimations() && !g_mouse.isCursorChanged()) {
         const int defaultId = g_mouse.getCursorId("default");
         if (defaultId != -1)
             g_window.setMouseCursor(defaultId);
@@ -266,17 +265,19 @@ void UIMap::onHoverChange(bool hovered)
     }
 }
 
+void UIMap::onHoverChange(bool hovered)
+{
+    UIWidget::onHoverChange(hovered);
+    if (!hovered)
+        resetCursorToDefault();
+}
+
 bool UIMap::onMouseMove(const Point& mousePos, const Point& mouseMoved)
 {
     const auto& pos = getPosition(mousePos);
     if (!pos.isValid()) {
-        if (isHovered() && m_mapView->hasCursorAnimations() && !g_mouse.isCursorChanged()) {
-            const int defaultId = g_mouse.getCursorId("default");
-            if (defaultId != -1)
-                g_window.setMouseCursor(defaultId);
-            else
-                g_window.restoreMouseCursor();
-        }
+        if (isHovered())
+            resetCursorToDefault();
         return false;
     }
 

--- a/src/client/uimap.h
+++ b/src/client/uimap.h
@@ -111,6 +111,7 @@ protected:
 private:
     void updateVisibleDimension();
     void updateMapSize();
+    void resetCursorToDefault();
 
     MapViewPtr m_mapView;
     Rect m_mapRect;

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -620,7 +620,7 @@ LRESULT WIN32Window::windowProc(const HWND hWnd, const uint32_t uMsg, const WPAR
     switch (uMsg) {
         case WM_SETCURSOR:
         {
-            if (m_cursor)
+            if (LOWORD(lParam) == HTCLIENT && m_cursor)
                 SetCursor(m_cursor);
             else
                 return DefWindowProc(hWnd, uMsg, wParam, lParam);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

https://github.com/opentibiabr/otclient/issues/1668

## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested
- resize .exe verticalcursor/horizontalcursor
- hover UIMap on the widget
- UIMap of m_mapRect

@gilfernandes234