### PR TITLE
fix: useInventoryItemWith source stackpos on pre-780 protocols (7.6 usewith)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -906,10 +906,10 @@ void Game::useInventoryItemWith(const uint16_t itemId, const ThingPtr& toThing)
     g_lua.callGlobalField("g_game", "onUseWith", pos, itemId, toThing, 0);
 }
 
-ItemPtr Game::findPlayerItem(const uint16_t itemId, const int subType)
+ItemPtr Game::findPlayerItem(const uint32_t itemId, const int subType)
 {
     if (m_localPlayer) {
-        for (int slot = Otc::InventorySlotHead; slot <= Otc::InventorySlotAmmo; ++slot) {
+        for (int slot = Otc::InventorySlotHead; slot < Otc::LastInventorySlot; ++slot) {
             const auto& item = m_localPlayer->getInventoryItem(static_cast<Otc::InventorySlot>(slot));
             if (item && item->getId() == itemId && (subType == -1 || item->getSubType() == subType))
                 return item;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -885,6 +885,18 @@ void Game::useInventoryItemWith(const uint16_t itemId, const ThingPtr& toThing)
     if (!canPerformGameAction() || !toThing)
         return;
 
+    // pre-780 protocols resolve the source item by its real inventory slot and
+    // stackpos, so the synthetic Position(0xFFFF, 0, 0) below (source stackpos 0)
+    // addresses the wrong slot and the use silently fails (e.g. rope on 7.6).
+    // resolve the real item and go through useWith, the same gate the hotkey and
+    // keybind code already apply. see #1541
+    if (getClientVersion() < 780) {
+        if (const auto& item = findPlayerItem(itemId, -1)) {
+            useWith(item, toThing);
+            return;
+        }
+    }
+
     const auto& pos = Position(0xFFFF, 0, 0); // means that is a item in inventory
     if (toThing->isCreature())
         m_protocolGame->sendUseOnCreature(pos, itemId, 0, toThing->getId());
@@ -892,6 +904,19 @@ void Game::useInventoryItemWith(const uint16_t itemId, const ThingPtr& toThing)
         m_protocolGame->sendUseItemWith(pos, itemId, 0, toThing->getPosition(), toThing->getId(), toThing->getStackPos());
 
     g_lua.callGlobalField("g_game", "onUseWith", pos, itemId, toThing, 0);
+}
+
+ItemPtr Game::findPlayerItem(const uint16_t itemId, const int subType)
+{
+    if (m_localPlayer) {
+        for (int slot = Otc::InventorySlotHead; slot <= Otc::InventorySlotAmmo; ++slot) {
+            const auto& item = m_localPlayer->getInventoryItem(static_cast<Otc::InventorySlot>(slot));
+            if (item && item->getId() == itemId && (subType == -1 || item->getSubType() == subType))
+                return item;
+        }
+    }
+
+    return findItemInContainers(itemId, subType, 0);
 }
 
 ItemPtr Game::findItemInContainers(const uint32_t itemId, const int subType, const uint8_t tier)

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -186,7 +186,7 @@ public:
     void useInventoryItem(uint16_t itemId);
     void useInventoryItemWith(uint16_t itemId, const ThingPtr& toThing);
     ItemPtr findItemInContainers(uint32_t itemId, int subType, uint8_t tier);
-    ItemPtr findPlayerItem(uint16_t itemId, int subType);
+    ItemPtr findPlayerItem(uint32_t itemId, int subType);
 
     // container related
     int open(const ItemPtr& item, const ContainerPtr& previousContainer);

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -186,6 +186,7 @@ public:
     void useInventoryItem(uint16_t itemId);
     void useInventoryItemWith(uint16_t itemId, const ThingPtr& toThing);
     ItemPtr findItemInContainers(uint32_t itemId, int subType, uint8_t tier);
+    ItemPtr findPlayerItem(uint16_t itemId, int subType);
 
     // container related
     int open(const ItemPtr& item, const ContainerPtr& previousContainer);


### PR DESCRIPTION
# Description

vBot cavebot `usewith` (and any `g_game.useInventoryItemWith(itemId, target)` call) is broken on protocol 7.6. the root cause is in `Game::useInventoryItemWith`: it sends the source item as a synthetic `Position(0xFFFF, 0, 0)` with the source stackpos byte hardcoded to `0`. modern protocols (>=780) resolve the source by itemId so the bad slot/stackpos doesn't matter, but classic protocols resolve the source by its real inventory encoding, where an inventory item lives at `Position(0xFFFF, slot, 0)` with the slot in the `y` field. sending slot 0 addresses the wrong item and the action silently fails (e.g. using a rope on a hole)

the hotkey and keybind code already dodge this by gating on `getClientVersion() < 780` and resolving the real `ItemPtr` via `findPlayerItem` before calling `useWith`. this pushes that same rule down into `useInventoryItemWith` so every caller gets it instead of each caller special-casing old protocols. also adds a small C++ `Game::findPlayerItem` that mirrors the existing lua `g_game.findPlayerItem` (inventory slots first, then open containers)

## Behavior

### **Actual**

on 7.6, `g_game.useInventoryItemWith(itemId, target)` sends source stackpos/slot `0`, the server can't find the source item and nothing happens — cavebot rope/shovel/machete "use with" steps do nothing

### **Expected**

the client resolves the actual inventory/container item and sends its real position and stackpos, so "use with" works on 7.6 exactly like the equivalent `useWith(item, target)` call already does

## Fixes

# 1541

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - traced the wire format: `processInventoryChange` stores inventory items at `Position(0xFFFF, slot, 0)` on all versions, and `getStackPos()` returns the z field for x == 0xFFFF, so the resolved `useWith` path sends the correct slot/stackpos while the old code sent 0/0
  - confirmed the existing working paths (`hotkeys_manager.lua`, `keybind.lua`, and the bot's own `TargetBot.useItem`) already gate on `getClientVersion() < 780` + `findPlayerItem` + `useWith`, and `useInventoryItemWith` was the only "use with" entry point missing that gate
  - static verification only — i don't have a live 7.6 server handy, so a behavioral test on a 7.6 otserv (rope on a hole via cavebot and via a hotkey) is still wanted before merge. modern protocols (>=780) take the unchanged fast path, so no risk there

**Test Configuration**:

  - Server Version: 7.6 (classic otserv/tfs)
  - Client: otclient-redemption with this change
  - Operating System: any

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when using inventory items on older client versions, reducing silent failures.
  * The game now correctly identifies the matching inventory item and uses accurate slot/stack information for the action.
  * If the item isn’t found in the player’s inventory, the game will check nearby containers and proceed when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->