### PR TITLE
fix: build vs26 directX

### DIFF
--- a/overlay-ports/openal-soft/devendor-fmt.diff
+++ b/overlay-ports/openal-soft/devendor-fmt.diff
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b65e924..814d59e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -256,7 +256,8 @@ if(ALSOFT_ENABLE_MODULES)
+ endif()
+ 
+ 
+-add_subdirectory(fmt-11.2.0 EXCLUDE_FROM_ALL)
++find_package(fmt CONFIG REQUIRED)
++add_library(alsoft::fmt ALIAS fmt::fmt)
+ 
+ 
+ set(CPP_DEFS ) # C pre-processor, not C++
+@@ -1614,7 +1615,7 @@ if(LIBTYPE STREQUAL "STATIC")
+     target_compile_definitions(${IMPL_TARGET} PUBLIC AL_LIBTYPE_STATIC)
+     target_include_directories(${IMPL_TARGET} PRIVATE ${OpenAL_SOURCE_DIR}/gsl/include)
+     target_link_libraries(${IMPL_TARGET} PRIVATE ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB}
+-        $<BUILD_LOCAL_INTERFACE:alsoft::fmt>)
++        alsoft::fmt)
+ 
+     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET
+         AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.13")
+diff --git a/OpenALConfig.cmake.in b/OpenALConfig.cmake.in
+index 4c1ad05..f462df5 100644
+--- a/OpenALConfig.cmake.in
++++ b/OpenALConfig.cmake.in
+@@ -2,6 +2,9 @@ if((NOT DEFINED CMAKE_VERSION) OR (CMAKE_VERSION VERSION_LESS "3.1"))
+    message(FATAL_ERROR "CMake >= 3.1 required")
+ endif()
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(fmt CONFIG)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/OpenALTargets.cmake")
+ 
+ set(OPENAL_FOUND ON)
+diff --git a/openal.pc.in b/openal.pc.in
+index dfa6f57..e04e807 100644
+--- a/openal.pc.in
++++ b/openal.pc.in
+@@ -6,6 +6,7 @@ includedir=@includedir@
+ Name: OpenAL
+ Description: OpenAL is a cross-platform 3D audio API
+ Requires: @PKG_CONFIG_REQUIRES@
++Requires.private: fmt
+ Version: @PACKAGE_VERSION@
+ Libs: -L${libdir} -l@LIBNAME@ @PKG_CONFIG_LIBS@
+ Libs.private:@PKG_CONFIG_PRIVATE_LIBS@

--- a/overlay-ports/openal-soft/pkgconfig-cxx.diff
+++ b/overlay-ports/openal-soft/pkgconfig-cxx.diff
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c0f59f2..b65e924 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1493,6 +1493,15 @@ if(LIBTYPE STREQUAL "STATIC")
+             set(PKG_CONFIG_PRIVATE_LIBS "${PKG_CONFIG_PRIVATE_LIBS} -l${FLAG}")
+         endif()
+     endforeach()
++    foreach(lib IN LISTS CMAKE_CXX_IMPLICIT_LINK_LIBRARIES)
++        if(lib IN_LIST CMAKE_C_IMPLICIT_LINK_LIBRARIES)
++            continue()
++        elseif(EXISTS "${lib}")
++            string(APPEND PKG_CONFIG_PRIVATE_LIBS " ${lib}")
++        else()
++            string(APPEND PKG_CONFIG_PRIVATE_LIBS " -l${lib}")
++        endif()
++    endforeach()
+ endif()
+ 
+ if(UNIX_ELF)

--- a/overlay-ports/openal-soft/portfile.cmake
+++ b/overlay-ports/openal-soft/portfile.cmake
@@ -120,5 +120,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(READ "${SOURCE_PATH}/common/pffft.cpp" pffft_license)
 string(REGEX REPLACE "[*]/.*" "*/\n" pffft_license "${pffft_license}")
