### PR TITLE
fix: call draw preLoad before rendering foreground

### DIFF
--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -26,6 +26,7 @@
 #include "clock.h"
 #include "eventdispatcher.h"
 #include "garbagecollection.h"
+#include "client/game.h"
 #include "framework/graphics/drawpoolmanager.h"
 #include "framework/graphics/graphics.h"
 #include "framework/graphics/image.h"
@@ -210,20 +211,21 @@ void GraphicalApplication::run()
                 continue;
             }
 
-            const bool canDrawForeground = !g_drawPool.isDrawing(DrawPoolType::FOREGROUND) && m_drawEvents->canDraw(DrawPoolType::FOREGROUND);
+            {
+                AutoStat s(STATS_RENDER, "DrawPreload");
+                m_drawEvents->preLoad();
+            }
 
-            if (canDrawMap()) {
-                {
-                    AutoStat s(STATS_RENDER, "DrawPreload");
-                    m_drawEvents->preLoad();
-                }
+            bool canDrawForeground = !g_drawPool.isDrawing(DrawPoolType::FOREGROUND) && m_drawEvents->canDraw(DrawPoolType::FOREGROUND);
 
-                if (canDrawForeground) {
-                    tasks.emplace_back(g_asyncDispatcher->submit_task([] {
-                        AutoStat s(STATS_RENDER, "DrawForegroundUI");
-                        g_ui.render(DrawPoolType::FOREGROUND);
-                    }));
-                }
+            if (!g_game.isOnline() && canDrawForeground) {
+                AutoStat s(STATS_RENDER, "DrawForegroundUI");
+                g_ui.render(DrawPoolType::FOREGROUND);
+            } else if (canDrawMap() && canDrawForeground) {
+                tasks.emplace_back(g_asyncDispatcher->submit_task([] {
+                    AutoStat s(STATS_RENDER, "DrawForegroundUI");
+                    g_ui.render(DrawPoolType::FOREGROUND);
+                }));
 
                 static constexpr std::array<DrawPoolType, 2> types{ DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP };
                 for (const auto type : types) {
@@ -242,9 +244,6 @@ void GraphicalApplication::run()
 
                 tasks.wait();
                 tasks.clear();
-            } else if (canDrawForeground) {
-                AutoStat s(STATS_RENDER, "DrawForegroundUI");
-                g_ui.render(DrawPoolType::FOREGROUND);
             }
 
             m_mapProcessFrameCounter.update();

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -213,6 +213,11 @@ void GraphicalApplication::run()
             const bool canDrawForeground = !g_drawPool.isDrawing(DrawPoolType::FOREGROUND) && m_drawEvents->canDraw(DrawPoolType::FOREGROUND);
 
             if (canDrawMap()) {
+                {
+                    AutoStat s(STATS_RENDER, "DrawPreload");
+                    m_drawEvents->preLoad();
+                }
+
                 if (canDrawForeground) {
                     tasks.emplace_back(g_asyncDispatcher->submit_task([] {
                         AutoStat s(STATS_RENDER, "DrawForegroundUI");
@@ -220,10 +225,6 @@ void GraphicalApplication::run()
                     }));
                 }
 
-                {
-                    AutoStat s(STATS_RENDER, "DrawPreload");
-                    m_drawEvents->preLoad();
-                }
                 static constexpr std::array<DrawPoolType, 2> types{ DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP };
                 for (const auto type : types) {
                     if (m_drawEvents->canDraw(type)) {


### PR DESCRIPTION
# Description

Attached widget's position is updated with m_drawEvents->preLoad() call, which is called after the FOREGROUND starts drawing. This results in attached widget "jittering" effect and the fix was to swap them, first preLoad, then render.

## Behavior

### **Actual**

https://github.com/user-attachments/assets/4f1aaada-74bd-4fa3-a912-f731028955ea

### **Expected**

https://github.com/user-attachments/assets/ee5491c4-3111-423f-83af-babb236de89d

## Fixes

\#1760

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering sequencing so preload work runs before any foreground interface draw tasks, reducing timing-related inconsistencies.
  * Refined foreground UI rendering logic: it now renders immediately only when appropriate for offline play, and otherwise enqueues foreground UI updates when map rendering is available—removing the prior fallback that could render at the wrong time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->