### PR TITLE
fix(rewardwall): send the daily reward source byte Canary expects

### DIFF
--- a/modules/game_rewardwall/game_rewardwall.lua
+++ b/modules/game_rewardwall/game_rewardwall.lua
@@ -83,7 +83,9 @@ local BOX_CONFIGS = {
         title = "Confirmation of using Instant Reward Access",
         content = "Remember! You can always collect your daily reward for free by visiting a reward shrine!\n\nYou Currently own 3x Instant Reward Access. Do you really want to use one to claim your daily reward now?",
         okCallback = function()
-            g_game.requestGetRewardDaily(bonusShrine, actualUsed)
+            -- Canary expects 0 = shrine / 1 = panel (inverse of the OpenRewardWall byte
+            -- stored in bonusShrine, where 1 = shrine / 0 = panel)
+            g_game.requestGetRewardDaily(bonusShrine == OPEN_WINDOWS.SHRINE and 0 or 1, actualUsed)
             if windowsPickWindow then
                 windowsPickWindow:destroy()
                 windowsPickWindow = nil
@@ -677,6 +679,17 @@ end
 
 function onClickBtnOk()
     if table.empty(actualUsed) then
+        return
+    end
+    if bonusShrine == OPEN_WINDOWS.SHRINE then
+        -- Collecting at a reward shrine is free: no Instant Reward Access confirmation.
+        -- Canary expects 0 = shrine on the collect packet.
+        g_game.requestGetRewardDaily(0, actualUsed)
+        if windowsPickWindow then
+            windowsPickWindow:destroy()
+            windowsPickWindow = nil
+        end
+        show()
         return
     end
     managerMessageBoxWindow(CONST_WINDOWS_BOX.CONFIRMATION_IRA)


### PR DESCRIPTION
The OpenRewardWall packet uses 1 = shrine / 0 = instant access panel, and the module echoed that same value back on the SelectReward packet. Canary's daily_reward module however expects the inverse on collect (0 = shrine / 1 = panel), so collecting while standing at a reward shrine was treated as an Instant Reward Access collect and failed with "You do not have enough collection tokens", while remote collects were accidentally free.

Translate the byte when sending the collect request, and skip the Instant Reward Access confirmation dialog when the wall was opened at a shrine, since shrine collects are free.

Tested against a Canary 15.11 server: collecting at a reward shrine now succeeds without consuming collection tokens, and the panel (remote) collect goes through the confirmation dialog as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily reward collection behavior so shrine rewards are handled correctly.
  * Shrine-based rewards now collect immediately for free and return users to the reward wall UI.
  * Non-shrine reward confirmations now send the proper reward flag, preventing incorrect reward requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->