### PR TITLE
fix(platform): compute mouseMoved delta in Cocoa mouse move events

### DIFF
--- a/src/framework/platform/cocoawindow.mm
+++ b/src/framework/platform/cocoawindow.mm
@@ -739,6 +739,7 @@ void CocoaWindow::handleMouseButton(Fw::MouseButton button, bool pressed, const 
 void CocoaWindow::handleMouseMove(const Point& position)
 {
     m_inputEvent.reset(Fw::MouseMoveInputEvent);
+    m_inputEvent.mouseMoved = position - m_inputEvent.mousePos;
     m_inputEvent.mousePos = position;
 
     if (m_onInputEvent)


### PR DESCRIPTION
CocoaWindow::handleMouseMove never filled InputEvent::mouseMoved, so it stayed (0,0) after reset(). Any drag interaction driven by the move delta was broken on macOS: scrollbar slider knobs (e.g. NPC trade amount bar), option sliders, etc. Clicking the empty track worked because UIScrollBar:onClickSlider computes its own delta from the absolute mouse position.

Mirror the x11/win32/browser implementations by computing the delta from the previous mousePos before overwriting it.

Tested on macOS (Apple Silicon): scrollbar knob drag, options sliders and market amount bar all work after the fix; no regression expected on Linux/Windows (their backends already computed the delta).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mouse movement input now reports the correct movement delta when the cursor moves, improving responsiveness and accuracy for pointer-based interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->