### PR TITLE
feat: add 'resume' and 'pause' functions to Stats class

### DIFF
--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -295,6 +295,8 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_stats", "get", &Stats::get, &g_stats);
     g_lua.bindSingletonFunction("g_stats", "clear", &Stats::clear, &g_stats);
     g_lua.bindSingletonFunction("g_stats", "clearAll", &Stats::clearAll, &g_stats);
+    g_lua.bindSingletonFunction("g_stats", "pause", &Stats::pause, &g_stats);
+    g_lua.bindSingletonFunction("g_stats", "resume", &Stats::resume, &g_stats);
     g_lua.bindSingletonFunction("g_stats", "getSlow", &Stats::getSlow, &g_stats);
     g_lua.bindSingletonFunction("g_stats", "clearSlow", &Stats::clearSlow, &g_stats);
     g_lua.bindSingletonFunction("g_stats", "getSleepTime", &Stats::getSleepTime, &g_stats);

--- a/src/framework/util/stats.cpp
+++ b/src/framework/util/stats.cpp
@@ -36,7 +36,7 @@
 Stats g_stats;
 
 void Stats::add(int type, Stat* stat) {
-    if (type < 0 || type > STATS_LAST)
+    if (type < 0 || type > STATS_LAST || paused)
         return;
     std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/framework/util/stats.cpp
+++ b/src/framework/util/stats.cpp
@@ -36,8 +36,10 @@
 Stats g_stats;
 
 void Stats::add(int type, Stat* stat) {
-    if (type < 0 || type > STATS_LAST || paused)
+    if (type < 0 || type > STATS_LAST || paused) {
+        delete stat;
         return;
+    }
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = stats[type].data.emplace(stat->description, StatsData(0, 0, stat->extraDescription)).first;

--- a/src/framework/util/stats.h
+++ b/src/framework/util/stats.h
@@ -127,7 +127,7 @@ private:
     int destroyedThings = 0;
     int createdCreatures = 0;
     int destroyedCreatures = 0;
-    bool paused = false;
+    std::atomic_bool paused { false };
     std::mutex m_mutex;
 };
 

--- a/src/framework/util/stats.h
+++ b/src/framework/util/stats.h
@@ -107,6 +107,9 @@ public:
     inline void addCreature() { createdCreatures += 1; }
     inline void removeCreature() { destroyedCreatures += 1; }
 
+    inline void pause() { paused = true; }
+    inline void resume() { paused = false; }
+
 private:
     struct
     {
@@ -124,6 +127,7 @@ private:
     int destroyedThings = 0;
     int createdCreatures = 0;
     int destroyedCreatures = 0;
+    bool paused = false;
     std::mutex m_mutex;
 };
 


### PR DESCRIPTION
# Description

Adds functions to pause and resume of Stats counting.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to pause and resume statistics collection.
  * While paused, new statistics are no longer recorded; previously gathered statistics remain intact.
  * Lua scripts can now control statistics collection using new `pause` and `resume` commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->