### PR TITLE
fix: outfit animation speed ignoring Animator when always animated

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -1205,6 +1205,10 @@ uint16_t Creature::getCurrentAnimationPhase(const bool mount)
     }
 
     if (thingType->isAnimateAlways()) {
+        if (const auto animator = thingType->getAnimator()) {
+            return static_cast<uint16_t>(thingType->getIdleAnimationPhases() + animator->getPhase());
+        }
+
         const int animationPhases = thingType->getAnimationPhases();
         if (animationPhases <= 0) return 0;
 


### PR DESCRIPTION
# Description

This PR fixes an issue where outfits with the `AnimateAlways` flag enabled were ignoring the custom animation delays defined in the `Animator` (configured via Object Builder). 
Instead of using the configured frame durations, the client was falling back to a hardcoded calculation that forced the entire animation to run in exactly 1 second, resulting in excessively fast animations. The fix ensures that if a valid `Animator` exists when `isAnimateAlways` is true, its `getPhase()` is respected for the correct animation timings.

<img width="1193" height="388" alt="Screenshot_1" src="https://github.com/user-attachments/assets/f74950ff-5b34-4881-af03-b085c577700e" />

<img width="992" height="393" alt="Screenshot_2" src="https://github.com/user-attachments/assets/20b3b6dc-3b46-4b0e-9c9b-3b512031fb4b" />


### **Actual**
When enabling the "Animate Always" flag on an outfit, the client ignores custom animation durations (delays) and the outfit animates at a predefined accelerated speed when the creature is standing still.

https://github.com/user-attachments/assets/ee88f735-29f1-4db7-8872-24ffdf6c7cc5


### **Expected**
When enabling the "Animate Always" flag, the outfit should animate while standing still and correctly respect all custom frame durations defined in the Animator.

https://github.com/user-attachments/assets/2f375090-868d-4dad-9bcf-6bfa95f65faa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation timing for creatures with attached animators.
  * Ensured animator-driven phases are used when available, while preserving existing behavior for other creatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->