### PR TITLE
fix: few modules that fail to load on the browser/wasm build

### DIFF
--- a/modules/game_actionbar/logics/MultiActionLogic.lua
+++ b/modules/game_actionbar/logics/MultiActionLogic.lua
@@ -150,8 +150,9 @@ local function findNextAvailableAction(multiActions)
     local spellCount = 0
 
     for i, data in ipairs(multiActions) do
+        repeat
         if not data or table.empty(data) then
-            goto continue
+            break
         end
 
         if data["chatText"] then
@@ -167,11 +168,11 @@ local function findNextAvailableAction(multiActions)
                 local canUse = playerCanUseSpellLocal(spellData)
                 if not canUse and onlyOneSpell and spellCount == 1 then
                     firstValidAction = firstValidAction or data
-                    goto continue
+                    break
                 end
 
                 if not canUse then
-                    goto continue
+                    break
                 end
 
                 firstValidAction = firstValidAction or data
@@ -212,7 +213,7 @@ local function findNextAvailableAction(multiActions)
             end
         end
 
-        ::continue::
+        until true
     end
 
     return bestAction or closestCooldownAction or firstValidAction

--- a/modules/game_shaders/shaders/fragment/text_glow.frag
+++ b/modules/game_shaders/shaders/fragment/text_glow.frag
@@ -22,8 +22,8 @@ void main() {
     const int MAX_STEPS = 2; // constant loop bound (WebGL2/GLSL ES rejects non-const)
     float maxDist = float(MAX_STEPS); // Reduced glow radius
 
-    for (int step = 1; step <= MAX_STEPS; step++) {
-        float dist = float(step);
+    for (int i = 1; i <= MAX_STEPS; i++) {
+        float dist = float(i);
         float weight = (maxDist - dist + 1.0) / maxDist;
 
         glow += texture2D(u_Tex0, v_TexCoord + vec2(-texelSize.x * dist, 0.0)).a * weight;

--- a/modules/game_shaders/shaders/fragment/text_glow.frag
+++ b/modules/game_shaders/shaders/fragment/text_glow.frag
@@ -19,11 +19,13 @@ void main() {
     
     // Multi-sample for soft glow
     float glow = 0.0;
-    float maxDist = 2.0; // Reduced glow radius
-    
-    for (float dist = 1.0; dist <= maxDist; dist += 1.0) {
+    const int MAX_STEPS = 2; // constant loop bound (WebGL2/GLSL ES rejects non-const)
+    float maxDist = float(MAX_STEPS); // Reduced glow radius
+
+    for (int step = 1; step <= MAX_STEPS; step++) {
+        float dist = float(step);
         float weight = (maxDist - dist + 1.0) / maxDist;
-        
+
         glow += texture2D(u_Tex0, v_TexCoord + vec2(-texelSize.x * dist, 0.0)).a * weight;
         glow += texture2D(u_Tex0, v_TexCoord + vec2(texelSize.x * dist, 0.0)).a * weight;
         glow += texture2D(u_Tex0, v_TexCoord + vec2(0.0, -texelSize.y * dist)).a * weight;

--- a/modules/game_wheel/classes/bonus.lua
+++ b/modules/game_wheel/classes/bonus.lua
@@ -795,9 +795,10 @@ function getConvictionPerks()
 	}
   
 	for id, bonus in pairs(WheelBonus) do
+	  repeat
 	  local index = id + 1
 	  if not WheelOfDestiny.isLit(index) then
-		goto label
+		break
 	  end
   
 	  local t = order[bonus.conviction] or table.size(order) + 1
@@ -805,7 +806,7 @@ function getConvictionPerks()
 	  local pointsInvested = WheelOfDestiny.pointInvested[index] or 0	
   
 	  if pointsInvested ~= bonus.maxPoints then
-		  goto label
+		  break
 	  end
   
 	  if bonus.conviction ==  "special_1" then
@@ -1514,7 +1515,7 @@ function getConvictionPerks()
 		end
     end
 
-    ::label::
+	  until true
   end
 
   return convictions
@@ -1835,8 +1836,9 @@ function getVesselBonus()
 	end
 
 	for _, k in pairs(WheelOfDestiny.equipedGemBonuses) do
+		repeat
 		if k.bonusID == -1 then
-			goto continue
+			break
 		end
 
 		local bonus = k.supreme and SupremeGemDescription[k.bonusID] or RegularGemDescription[k.bonusID]
@@ -1861,7 +1863,7 @@ function getVesselBonus()
 					else
 						bonuses[#bonuses + 1] = {bonusType = bonus.type1, text = "Mitigation Mult.", value = number, tooltip = bonus.tooltip}
 					end
-					goto continue
+					break
 				end
 
 				local number = getBonusValueUpgrade(k.bonusID, k.gemID, k.supreme, true)
@@ -1957,7 +1959,7 @@ function getVesselBonus()
 			end
 		end
 
-		:: continue ::
+		until true
 	end
 
 	if #defenses > 0 then
@@ -1965,13 +1967,14 @@ function getVesselBonus()
 	end
 
 	for _, v in pairs(defenses) do
+		repeat
 		if v.value == 0 then
-			goto continue
+			break
 		end
 
 		local valueString = tonumber(v.value) > 0 and "+" .. v.value or v.value
 		bonuses[#bonuses + 1] = {bonusType = v.bonusType, text = ("  " .. v.text:gsub(" Resistance", "")), value = (valueString .. "%")}
-		:: continue ::
+		until true
 	end
 
 	-- Damage and healing

--- a/modules/game_wheel/classes/gematelier.lua
+++ b/modules/game_wheel/classes/gematelier.lua
@@ -97,8 +97,9 @@ function GemAtelier.redirectToGem(gemData)
 	local foundIndex = 1
 
 	for i, data in pairs(WheelOfDestiny.atelierGems) do
+		repeat
 		if (sortQuality > 1 and data.gemType ~= sortQuality - 2) or (sortAffinity > 1 and data.gemDomain ~= sortAffinity - 2) then
-		 	goto continue
+		 	break
 	 	end
 
 		if gemData.gemID == data.gemID then
@@ -108,7 +109,7 @@ function GemAtelier.redirectToGem(gemData)
 
 		index = index + 1
 		table.insert(totalGemList, data)
-		:: continue ::
+		until true
 	end
 
 	local gemCount = 0
@@ -116,17 +117,19 @@ function GemAtelier.redirectToGem(gemData)
 	local focusedGem = nil
 
 	for i, data in pairs(totalGemList) do
+		local __brk = false
+		repeat
 		if gemCount == 15 then
-			break
+			do __brk = true break end
 		end
 
 		if i < beginList then
-			goto continue
+			break
 		end
 
 		local widget = g_ui.createWidget('GemPanel', gemList)
 		local success = GemAtelier.setupGemWidget(widget, data)
-		
+			
 		if success then
 			currentGemList[#currentGemList + 1] = data
 			if widget then
@@ -140,8 +143,9 @@ function GemAtelier.redirectToGem(gemData)
 		else
 			widget:destroy()
 		end
-
-		:: continue ::
+		
+		until true
+		if __brk then break end
 	end
 
 	GemAtelier.showGemRevelation()
@@ -173,24 +177,25 @@ function GemAtelier.showGems(selectFirst, lastIndex)
 	
 	
 	for i, data in pairs(WheelOfDestiny.atelierGems) do
+		repeat
 		if not data.gemID or data.gemID < 0 then
 			g_logger.debug(string.format("[GemAtelier] Skipping gem with invalid ID: %s", tostring(data.gemID)))
-			goto continue
+			break
 		end
-		
+
 		local isLocked = data.locked == 1 or data.locked == true
 		if lockedOnly and not isLocked then
-			goto continue
+			break
 		elseif sortQuality > 1 and data.gemType ~= sortQuality - 2 then
-			goto continue
+			break
 		elseif sortAffinity > 1 and data.gemDomain ~= sortAffinity - 2 then
-			goto continue
+			break
 		elseif #currentSearchText > 0 and not GemAtelier.matchGemText(data) then
-			goto continue
+			break
 		end
 
 		table.insert(totalGemList, data)
-		:: continue ::
+		until true
 	end
 
 	gemList:destroyChildren()
@@ -200,17 +205,19 @@ function GemAtelier.showGems(selectFirst, lastIndex)
 	local beginList = (currentPage - 1) * 15 + 1
 
 	for i, data in pairs(totalGemList) do
+		local __brk = false
+		repeat
 		if gemCount == 15 then
-			break
+			do __brk = true break end
 		end
 
 		if i < beginList then
-			goto continue
+			break
 		end
 
 		local widget = g_ui.createWidget('GemPanel', gemList)
 		local success = GemAtelier.setupGemWidget(widget, data)
-		
+
 		if success then
 			currentGemList[#currentGemList + 1] = data
 			if widget then
@@ -221,7 +228,8 @@ function GemAtelier.showGems(selectFirst, lastIndex)
 			widget:destroy()
 		end
 
-		:: continue ::
+		until true
+		if __brk then break end
 	end
 
 	GemAtelier.showGemRevelation()
@@ -1158,8 +1166,9 @@ function GemAtelier.setupVesselPanel()
     end
 
     for _, id in pairs(WheelOfDestiny.equipedGems) do
+        repeat
         if type(id) ~= "number" or id < 0 then
-            goto skipGem
+            break
         end
         
         local data = GemAtelier.getGemDataById(id)
@@ -1199,7 +1208,7 @@ function GemAtelier.setupVesselPanel()
                 ))
             end
         end
-        ::skipGem::
+        until true
     end
 
     g_logger.debug("[GemAtelier] setupVesselPanel completed with 4 vessels.")

--- a/modules/game_wheel/classes/wheelclass.lua
+++ b/modules/game_wheel/classes/wheelclass.lua
@@ -114,23 +114,24 @@ function WheelOfDestiny.getSliceIndex(position)
   local smallCircle = Circle.new(x, y, SMALL_CIRCLE)
 
   for _, index in pairs(wheelClick) do
+    repeat
     if WheelButtons[index] then
       local radius = WheelButtons[index].radius
       local circle = Circle.new(x, y, radius)
       if radius == BIG_LARGE_CIRCLE and (largeCircle:inArea(position) or bigMediumCircle:inArea(position) or mediumCircle:inArea(position) or smallCircle:inArea(position)) then
-        goto continue
+        break
       elseif radius == BIG_LARGE_CIRCLE then
         circle = bigLargeCircle
       elseif radius == LARGE_CIRCLE and (bigMediumCircle:inArea(position) or mediumCircle:inArea(position) or smallCircle:inArea(position)) then
-        goto continue
+        break
       elseif radius == LARGE_CIRCLE then
         circle = largeCircle
       elseif radius == BIG_MEDIUM_CIRCLE and (mediumCircle:inArea(position) or smallCircle:inArea(position)) then
-        goto continue
+        break
       elseif radius == BIG_MEDIUM_CIRCLE then
         circle = bigMediumCircle
       elseif radius == MEDIUM_CIRCLE and smallCircle:inArea(position) then
-        goto continue
+        break
       elseif radius == MEDIUM_CIRCLE then
         circle = mediumCircle
       elseif radius == SMALL_CIRCLE then
@@ -143,8 +144,8 @@ function WheelOfDestiny.getSliceIndex(position)
         end
       end
 
-      ::continue::
     end
+    until true
   end
 
   return 0
@@ -566,6 +567,7 @@ function WheelOfDestiny.checkFilledVessels(originalIndex)
 
 	local lastModInserted = 0
 	for _, id in pairs(WheelOfDestiny.vesselEnabled[bonus.domain - 1]) do
+		repeat
 		local widget = wheelPanel:recursiveGetChildById("icon"..id)
 		local modIcon = widget:recursiveGetChildById("modIcon"..id)
 		local iconInfo = WheelIcons[WheelOfDestiny.vocationId][id]
@@ -573,7 +575,7 @@ function WheelOfDestiny.checkFilledVessels(originalIndex)
 		bonus = WheelBonus[id - 1]
 		local gem = GemAtelier.getEquipedGem(bonus.domain - 1)
 		if not gem then
-			goto continue
+			break
 		end
 
 		widget:setImageSource("/images/game/wheel/icons-skillwheel-mediumperks")
@@ -600,7 +602,7 @@ function WheelOfDestiny.checkFilledVessels(originalIndex)
 			WheelOfDestiny.equipedGemBonuses[id] = {bonusID = gem.supremeBonus, supreme = true, gemID = gem.gemID}
 			lastModInserted = 3
 		end
-		:: continue ::
+		until true
 	end
 end
 
@@ -1165,6 +1167,7 @@ function resetWheel(ignoreprotocol)
   WheelOfDestiny.passivePoints = table.reserve(4, 0)
 
   for index, connection in ipairs(WheelNodes) do
+    repeat
     if WheelOfDestiny.vocationId ~= 0 then
       local widget = wheelPanel:recursiveGetChildById("icon"..index)
       local modIcon = widget:recursiveGetChildById("modIcon"..index)
@@ -1180,13 +1183,13 @@ function resetWheel(ignoreprotocol)
     if WheelButtons[index].radius == SMALL_CIRCLE then
       wheelPanel:recursiveGetChildById('fullColorWheel_'..index):setVisible(true)
       wheelPanel:recursiveGetChildById('colorWheel_'..index):setVisible(false)
-      goto continue
+      break
     end
 
     wheelPanel:recursiveGetChildById('fullColorWheel_'..index):setVisible(false)
     wheelPanel:recursiveGetChildById('colorWheel_'..index):setVisible(false)
 
-    ::continue::
+    until true
 
     WheelOfDestiny.pointInvested[index] = 0
   end
@@ -1247,9 +1250,10 @@ function WheelOfDestiny.configureDedicationPerk()
   local vocation = WheelOfDestiny.vocationId
 
   for id, bonus in pairs(WheelBonus) do
+    repeat
     local index = id + 1
     if not WheelOfDestiny.isLit(index) then
-      goto label
+      break
     end
     local points = WheelOfDestiny.pointInvested[index]
     local attribute = WheelConsts[bonus.dedication]
@@ -1267,7 +1271,7 @@ function WheelOfDestiny.configureDedicationPerk()
       mana = mana +  (points * attribute["mana"][vocation])
     end
 
-    ::label::
+    until true
   end
 
   wheelOfDestinyWindow.dedicationPerks.tabContent.hitPoints.value:setText((health > 0 and "+" or "") .. health)
@@ -1368,9 +1372,10 @@ function WheelOfDestiny.configureSummary()
   local vocation = WheelOfDestiny.vocationId
 
   for id, bonus in pairs(WheelBonus) do
+    repeat
     local index = id + 1
     if not WheelOfDestiny.isLit(index) then
-      goto label
+      break
     end
     local points = WheelOfDestiny.pointInvested[index]
     local attribute = WheelConsts[bonus.dedication]
@@ -1388,13 +1393,14 @@ function WheelOfDestiny.configureSummary()
       mana = mana +  (points * attribute["mana"][vocation])
     end
 
-    ::label::
+    until true
   end
 
   -- normal gem bonusses
   for i, k in pairs(WheelOfDestiny.equipedGemBonuses) do
+		repeat
 		if k.bonusID == -1 then
-			goto continue
+			break
 		end
 
 		local bonus = k.supreme and SupremeGemDescription[k.bonusID] or RegularGemDescription[k.bonusID]
@@ -1423,7 +1429,7 @@ function WheelOfDestiny.configureSummary()
         mitigation = mitigation + (type1 + type2)
       end
     end
-    :: continue ::
+    until true
   end
 
   -- damage and healing
@@ -1462,6 +1468,7 @@ function WheelOfDestiny.configureSummary()
 
   local convictions = getConvictionPerks()
   for _, t in ipairs(f_table) do
+    repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
     widget.perk:setText(t)
     widget.info:setVisible(false)
@@ -1479,7 +1486,7 @@ function WheelOfDestiny.configureSummary()
       local lifeleech = convictions[4]
       if not lifeleech or lifeleech.points == 0 then
         widget:destroy()
-        goto label
+        break
       end
 
       widget.value:setText(lifeleech.stringPoint)
@@ -1488,7 +1495,7 @@ function WheelOfDestiny.configureSummary()
       local manaleech = convictions[5]
       if not manaleech or manaleech.points == 0 then
         widget:destroy()
-        goto label
+        break
       end
 
       widget.value:setText(manaleech.stringPoint)
@@ -1496,7 +1503,7 @@ function WheelOfDestiny.configureSummary()
     else
       widget:destroy()
     end
-    ::label::
+    until true
   end
 
   -- separator
@@ -1511,12 +1518,13 @@ function WheelOfDestiny.configureSummary()
 
   local hasCreated = false
   for _, t in pairs(f_table) do
+    repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
     if t == "special_1" then
       local c = convictions[1]
       if not c then
         widget:destroy()
-        goto label
+        break
       end
 
       widget.perk:setText(c.perk)
@@ -1528,7 +1536,7 @@ function WheelOfDestiny.configureSummary()
       local c = convictions[2]
       if not c then
         widget:destroy()
-        goto label
+        break
       end
 
       widget.perk:setText(c.perk)
@@ -1540,7 +1548,7 @@ function WheelOfDestiny.configureSummary()
       local c = convictions[3]
       if not c then
         widget:destroy()
-        goto label
+        break
       end
 
       widget.perk:setText(c.perk)
@@ -1549,7 +1557,7 @@ function WheelOfDestiny.configureSummary()
       widget.info:setTooltip(c.tooltip)
       hasCreated = true
     end
-    ::label::
+    until true
   end
 
   if hasCreated then
@@ -1567,11 +1575,12 @@ function WheelOfDestiny.configureSummary()
   --- Convictions
   local hasCreated = false
   for _, t in pairs(f_table) do
+    repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
     local c = convictions[_]
     if not c then
       widget:destroy()
-      goto label
+      break
     end
 
     widget.perk:setText(c.perk)
@@ -1579,13 +1588,14 @@ function WheelOfDestiny.configureSummary()
     widget.info:setTooltip(c.tooltip)
     widget.info:setVisible(true)
     hasCreated = true
-    ::label::
+    until true
   end
 
   local bonus = getVesselBonus()
   for _, data in pairs(bonus) do
+    repeat
     if data.bonusType ~= "augment" then
-      goto continue
+      break
     end
 
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
@@ -1611,7 +1621,7 @@ function WheelOfDestiny.configureSummary()
     end
 
     hasCreated = true
-    :: continue ::
+    until true
   end
 
   if hasCreated then
@@ -1723,8 +1733,9 @@ function WheelOfDestiny.configureSummary()
 
   local bonus = getVesselBonus()
   for _, data in pairs(bonus) do
+    repeat
     if data.bonusType ~= "revelation" then
-      goto continue
+      break
     end
 
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
@@ -1748,7 +1759,7 @@ function WheelOfDestiny.configureSummary()
     else
       widget.value:setText(data.value)
     end
-    :: continue ::
+    until true
   end
 
   ----------------------------
@@ -1758,8 +1769,9 @@ function WheelOfDestiny.configureSummary()
   local hasDefense = false
   local bonus = getVesselBonus()
   for _, data in pairs(bonus) do
+    repeat
     if data.bonusType ~= "defense" then
-      goto continue
+      break
     end
 
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
@@ -1785,7 +1797,7 @@ function WheelOfDestiny.configureSummary()
     end
 
     hasDefense = true
-    :: continue ::
+    until true
   end
 
   if hasDefense then
@@ -1802,18 +1814,19 @@ function WheelOfDestiny.configureSummary()
 
   local hasCreated = false
   for _, t in pairs(f_table) do
+    repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
     local c = convictions[_]
     if not c then
       widget:destroy()
-      goto label
+      break
     end
     widget.perk:setText(c.perk)
     widget.value:setText(c.stringPoint)
     widget.info:setTooltip(c.tooltip)
     widget.info:setVisible(true)
     hasCreated = true
-    ::label::
+    until true
   end
 
   if hasCreated then
@@ -1981,13 +1994,14 @@ local function getLocalGemStruct()
   local struct = {-1, -1, -1, -1}
 
   for _, id in pairs(WheelOfDestiny.equipedGems) do
+    repeat
     local domain = GemAtelier.getGemDomainById(id)
     if domain == -1 then
-      goto continue
+      break
     end
 
     struct[domain + 1] = id
-    ::continue::
+    until true
   end
 
   return struct
@@ -3233,6 +3247,7 @@ function WheelOfDestiny.generateInternalPreset()
 
   
 	for k, v in pairs(WheelOfDestiny.externalPreset.presets) do
+		repeat
 		local codeString = v["exportString"]
 		local vocationString = codeString:sub(1, 2)
 		local base64Data = codeString:sub(3)
@@ -3241,13 +3256,13 @@ function WheelOfDestiny.generateInternalPreset()
 		-- Invalid data
 		if table.empty(data) or vocationString ~= getVocationSt(playerVocation) then
 			table.remove(WheelOfDestiny.externalPreset.presets, k)
-      goto continue
+      break
 		end
 
 		g_logger.debug(string.format("[WheelPresets] Adding preset '%s' with %d points", v.name, data.maxPoints))
 		table.insert(WheelOfDestiny.internalPreset, { presetName = v.name, availablePoints = data.maxPoints, usedPoints = data.usedPoints, pointInvested = data.pointInvested, equipedGems = data.equipedGems })
-	
-    :: continue ::
+
+    until true
   end
 end
 

--- a/modules/game_wheel/classes/workshop.lua
+++ b/modules/game_wheel/classes/workshop.lua
@@ -39,17 +39,18 @@ function Workshop.createFragments()
 
 	fragmentList = {}
 	for id = 0, #FlatSupremeMods do
+		repeat
 		local info = FlatSupremeMods[id]
 		if info then
 			if id == 4 and vocationId > 6 then
-				goto continue
+				break
 			end
 
 			info.modID = id
 			info.supreme = true
 			table.insert(fragmentList, info)
-			::continue::
 		end
+		until true
 	end
 
 	local vocationMods = VocationSupremeMods[vocationId]
@@ -614,9 +615,10 @@ function Workshop.getSortList(sortOption, equippedBasic, equippedSupreme, text)
 	local gradesText = { ["Grade II"] = 1, ["Grade III"] = 2, ["Grade IV"] = 3 }
 
     for _, data in pairs(fragmentList) do
+		repeat
 		-- Only apply text filter if text is not empty
 		if text and not string.empty(text) and not matchText(text, data.tooltip) then
-			goto continue
+			break
 		end
 
         local modIDStr = tostring(data.modID)
@@ -646,7 +648,7 @@ function Workshop.getSortList(sortOption, equippedBasic, equippedSupreme, text)
             end
         end
 
-		:: continue ::
+		until true
     end
     return tmpList
 end

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -1262,7 +1262,6 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIProgressRect>("getTimeElapsed", &UIProgressRect::getTimeElapsed);
     g_lua.bindClassMemberFunction<UIProgressRect>("getDuration", &UIProgressRect::getDuration);
 
-#ifndef __EMSCRIPTEN__
     g_lua.registerClass<UIGraph, UIWidget>();
     g_lua.bindClassStaticFunction<UIGraph>("create", [] { return std::make_shared<UIGraph>(); });
     g_lua.bindClassMemberFunction<UIGraph>("clear", &UIGraph::clear);
@@ -1279,7 +1278,6 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIGraph>("setInfoLineColor", &UIGraph::setInfoLineColor);
     g_lua.bindClassMemberFunction<UIGraph>("setTextBackground", &UIGraph::setTextBackground);
     g_lua.bindClassMemberFunction<UIGraph>("setGraphVisible", &UIGraph::setGraphVisible);
-#endif
 
     g_lua.registerClass<UIMapAnchorLayout, UIAnchorLayout>();
 }


### PR DESCRIPTION
been poking at the emscripten/browser build and a bunch of modules that work fine on desktop fail to load at startup, so this fixes all of them

the main root cause is that the wasm build links stock lua 5.1 (browser/include/lua51/liblua.a) which has no `goto` (that landed in 5.2, and the desktop luajit accepts it), so every module using the `goto continue` / `::label::` idiom fails to parse with "'=' expected near 'continue'" and the whole module gets dropped

what's in here:

- rewrote the goto/label continue idiom to `repeat ... until true` + `break` in game_wheel (wheelclass, bonus, gematelier, workshop) and game_actionbar/logics/MultiActionLogic — behavior is identical, and on the couple of loops that already had a real outer break i used a flag (`local __brk`) so that break still exits the loop instead of turning into a continue. fixing MultiActionLogic is what brings the whole game_actionbar module back (its whole scripts list was failing because of that one file)
- dropped the `#ifndef __EMSCRIPTEN__` guard around the UIGraph registration in luafunctions.cpp — uigraph.cpp is already compiled for wasm, it just wasn't registered, so styles/supply, styles/loot, styles/xp, styles/impact, styles/input and game_analyser all die with "unable to create widget of type 'UIGraph'". with it registered they load
- text_glow.frag used a non-constant for-loop bound which webgl2/glsl es rejects ("'dist': Loop index cannot be compared with non-constant expression"), swapped it for a `const int` bound with the same 2 samples so the visual is unchanged

before this, the browser boot logged errors for game_wheel, game_actionbar, game_analyser, the 5 UIGraph styles and the Text-Glow shader. after, none of those show up and the client still reaches "Startup done" clean

on validation: i checked the lua rewrites against a stock lua 5.1.5 `luac -p` (same parser the wasm build uses) so they all parse, and i verified every `break` that ended up inside an injected `repeat...until true` came from a goto — so no original break had its meaning changed

no desktop/luajit behavior changes, the goto files still parse fine there and the guards i touched were browser-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and consistency in wheel, gem, workshop, and action selection flows.
  * Fixed UI behavior so graph-related controls are now available in all supported builds.
  * Updated glow rendering to work reliably across more graphics environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->