### PR TITLE
fix: allow ground-border items as use-with targets in Tile::getTopMultiUseThing

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -654,7 +654,7 @@ ThingPtr Tile::getTopMultiUseThing()
     }
 
     for (const auto& thing : m_things) {
-        if (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnTop())
+        if (!thing->isGround() && !thing->isOnTop())
             return thing;
     }
 


### PR DESCRIPTION
## Description

`Tile::getTopMultiUseThing()` excludes `isGroundBorder()` in **every** loop, including the final fallback. As a result, items flagged as `clip` (ground border) in the official appearances can **never** be sent as the target of a use-with action: the client always falls back to `m_things[0]` (the ground) and the server replies "You cannot use this object.".

The original otclient (edubart) accepts ground borders in that final fallback (`!isGround() && !isOnTop()`), so this is a regression introduced in this fork. This PR restores the original semantics — one line.

## Real-world impact

The Ice Islands Quest (Nibelor 1: Breaking the Ice) is **impossible to complete** with this client: the three "small crack in the ice" items (id 7185) are flagged `clip` in the appearances (with no `usable` flag), so using a pick on them always targets the ice ground underneath instead of the crack. The server-side action (`register_actions.lua`, action id 60000) never matches and cancels silently.

Verified end-to-end against a canary v3.6.0 server:

- player quest storages correct (`Questline=3`, `Mission02=1`), crack tile has action id 60000 assigned by the startup table, map item present — everything server-side is fine;
- discriminating test: using the pick on *fragile ice* (7200, a ground item with `usable`) works, while the crack (a stacked `clip` item) never does;
- appearance flags extracted from the 15.x appearances protobuf: `3456 pick = {usable, multiuse}`, `7200 fragile ice = {bank, usable}`, `7185 small crack = {clip}` only;
- with this one-line fix the client targets the crack again and the quest works.

Other quest objects classified as borders are affected the same way (the otservbr datapack even works around this pattern ad hoc for the Dawnport crack by matching `toPosition` instead of the target).

## Behaviour

- **Before:** use-with on a tile whose only non-ground things are ground borders always targets the ground.
- **After:** the topmost border-classified item is targetable when nothing else matches (same as edubart's otclient and the CipSoft client).

Creature-first targeting, force-use priority and the common-item loop are unchanged; this only affects the final fallback.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- macOS (Apple Silicon) build, connected to a canary v3.6.0 server (protocol 15.11): pick on the Nibelor cracks now opens the hole and spawns the chakoyas; pick on fragile ice, rope/shovel spots and NPC trade unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted tile interaction behavior so certain items on a tile can now be selected more consistently.
  * Improved the fallback selection logic to better recognize eligible multi-use objects, including some items that were previously skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->