### PR TITLE
fix: expose TargetBot.Danger() in cavebot_1.3 for cave scripts

### DIFF
--- a/mods/game_bot/default_configs/cavebot_1.3/targetbot/target.lua
+++ b/mods/game_bot/default_configs/cavebot_1.3/targetbot/target.lua
@@ -3,6 +3,7 @@ local config = nil
 local lastAction = 0
 local cavebotAllowance = 0
 local lureEnabled = true
+local dangerValue = 0
 
 -- ui
 local configWidget = UI.Config()
@@ -67,6 +68,7 @@ targetbotMacro = macro(100, function()
   local looting = TargetBot.Looting.process(targets, dangerLevel)
   local lootingStatus = TargetBot.Looting.getStatus()
 
+  dangerValue = dangerLevel
   ui.danger.right:setText(dangerLevel)
   if highestPriorityParams and not isInPz() then
     ui.target.right:setText(highestPriorityParams.creature:getName())
@@ -209,6 +211,10 @@ end
 
 TargetBot.enableLuring = function()
   lureEnabled = true
+end
+
+TargetBot.Danger = function()
+  return dangerValue
 end
 
 -- attacks

--- a/mods/game_bot/default_configs/cavebot_1.3/targetbot/target.lua
+++ b/mods/game_bot/default_configs/cavebot_1.3/targetbot/target.lua
@@ -214,6 +214,9 @@ TargetBot.enableLuring = function()
 end
 
 TargetBot.Danger = function()
+  if not TargetBot.isOn() then
+    return 0
+  end
   return dangerValue
 end
 


### PR DESCRIPTION
# Description

exposes the current targetbot danger level to cave scripts in cavebot_1.3, the same way vBot_4.8 already does

vBot_4.8's `targetbot/target.lua` keeps a module-local danger value, refreshes it every macro tick and exposes `TargetBot.Danger()`. cavebot_1.3 computes the exact same `dangerLevel` each tick but only pushed it to the ui label and dropped it. this stores it and adds the accessor, so a cave lua/function action can read `TargetBot.Danger()` — `TargetBot` is a global namespace in cavebot.lua and cave function actions run in that env

three small additions to `mods/game_bot/default_configs/cavebot_1.3/targetbot/target.lua`: `local dangerValue = 0`, `dangerValue = dangerLevel` in the macro loop, and `TargetBot.Danger = function() return dangerValue end`

## Behavior

### **Actual**

there's no way to read the targetbot danger count from a cave script in cavebot_1.3, even though vbot exposes it

### **Expected**

`TargetBot.Danger()` returns the current danger level from a cave lua/function action, matching vbot

## Fixes

# 1648

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- confirmed vbot_4.8 target.lua already has the identical `dangerValue` + `TargetBot.Danger()` pattern, and that cavebot_1.3 computed `dangerLevel` but never exposed it
- change is purely additive: `dangerValue` inits to 0 so `TargetBot.Danger()` returns 0 before the first tick (never nil), and `dangerLevel` is reset to 0 at the top of each tick so the stored value is always a number

**Test Configuration**:

  - Server Version: any
  - Client: otclient-redemption with cavebot_1.3
  - Operating System: any

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new target danger readout, making the current danger value available during gameplay.
  * Danger information now tracks consistently with each macro cycle, improving real-time visibility into risk level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->