### PR TITLE
fix: webgl crash on chrome 149+ (growable memory = resizable sharedarraybuffer)

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -72,7 +72,7 @@ RUN source /opt/emsdk/emsdk_env.sh \
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_C_FLAGS="-pthread -matomics -mbulk-memory -fno-lto" \
     -DCMAKE_CXX_FLAGS="-pthread -matomics -mbulk-memory -fno-lto -std=c++20 -D_LIBCPP_DISABLE_AVAILABILITY -fexperimental-library" \
-    -DCMAKE_EXE_LINKER_FLAGS="-pthread -matomics -mbulk-memory -Wno-pthreads-mem-growth -s ALLOW_MEMORY_GROWTH=1 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s WASM=1 -s NO_EXIT_RUNTIME=1 -fno-lto" \
+    -DCMAKE_EXE_LINKER_FLAGS="-pthread -matomics -mbulk-memory -Wno-pthreads-mem-growth -s ALLOW_MEMORY_GROWTH=0 -s INITIAL_MEMORY=1073741824 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s WASM=1 -s NO_EXIT_RUNTIME=1 -fno-lto" \
     -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG -fno-lto" \
     -DCMAKE_CXX_FLAGS_DEBUG="-O0 -g -fno-lto" \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -72,7 +72,7 @@ RUN source /opt/emsdk/emsdk_env.sh \
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_C_FLAGS="-pthread -matomics -mbulk-memory -fno-lto" \
     -DCMAKE_CXX_FLAGS="-pthread -matomics -mbulk-memory -fno-lto -std=c++20 -D_LIBCPP_DISABLE_AVAILABILITY -fexperimental-library" \
-    -DCMAKE_EXE_LINKER_FLAGS="-pthread -matomics -mbulk-memory -Wno-pthreads-mem-growth -s ALLOW_MEMORY_GROWTH=0 -s INITIAL_MEMORY=1073741824 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s WASM=1 -s NO_EXIT_RUNTIME=1 -fno-lto" \
+    -DCMAKE_EXE_LINKER_FLAGS="-pthread -matomics -mbulk-memory -s ALLOW_MEMORY_GROWTH=0 -s INITIAL_MEMORY=1073741824 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s WASM=1 -s NO_EXIT_RUNTIME=1 -fno-lto" \
     -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG -fno-lto" \
     -DCMAKE_CXX_FLAGS_DEBUG="-O0 -g -fno-lto" \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -936,7 +936,11 @@ elseif(WASM)
           -sUSE_PTHREADS=1
           -sFETCH=1
           -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency
-          -sALLOW_MEMORY_GROWTH=1
+          # Growable WASM memory becomes a resizable SharedArrayBuffer, which
+          # Chrome 149+ refuses to accept as a source for WebGL uploads
+          # ("ArrayBuffer value must not be resizable"). Use a fixed heap.
+          -sALLOW_MEMORY_GROWTH=0
+          -sINITIAL_MEMORY=1073741824
           --preload-file=../otclientrc.lua@otclientrc.lua
           --preload-file=../init.lua@init.lua
           --preload-file=../data@data


### PR DESCRIPTION
if you build the browser/wasm target and open it in chrome 149 (or edge on the same engine), the client boots fine, prints "Startup done", then instantly dies on the first frame with:

  TypeError: Failed to execute 'uniformMatrix3fv' on 'WebGL2RenderingContext': The provided ArrayBuffer value must not be resizable

reason: with `-sALLOW_MEMORY_GROWTH=1` + pthreads the wasm memory is a growable (resizable) SharedArrayBuffer. chrome 149 started enforcing the webgl rule that a typed array handed to uniform*/bufferData/etc must not be backed by a resizable ArrayBuffer, so every gl upload throws. chrome <= 148 didn't enforce it, which is why it worked before and broke on the browser update

the emscripten glue makes it obvious — with growth on, `_emscripten_glUniformMatrix3fv` passes `(growMemViews(),HEAPF32)`, i.e. a view onto the growable buffer. it hits every gl call, uniformMatrix3fv is just the first one on boot

fix: turn memory growth off and reserve a fixed 1 GiB heap, so `HEAPF32.buffer` is a plain non-resizable SharedArrayBuffer that webgl accepts. after this the client renders normally — verified on chrome 149.0.7827.155 with a real gpu, reaches the login / language-select screen

tradeoff: fixed heap instead of growable, so if a client ever needs more than 1 GiB it hits the cap — bump `INITIAL_MEMORY` if that happens. the proper long-term fix is really on the emscripten side (copy into a non-resizable temp buffer for gl uploads when the heap can grow), but this is the pragmatic project-level workaround to make the browser build usable on current chrome again

only touches the two link-flag spots: `Dockerfile.browser` and `src/CMakeLists.txt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the browser/WebAssembly build to use a fixed heap size instead of growable memory.
  * Improves compatibility with newer Chrome versions and helps prevent WebGL upload failures and related runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->