-file(WRITE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/pffft Notice" "${pffft_license}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/pffft Notice")
+set(PFFFT_NOTICE "${CURRENT_BUILDTREES_DIR}/pffft Notice")
+file(WRITE "${PFFFT_NOTICE}" "${pffft_license}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${PFFFT_NOTICE}")

--- a/overlay-ports/openal-soft/portfile.cmake
+++ b/overlay-ports/openal-soft/portfile.cmake
@@ -1,0 +1,119 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcat/openal-soft
+    REF ${VERSION}
+    SHA512 47eccb317ed6040c549f2b51d2d45afcdcd03d56d8cb0ea9ef8a98d2c61c9629ffad39596cffa2ad848dd3b65a227a6591406dc483ebd3a3e03bb0a4d0f112b1
+    HEAD_REF master
+    PATCHES
+        pkgconfig-cxx.diff
+        devendor-fmt.diff
+        fix-fmt-header.patch
+)
+
+vcpkg_replace_string(
+    "${SOURCE_PATH}/alc/alc.cpp"
+    "| std::views::transform(&ContextBase::EffectSlotCluster::operator*)"
+    "| std::views::transform([](ContextBase::EffectSlotCluster const &clusterptr) -> auto&\n            {\n                return *clusterptr;\n            })"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pipewire    ALSOFT_BACKEND_PIPEWIRE
+        pipewire    ALSOFT_REQUIRE_PIPEWIRE
+        pulseaudio  ALSOFT_BACKEND_PULSEAUDIO
+        pulseaudio  ALSOFT_REQUIRE_PULSEAUDIO
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(OPENAL_LIBTYPE "SHARED")
+else()
+    set(OPENAL_LIBTYPE "STATIC")
+endif()
+
+set(ALSOFT_REQUIRE_LINUX OFF)
+set(ALSOFT_REQUIRE_WINDOWS OFF)
+set(ALSOFT_REQUIRE_WINDOWS_NOT_UWP OFF)
+set(ALSOFT_REQUIRE_APPLE OFF)
+set(ALSOFT_CPUEXT_NEON OFF)
+
+if(VCPKG_TARGET_IS_LINUX)
+    set(ALSOFT_REQUIRE_LINUX ON)
+endif()
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(ALSOFT_REQUIRE_WINDOWS ON)
+    if(NOT VCPKG_TARGET_IS_UWP)
+        set(ALSOFT_REQUIRE_WINDOWS_NOT_UWP ON)
+    endif()
+endif()
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    set(ALSOFT_REQUIRE_APPLE ON)
+endif()
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(ALSOFT_CPUEXT_NEON ON)
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DALSOFT_CPUEXT_NEON=${ALSOFT_CPUEXT_NEON}
+        -DALSOFT_EXAMPLES=OFF
+        -DALSOFT_INSTALL_AMBDEC_PRESETS=OFF
+        -DALSOFT_INSTALL_CONFIG=OFF
+        -DALSOFT_INSTALL_HRTF_DATA=OFF
+        -DALSOFT_NO_CONFIG_UTIL=ON
+        -DALSOFT_UPDATE_BUILD_VERSION=OFF
+        -DALSOFT_UTILS=OFF
+        -DLIBTYPE=${OPENAL_LIBTYPE}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        -DALSOFT_BACKEND_ALSA=${ALSOFT_REQUIRE_LINUX}
+        -DALSOFT_REQUIRE_ALSA=${ALSOFT_REQUIRE_LINUX}
+        -DALSOFT_BACKEND_OBOE=OFF
+        -DALSOFT_BACKEND_OSS=OFF
+        -DALSOFT_BACKEND_OPENSL=${VCPKG_TARGET_IS_ANDROID}
+        -DALSOFT_REQUIRE_OPENSL=${VCPKG_TARGET_IS_ANDROID}
+        -DALSOFT_BACKEND_PORTAUDIO=OFF
+        -DALSOFT_BACKEND_SOLARIS=OFF
+        -DALSOFT_BACKEND_SNDIO=OFF
+        -DALSOFT_BACKEND_WAVE=ON
+        -DALSOFT_BACKEND_WINMM=OFF
+        -DALSOFT_BACKEND_DSOUND=${ALSOFT_REQUIRE_WINDOWS_NOT_UWP}
+        -DALSOFT_REQUIRE_DSOUND=${ALSOFT_REQUIRE_WINDOWS_NOT_UWP}
+        -DALSOFT_BACKEND_WASAPI=${ALSOFT_REQUIRE_WINDOWS}
+        -DALSOFT_REQUIRE_WASAPI=${ALSOFT_REQUIRE_WINDOWS}
+        -DALSOFT_BACKEND_JACK=OFF
+        -DALSOFT_BACKEND_COREAUDIO=${ALSOFT_REQUIRE_APPLE}
+        -DALSOFT_REQUIRE_COREAUDIO=${ALSOFT_REQUIRE_APPLE}
+    MAYBE_UNUSED_VARIABLES
+        ALSOFT_BACKEND_ALSA
+        ALSOFT_REQUIRE_ALSA
+        ALSOFT_BACKEND_OSS
+        ALSOFT_BACKEND_SOLARIS
+        ALSOFT_BACKEND_SNDIO
+        ALSOFT_BACKEND_WINMM
+        ALSOFT_BACKEND_DSOUND
+        ALSOFT_REQUIRE_DSOUND
+        ALSOFT_BACKEND_WASAPI
+        ALSOFT_REQUIRE_WASAPI
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/OpenAL")
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    foreach(HEADER IN ITEMS al.h alc.h)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/AL/${HEADER}" "defined(AL_LIBTYPE_STATIC)" "1")
+    endforeach()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(READ "${SOURCE_PATH}/common/pffft.cpp" pffft_license)
+string(REGEX REPLACE "[*]/.*" "*/\n" pffft_license "${pffft_license}")
+file(WRITE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/pffft Notice" "${pffft_license}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/pffft Notice")

--- a/overlay-ports/openal-soft/portfile.cmake
+++ b/overlay-ports/openal-soft/portfile.cmake
@@ -16,13 +16,18 @@ vcpkg_replace_string(
     "| std::views::transform([](ContextBase::EffectSlotCluster const &clusterptr) -> auto&\n            {\n                return *clusterptr;\n            })"
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        pipewire    ALSOFT_BACKEND_PIPEWIRE
-        pipewire    ALSOFT_REQUIRE_PIPEWIRE
-        pulseaudio  ALSOFT_BACKEND_PULSEAUDIO
-        pulseaudio  ALSOFT_REQUIRE_PULSEAUDIO
-)
+set(ALSOFT_BACKEND_PIPEWIRE OFF)
+set(ALSOFT_REQUIRE_PIPEWIRE OFF)
+set(ALSOFT_BACKEND_PULSEAUDIO OFF)
+set(ALSOFT_REQUIRE_PULSEAUDIO OFF)
+if("pipewire" IN_LIST FEATURES)
+    set(ALSOFT_BACKEND_PIPEWIRE ON)
+    set(ALSOFT_REQUIRE_PIPEWIRE ON)
+endif()
+if("pulseaudio" IN_LIST FEATURES)
+    set(ALSOFT_BACKEND_PULSEAUDIO ON)
+    set(ALSOFT_REQUIRE_PULSEAUDIO ON)
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(OPENAL_LIBTYPE "SHARED")

--- a/overlay-ports/openal-soft/vcpkg.json
+++ b/overlay-ports/openal-soft/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "openal-soft",
+  "version": "1.25.1",
+  "port-version": 2,
+  "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
+  "homepage": "https://github.com/kcat/openal-soft",
+  "license": "LGPL-2.0-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    {
+      "name": "alsa",
+      "platform": "linux"
+    },
+    {
+      "name": "cppwinrt",
+      "platform": "uwp"
+    },
+    "fmt",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "pipewire": {
+      "description": "Enable PipeWire backend",
+      "dependencies": [
+        "pipewire"
+      ]
+    },
+    "pulseaudio": {
+      "description": "Enable PulseAudio backend",
+      "dependencies": [
+        "pulseaudio"
+      ]
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,10 @@
   "dependencies": [
     "asio",
     "abseil",
-    "cpp-httplib",
+    {
+      "name": "cpp-httplib",
+      "version>=": "0.45.0"
+    },
     "cppcodec",
     "discord-rpc",
     "liblzma",
@@ -44,6 +47,7 @@
     },
     {
       "name": "luajit",
+      "version>=": "2026-03-30",
       "platform": "!android & !wasm32"
     },
     {


### PR DESCRIPTION
I managed to fix the build issue with the SLN for DirectX x64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAL Soft vcpkg port (OpenAL Soft 1.25.1) with optional PipeWire and PulseAudio support.
  * Added detailed vcpkg manifest metadata and feature wiring.
* **Bug Fixes**
  * Improved dependency discovery for `fmt` during CMake configuration and CMake package export.
  * Updated pkg-config metadata and static linking flags to include C++ implicit link libraries.
  * Refined installation/configuration steps, including static header macro adjustments and generated notices.  
* **Documentation**
  * Added minimum version requirements for `cpp-httplib` and `luajit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->