### PR TITLE
ci: remove schedule diario do update_vcpkg_baseline (bump manual)

### DIFF
--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -1,8 +1,7 @@
 name: Update vcpkg Baseline
 
 on:
-  schedule:
-    - cron: "0 2 * * *"
+  # schedule removido: bump de baseline manual p/ nao esfriar o cache vcpkg
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Mantem workflow_dispatch. Evita CI diaria e merges de baseline que esfriam o feed vcpkg (binary cache por ABI). Bump quando quiser via 'Run workflow' ou rodando o workflow manualmente.


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified automated baseline update workflow to use manual triggering instead of scheduled automatic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->