### PR TITLE
ci: gate Docker package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/reusable-build-docker.yml
+    with:
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      vcpkg_binary_cache_access: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'readwrite' || 'read' }}
     secrets: inherit
 
   build-browser:

--- a/.github/workflows/reusable-build-docker.yml
+++ b/.github/workflows/reusable-build-docker.yml
@@ -23,8 +23,9 @@ jobs:
     name: Image Build
     runs-on: ubuntu-latest
     env:
-      DOCKER_PUBLISH: ${{ inputs.push && secrets.VCPKG_PACKAGES_TOKEN != '' && 'true' || 'false' }}
-      VCPKG_BINARY_CACHE_ACCESS: ${{ inputs.vcpkg_binary_cache_access == 'readwrite' && secrets.VCPKG_PACKAGES_TOKEN != '' && 'readwrite' || 'read' }}
+      DOCKER_PUBLISH_CONTEXT: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'opentibiabr/otclient' && 'true' || 'false' }}
+      DOCKER_PUBLISH: ${{ inputs.push && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'opentibiabr/otclient' && secrets.VCPKG_PACKAGES_TOKEN != '' && 'true' || 'false' }}
+      VCPKG_BINARY_CACHE_ACCESS: ${{ inputs.vcpkg_binary_cache_access == 'readwrite' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'opentibiabr/otclient' && secrets.VCPKG_PACKAGES_TOKEN != '' && 'readwrite' || 'read' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,9 +42,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Warn when Docker publishing is disabled
+        if: inputs.push && env.DOCKER_PUBLISH != 'true'
+        shell: bash
+        run: |
+          if [ "${DOCKER_PUBLISH_CONTEXT}" != "true" ]; then
+            echo "::warning::Docker publishing was requested outside the opentibiabr/otclient push-to-main context; building without publishing."
+          else
+            echo "::warning::Docker publishing was requested, but VCPKG_PACKAGES_TOKEN is not configured; building without publishing."
+          fi
+
       - name: Login to GHCR
         if: env.DOCKER_PUBLISH == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/reusable-build-docker.yml
+++ b/.github/workflows/reusable-build-docker.yml
@@ -2,6 +2,17 @@ name: Reusable Docker Build
 
 on:
   workflow_call:
+    inputs:
+      push:
+        description: Publish the Docker image to GHCR.
+        required: false
+        type: boolean
+        default: false
+      vcpkg_binary_cache_access:
+        description: vcpkg binary cache access mode. Use readwrite only for trusted publishing events.
+        required: false
+        type: string
+        default: read
 
 permissions:
   contents: read
@@ -11,6 +22,9 @@ jobs:
   build:
     name: Image Build
     runs-on: ubuntu-latest
+    env:
+      DOCKER_PUBLISH: ${{ inputs.push && secrets.VCPKG_PACKAGES_TOKEN != '' && 'true' || 'false' }}
+      VCPKG_BINARY_CACHE_ACCESS: ${{ inputs.vcpkg_binary_cache_access == 'readwrite' && secrets.VCPKG_PACKAGES_TOKEN != '' && 'readwrite' || 'read' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -28,15 +42,15 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        if: github.ref == 'refs/heads/main'
+        if: env.DOCKER_PUBLISH == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.VCPKG_PACKAGES_TOKEN }}
 
-      - name: Build and push (main)
-        if: github.ref == 'refs/heads/main'
+      - name: Build and push
+        if: env.DOCKER_PUBLISH == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -45,8 +59,8 @@ jobs:
           build-args: |
             VCPKG_FEED_URL=https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
             VCPKG_FEED_USERNAME=${{ github.repository_owner }}
-            VCPKG_BINARY_CACHE_ACCESS=readwrite
-            VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite;nugettimeout,1200
+            VCPKG_BINARY_CACHE_ACCESS=${{ env.VCPKG_BINARY_CACHE_ACCESS }}
+            VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ env.VCPKG_BINARY_CACHE_ACCESS }};nugettimeout,1200
           secrets: |
             github_token=${{ secrets.VCPKG_PACKAGES_TOKEN || github.token }}
           tags: |
@@ -55,8 +69,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and export (PR)
-        if: github.ref != 'refs/heads/main'
+      - name: Build and export
+        if: env.DOCKER_PUBLISH != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -66,15 +80,15 @@ jobs:
           build-args: |
             VCPKG_FEED_URL=https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
             VCPKG_FEED_USERNAME=${{ github.repository_owner }}
-            VCPKG_BINARY_CACHE_ACCESS=read
-            VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,read;nugettimeout,1200
+            VCPKG_BINARY_CACHE_ACCESS=${{ env.VCPKG_BINARY_CACHE_ACCESS }}
+            VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ env.VCPKG_BINARY_CACHE_ACCESS }};nugettimeout,1200
           tags: |
-            ghcr.io/${{ steps.repo_lower.outputs.value }}:pr
+            ghcr.io/${{ steps.repo_lower.outputs.value }}:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Upload docker artifact
-        if: github.ref != 'refs/heads/main'
+        if: env.DOCKER_PUBLISH != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: docker-otclient


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for Docker image builds, making the process more flexible and secure. The main improvements are the introduction of configurable inputs for publishing and vcpkg cache access, better control over Docker publishing, and improved handling of secrets.

**Workflow flexibility and security improvements:**

* Added `push` and `vcpkg_binary_cache_access` as configurable inputs to the `reusable-build-docker.yml` workflow, allowing dynamic control over when images are published and what cache access mode is used. (`.github/workflows/ci.yml`, `.github/workflows/reusable-build-docker.yml`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR216-R218) [[2]](diffhunk://#diff-e711dd7da75f6d34ce75cf9c2a38898bee8363d1a25d1c948e086fb6dcb63c96R5-R15)
* Set environment variables (`DOCKER_PUBLISH`, `VCPKG_BINARY_CACHE_ACCESS`) based on workflow inputs and secret availability, ensuring publishing and cache access are only enabled for trusted events. (`.github/workflows/reusable-build-docker.yml`)

**Docker build and publish process enhancements:**

* Updated Docker login and build steps to use the new environment variables, so publishing only occurs when appropriate and with the correct credentials. (`.github/workflows/reusable-build-docker.yml`)
* Made the vcpkg binary cache access mode and sources configurable in Docker build args, supporting both read and readwrite modes as needed. (`.github/workflows/reusable-build-docker.yml`) [[1]](diffhunk://#diff-e711dd7da75f6d34ce75cf9c2a38898bee8363d1a25d1c948e086fb6dcb63c96L48-R63) [[2]](diffhunk://#diff-e711dd7da75f6d34ce75cf9c2a38898bee8363d1a25d1c948e086fb6dcb63c96L69-R91)
* Standardized artifact naming and tags for CI builds, and ensured artifacts are only uploaded for non-publishing events. (`.github/workflows/reusable-build-docker.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to allow conditional Docker image publishing (only on direct pushes to main) and to adjust binary cache access accordingly.
  * Reusable build workflow now accepts inputs to control publish and cache behavior, improves build/export steps, and adds safeguards when publishing is requested but not permitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/otclient/pull/1724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->