### PR TITLE
fix: stop busy loop / OOM on unknown opcodes in parseMessage

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -671,7 +671,12 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                     g_logger.warning(
                         "[{}] Unhandled opcode 0x{:02X} ({}) with {} unread bytes; previous opcode: 0x{:02X} ({}); next bytes: {}",
                         g_game.getClientVersion(), opcode, opcode, unreadSize, prevOpcode, prevOpcode, hexDump.str());
-                    msg->setReadPos(msg->getMessageSize());
+                    // getMessageSize() is the message body length, not an absolute read position.
+                    // Passing it to setReadPos() leaves eof() permanently false (readPos - headerPos
+                    // stays below messageSize because headerPos > 0), so the enclosing while (!eof())
+                    // loop keeps parsing past the end of the message -> busy loop / OOM on any unknown
+                    // opcode. Skip the remaining bytes instead so eof() is reached and parsing stops.
+                    msg->skipBytes(static_cast<uint16_t>(unreadSize));
                     break;
                 }
             }


### PR DESCRIPTION
# Description

The `default:` branch of the opcode switch in `ProtocolGame::parseMessage` tries to discard the rest of the current message when it receives an opcode it does not handle:

```cpp
msg->setReadPos(msg->getMessageSize());
```

`getMessageSize()` returns the **message body length**, not an absolute read position. `eof()` is defined as `(m_readPos - m_headerPos) >= m_messageSize`, and `m_headerPos` is non-zero (`m_maxHeaderSize`). After `setReadPos(m_messageSize)` the check becomes `(m_messageSize - m_headerPos) >= m_messageSize`, i.e. `-m_headerPos >= 0`, which is always **false**. `getUnreadSize()` likewise still reports `m_headerPos` bytes remaining.

So the enclosing `while (!eof())` parse loop never terminates on an unknown opcode: it keeps reading past the end of the message, dispatching garbage opcodes and allocating unbounded memory — an effective freeze / OOM.

The fix skips exactly the unread bytes so `eof()` is reached and the loop stops cleanly:

```cpp
msg->skipBytes(static_cast<uint16_t>(unreadSize));
```

With that, `m_readPos = m_headerPos + m_messageSize`, so `eof()` evaluates to `m_messageSize >= m_messageSize` → `true`.

## Behavior

### **Actual**

When the server sends an opcode the client does not handle, the client enters a busy loop reading past the end of the message, allocating memory until it freezes / runs out of memory. This is easy to trigger when connecting a client to an older-protocol server that emits opcodes the current parser does not implement.

### **Expected**

An unhandled opcode is logged (as it already is) and the remaining bytes of that message are skipped, so parsing of the next message continues normally without a freeze.

## Fixes

# (no existing issue — reproduced while connecting an older-protocol (7.72) server; the bug is protocol-agnostic)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Connected a client to a server that sends an opcode not handled by the parser. Before: the client freezes on login with runaway memory growth. After: the opcode is logged and the session continues normally.
  - [x] Verified against the `InputMessage` semantics: `getMessageSize()` returns the body length, `eof()` compares `m_readPos - m_headerPos` to `m_messageSize`, and `m_headerPos > 0`, so `setReadPos(getMessageSize())` can never reach `eof()`; `skipBytes(getUnreadSize())` does.

**Test Configuration**:

  - Server Version: OTServ-based, protocol 7.72 (bug is not version-specific)
  - Client: this branch, Windows RelWithDebInfo build
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client message parsing when encountering unknown or unsupported opcodes, so the client correctly stops at the end of the current message instead of continuing to read.
  * Prevented cases where malformed/unknown data could cause the client to loop indefinitely and degrade performance or memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->