### PR TITLE
fix: accept manually installed modern assets without marker

### DIFF
--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -1336,8 +1336,17 @@ function isClientVersionInstalled(version)
   end
 
   if version >= 1281 then
-    return hasInstalledModernClientFiles(version) and
-           installFileExists(string.format('data/things/%d/.client-assets-complete', version))
+    if not hasInstalledModernClientFiles(version) then
+      return false
+    end
+
+    -- Accept manually installed modern assets even when marker file is missing.
+    -- Marker remains useful for diagnostics, so we create it lazily when possible.
+    if not installFileExists(string.format('data/things/%d/.client-assets-complete', version)) then
+      markClientVersionInstalled(version)
+    end
+
+    return true
   end
 
   return g_resources.fileExists(string.format('/data/things/%d/Tibia.dat', version)) and

--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -322,15 +322,19 @@ local function hasCatalogEntryFile(basePath, entry)
 end
 
 local function installFileExists(path)
-  if g_resources.fileExistsInWorkDir then
-    return g_resources.fileExistsInWorkDir(path)
+  if g_resources.fileExistsInWorkDir and g_resources.fileExistsInWorkDir(path) then
+    return true
   end
   return g_resources.fileExists('/' .. path)
 end
 
 local function readInstallFile(path)
-  if g_resources.readFileContentsFromWorkDir then
-    return g_resources.readFileContentsFromWorkDir(path)
+  if g_resources.readFileContentsFromWorkDir and
+     (not g_resources.fileExistsInWorkDir or g_resources.fileExistsInWorkDir(path)) then
+    local ok, contents = pcall(function() return g_resources.readFileContentsFromWorkDir(path) end)
+    if ok and type(contents) == 'string' then
+      return contents
+    end
   end
   return g_resources.readFileContents('/' .. path)
 end

--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -394,9 +394,7 @@ local function hasModernClientFiles(version)
   return hasModernClientFilesAtPath(string.format('data/things/%d/', version), true)
 end
 
-local function hasInstalledModernClientFiles(version)
-  return hasModernClientFilesAtPath(string.format('data/things/%d/', version), true)
-end
+local hasInstalledModernClientFiles = hasModernClientFiles
 
 local function markClientVersionInstalled(config, version)
   local markerPath = completeMarkerPath(version)

--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -298,7 +298,7 @@ local function updateDownloadBar(window, percent)
 end
 
 local function completeMarkerPath(version)
-  return string.format('/data/things/%d/.client-assets-complete', version)
+  return string.format('data/things/%d/.client-assets-complete', version)
 end
 
 local function joinPhysicalPath(base, path)
@@ -312,6 +312,10 @@ end
 
 local function physicalInstallPath(path)
   return joinPhysicalPath(g_resources.getWorkDir(), path)
+end
+
+local function shouldInstallInWorkDir(config)
+  return config and config.installInWorkDir ~= false
 end
 
 local function hasCatalogEntryFile(basePath, entry)
@@ -394,13 +398,15 @@ local function hasInstalledModernClientFiles(version)
   return hasModernClientFilesAtPath(string.format('data/things/%d/', version), true)
 end
 
-local function markClientVersionInstalled(version)
-  if g_resources.writeFileContentsToWorkDir then
-    return g_resources.writeFileContentsToWorkDir(completeMarkerPath(version), string.format('client=%d\n', version))
+local function markClientVersionInstalled(config, version)
+  local markerPath = completeMarkerPath(version)
+  local contents = string.format('client=%d\n', version)
+  if shouldInstallInWorkDir(config) and g_resources.writeFileContentsToWorkDir then
+    return g_resources.writeFileContentsToWorkDir(markerPath, contents)
   end
 
   g_resources.makeDir(string.format('/data/things/%d', version))
-  return g_resources.writeFileContents(completeMarkerPath(version), string.format('client=%d\n', version))
+  return g_resources.writeFileContents('/' .. markerPath, contents)
 end
 
 local function normalizeVersionKey(version)
@@ -731,10 +737,6 @@ local function verifyInstalledSha256(destinationPath, expectedSha256, deleteOnMi
   end
 
   return true
-end
-
-local function shouldInstallInWorkDir(config)
-  return config and config.installInWorkDir ~= false
 end
 
 local function writeDownloadedFile(config, downloadPath, destinationPath, decompressLzma)
@@ -1414,9 +1416,9 @@ function ensureClientVersion(version, callback)
           return finishDownload(false, 'Assets were downloaded but the client files are still incomplete. Missing catalog-content.json, assets.json.sha256, or required catalog files.')
         end
 
-        local markerPath = string.format('data/things/%d/.client-assets-complete', version)
+        local markerPath = completeMarkerPath(version)
         if not installFileExists(markerPath) then
-          markClientVersionInstalled(version)
+          markClientVersionInstalled(config, version)
           if not installFileExists(markerPath) then
             logWarning('Assets were downloaded but the install marker could not be written.')
           end

--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -1336,17 +1336,7 @@ function isClientVersionInstalled(version)
   end
 
   if version >= 1281 then
-    if not hasInstalledModernClientFiles(version) then
-      return false
-    end
-
-    -- Accept manually installed modern assets even when marker file is missing.
-    -- Marker remains useful for diagnostics, so we create it lazily when possible.
-    if not installFileExists(string.format('data/things/%d/.client-assets-complete', version)) then
-      markClientVersionInstalled(version)
-    end
-
-    return true
+    return hasInstalledModernClientFiles(version)
   end
 
   return g_resources.fileExists(string.format('/data/things/%d/Tibia.dat', version)) and
@@ -1420,10 +1410,11 @@ function ensureClientVersion(version, callback)
           return finishDownload(false, 'Assets were downloaded but the client files are still incomplete. Missing catalog-content.json, assets.json.sha256, or required catalog files.')
         end
 
-        if not isClientVersionInstalled(version) then
+        local markerPath = string.format('data/things/%d/.client-assets-complete', version)
+        if not installFileExists(markerPath) then
           markClientVersionInstalled(version)
-          if not isClientVersionInstalled(version) then
-            return finishDownload(false, 'Assets were downloaded but the install marker could not be written.')
+          if not installFileExists(markerPath) then
+            logWarning('Assets were downloaded but the install marker could not be written.')
           end
         end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of modern client installations so setups are recognized even when legacy marker files are missing.
  * Install now completes successfully even if a completion marker cannot be created; a clear warning is logged instead of failing.
  * Workdir-based installs are handled more reliably: checks and reads prefer workdir storage when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->