### PR TITLE
fix: NPC trade greys out sellable items when an imbued copy is equipped

### DIFF
--- a/modules/game_npctrade/controllers/npc_legacy_ui.lua
+++ b/modules/game_npctrade/controllers/npc_legacy_ui.lua
@@ -278,8 +278,10 @@ function getSellQuantityLegacy(item)
                 removeAmount = removeAmount + inventoryItem:getCount()
             end
         end
+        -- equipped items with an active imbuement are not part of the server goods count
+        removeAmount = math.max(0, removeAmount - controllerNpcTrader:getEquippedImbuedCount(item:getId()))
     end
-    return playerItems[item:getId()] - removeAmount
+    return math.max(0, playerItems[item:getId()] - removeAmount)
 end
 
 function canTradeItemLegacy(item)

--- a/modules/game_npctrade/controllers/npc_trader.lua
+++ b/modules/game_npctrade/controllers/npc_trader.lua
@@ -329,6 +329,57 @@ function controllerNpcTrader:getPlayerMoney()
     return player:getTotalMoney()
 end
 
+-- Equipped items with an active imbuement are already excluded from the goods
+-- count the server sends (Item::hasMarketAttributes), so subtracting them again
+-- here would hide sellable copies the player carries in containers.
+function controllerNpcTrader:onUpdateEquippedImbuements(items)
+    local counts = {}
+    for _, entry in ipairs(items or {}) do
+        local ptr = entry.item
+        if ptr then
+            local hasActiveImbuement = false
+            for _, slot in pairs(entry.slots or {}) do
+                if slot.duration and slot.duration > 0 then
+                    hasActiveImbuement = true
+                    break
+                end
+            end
+            if hasActiveImbuement then
+                local id = ptr:getId()
+                counts[id] = (counts[id] or 0) + ptr:getCount()
+            end
+        end
+    end
+    self.equippedImbuedCounts = counts
+
+    if self:isLegacyMode() then
+        refreshPlayerGoods()
+    elseif self.isTradeOpen then
+        self:refreshPlayerGoods()
+    end
+end
+
+function controllerNpcTrader:getEquippedImbuedCount(itemId)
+    return (self.equippedImbuedCounts and self.equippedImbuedCounts[itemId]) or 0
+end
+
+function controllerNpcTrader:startEquippedImbuementsTracking()
+    self.equippedImbuedCounts = {}
+    if g_game.getClientVersion() >= 1100 then
+        g_game.imbuementDurations(true)
+    end
+end
+
+function controllerNpcTrader:stopEquippedImbuementsTracking()
+    self.equippedImbuedCounts = {}
+    if g_game.getClientVersion() < 1100 or not g_game.isOnline() then
+        return
+    end
+    local tracker = modules.game_imbuementtracker
+    local trackerOn = tracker and tracker.imbuementTrackerButton and tracker.imbuementTrackerButton:isOn() or false
+    g_game.imbuementDurations(trackerOn)
+end
+
 function controllerNpcTrader:getSellQuantity(itemPtr)
     if not itemPtr then
         return 0
@@ -347,6 +398,7 @@ function controllerNpcTrader:getSellQuantity(itemPtr)
                 equippedCount = equippedCount + item:getCount()
             end
         end
+        equippedCount = math.max(0, equippedCount - self:getEquippedImbuedCount(id))
         return math.max(0, inventoryTotal - equippedCount)
     end
 

--- a/modules/game_npctrade/game_npctrader.lua
+++ b/modules/game_npctrade/game_npctrader.lua
@@ -26,6 +26,7 @@ function controllerNpcTrader:onGameStart()
             onNpcChatWindow(data)
         end,
         onOpenNpcTrade = function(...)
+            self:startEquippedImbuementsTracking()
             if self:isLegacyMode() then
                 onOpenNpcTrade(...)
             else
@@ -39,7 +40,11 @@ function controllerNpcTrader:onGameStart()
                 self:onPlayerGoods(money, items)
             end
         end,
+        onUpdateImbuementTracker = function(items)
+            self:onUpdateEquippedImbuements(items)
+        end,
         onNpcChatWindowClose = function()
+            self:stopEquippedImbuementsTracking()
             if self:isLegacyMode() then
                 self:legacy_hide()
             else
@@ -47,6 +52,7 @@ function controllerNpcTrader:onGameStart()
             end
         end,
         onCloseNpcTrade = function()
+            self:stopEquippedImbuementsTracking()
             if self:isLegacyMode() then
                 self:legacy_hide()
             else


### PR DESCRIPTION
### Bug

In the NPC trade **Sell** tab, an item the player can perfectly sell is shown greyed out (and cannot be sold) when the player also has **another copy of the same item equipped with an active imbuement**.

**Steps to reproduce (Canary server):**
1. Equip an item with an active imbuement (e.g. a royal helmet with Basic Void).
2. Put a second, clean copy of the same item in your backpack.
3. Open trade with an NPC that buys it (e.g. Nah'Bob) and switch to Sell.
4. The item is greyed out with sell quantity 0 — the clean backpack copy cannot be sold. Unequipping the imbued copy immediately makes it sellable, and the server itself sells the backpack copy just fine either way.

### Root cause

`getSellQuantity` (new trader UI) and `getSellQuantityLegacy` (legacy UI) compute the sellable amount as *server goods count − all equipped items with that id*. But Canary already **excludes equipped items with an active imbuement from the goods list** it sends (`Item::hasMarketAttributes`), so those items get subtracted twice:

```
goods = 1 (clean bp copy; imbued equipped copy not counted by the server)
equipped = 1 (imbued copy)
sellable = 1 - 1 = 0  →  greyed out, sale blocked client-side
```

Introduced with the NPC trader revamp in #1604 (the legacy path had the same logic before).

### Fix

Track which equipped items carry an active imbuement using the **imbuement durations** packet (the one that feeds the imbuement tracker): it is enabled while the NPC trade window is open and restored to the tracker button state on close — Canary replies immediately on toggle and keeps the list updated on equipment changes. Equipped items with an active imbuement are then skipped in the equipped subtraction, in both the new controller UI and the legacy UI.

No protocol or C++ changes; Lua only. Verified in-game against a Canary 3.6.0 server (both the greyed-out case and that equipped imbued items still can't be sold with "Sell Equipped"/ignore-equipped off, since the server rejects them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC trading quantity calculations for items with active imbuements.
  * Prevented equipped imbuement items from being counted twice when determining sellable quantities.
  * Ensured sellable item quantities never display as negative.
  * Improved tracking cleanup when closing NPC trade windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->