### PR TITLE
fix: restore modules.game_interface.lastManualWalk for game_bot

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -19,6 +19,10 @@ countWindow = nil
 logoutWindow = nil
 exitWindow = nil
 bottomSplitter = nil
+-- timestamp of the last manual keyboard walk, refreshed by game_walk and read
+-- by consumers (e.g. game_bot) to pause automation while the player walks;
+-- defined here so it is always present whenever this module is loaded
+lastManualWalk = 0
 limitedZoom = false
 currentViewMode = 0
 leftIncreaseSidePanels = nil

--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -251,9 +251,6 @@ end
 
 --- Initializes the WalkController.
 function WalkController:onInit()
-    -- consumers (e.g. game_bot) read modules.game_interface.lastManualWalk to
-    -- pause automation while the player walks; keep it defined so it is never nil
-    modules.game_interface.lastManualWalk = 0
     bindKeys()
 end
 

--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -120,6 +120,7 @@ local function walk(dir)
         end
     end
 
+    modules.game_interface.lastManualWalk = g_clock.millis()
     g_game.walk(dir)
     return true
 end
@@ -250,6 +251,9 @@ end
 
 --- Initializes the WalkController.
 function WalkController:onInit()
+    -- consumers (e.g. game_bot) read modules.game_interface.lastManualWalk to
+    -- pause automation while the player walks; keep it defined so it is never nil
+    modules.game_interface.lastManualWalk = 0
     bindKeys()
 end
 


### PR DESCRIPTION
# Description

the keyboard walk/turn handling was moved into `game_walk`, and the field `modules.game_interface.lastManualWalk` went away in the process. that field was a timestamp the old code refreshed every time the player walked manually, and the bundled vbot still reads it in three spots (`mods/game_bot/panels/attacking.lua` and `mods/game_bot/panels/waypoints.lua`) as `modules.game_interface.lastManualWalk + 500 > context.now`

with the field gone that becomes `nil + 500`, a hard lua error that aborts the loot/attack/waypoint macro mid-run — which is exactly the "targeting and spell attack break, char runs like crazy while the cavebot loots" symptom in the report

this restores the field where the bot expects it: `game_walk` initializes `modules.game_interface.lastManualWalk = 0` on load so it is never nil, and stamps `g_clock.millis()` at the point a real manual walk is actually issued (right before `g_game.walk` in `walk()`). it is deliberately not stamped on turn keys or on no-op walks, so only a genuine manual walk pauses the bot for the grace window — the original intent of "manual walk". `context.now` is `g_clock.millis()` too, so the `+ 500` window keeps its meaning

## Behavior

### **Actual**

with the cavebot looting, targeting and spell attack break and the char runs erratically, because reading `lastManualWalk` throws `attempt to perform arithmetic on a nil value` and kills the macro

### **Expected**

manual walking briefly pauses bot looting/attacking (the original 500ms grace window) and nothing errors, whether or not the bot is active

## Fixes

# 946

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - confirmed the field is absent on current main and read (never initialized) at attacking.lua:904/1116 and waypoints.lua:602, so it evaluates nil + 500
  - the stamp sits right before `g_game.walk(dir)` in `walk()`, which is reached only for a genuine issued walk (the early returns for dead / walk-locked / auto-walking / can't-walk skip it), and turns go through a separate `turn()` path, so pure turning does not suppress the bot
  - `0 + 500 > now` is false at login, so the bot is not spuriously paused on start

**Test Configuration**:

  - Server Version: any
  - Client: otclient-redemption on current main
  - Operating System: any

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
