### PR TITLE
fix: select client asset archives by version

### DIFF
--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -69,6 +69,13 @@ local function isLzmaPath(path)
   return endsWith(tostring(path or ''):lower(), '.lzma')
 end
 
+local function isMacArchivePath(path)
+  path = tostring(path or ''):lower()
+  return endsWith(path, '.app.zip') or
+         path:find('macos', 1, true) or
+         path:find('%f[%a]mac%f[^%a]')
+end
+
 local function isNotFoundError(message)
   message = tostring(message or ''):lower()
   return message:find('404', 1, true) or message:find('not found', 1, true)
@@ -519,14 +526,14 @@ local function findReleaseArchive(release, version)
   end
 
   local tag = tostring(release.tag_name or ''):lower()
-  local label = versionLabel(version):lower()
+  local label = version and versionLabel(version):lower() or ''
   local bestUrl
   local bestScore = 0
 
   for _, asset in ipairs(release.assets) do
     local name = tostring(asset.name or ''):lower()
     local url = asset.browser_download_url
-    if url and isArchivePath(name) and not name:find('mac', 1, true) and not name:find('.app.zip', 1, true) then
+    if url and isArchivePath(name) and not isMacArchivePath(name) then
       local score = 0
       if tag ~= '' and name:find(tag, 1, true) then
         score = score + 4

--- a/modules/client_assets/client_assets.lua
+++ b/modules/client_assets/client_assets.lua
@@ -513,24 +513,46 @@ local function normalizeDescriptor(config, version, descriptor)
   return descriptor
 end
 
-local function findReleaseArchive(release)
+local function findReleaseArchive(release, version)
   if type(release.assets) ~= 'table' then
     return nil
   end
 
-  local fallback
+  local tag = tostring(release.tag_name or ''):lower()
+  local label = versionLabel(version):lower()
+  local bestUrl
+  local bestScore = 0
+
   for _, asset in ipairs(release.assets) do
     local name = tostring(asset.name or ''):lower()
     local url = asset.browser_download_url
-    if url and isArchivePath(name) then
-      fallback = fallback or url
-      if not name:find('mac', 1, true) and not name:find('.app.zip', 1, true) then
-        return url
+    if url and isArchivePath(name) and not name:find('mac', 1, true) and not name:find('.app.zip', 1, true) then
+      local score = 0
+      if tag ~= '' and name:find(tag, 1, true) then
+        score = score + 4
+      end
+      if label ~= '' and name:find(label, 1, true) then
+        score = score + 2
+      end
+
+      -- Releases may contain unrelated legacy client archives. Only accept
+      -- an archive that identifies the requested tag or client version.
+      if score > 0 then
+        if name:find('client', 1, true) then
+          score = score + 1
+        end
+        if name:find('original', 1, true) or name:find('linux', 1, true) then
+          score = score - 1
+        end
+        if score > bestScore then
+          bestUrl = url
+          bestScore = score
+        end
       end
     end
   end
 
-  return fallback
+  return bestUrl
 end
 
 local function codeloadZipUrl(repository, tag)
@@ -553,7 +575,7 @@ local function descriptorFromRelease(config, version, release)
     manifestUrl = baseUrl .. 'assets.json',
     manifestSha256Url = baseUrl .. 'assets.json.sha256',
     treeUrl = string.format('https://api.github.com/repos/%s/git/trees/%s?recursive=1', config.repository, tag),
-    archiveUrl = findReleaseArchive(release) or codeloadZipUrl(config.repository, tag)
+    archiveUrl = findReleaseArchive(release, version) or codeloadZipUrl(config.repository, tag)
   })
 end
 


### PR DESCRIPTION
## Summary

- Select release archives only when their filename identifies the requested client version or release tag.
- Prefer the normal client archive over platform-specific original packages.
- Fall back to the tag source ZIP when a release has no compatible archive instead of accepting an unrelated legacy ZIP.

## Root cause

The archive selector accepted the first non-macOS `.zip` in a release. The 15.25 release lists `client-11.zip` first, so a 15.25 install could download client 11 assets before the 15.25 fallback paths ran.

## Verification

- Reproduced the selection against the live `15.25.0a00a0` release metadata: `tibia-client-15.25.0a00a0.zip` scores higher than `client-11.zip` and `tibia-8.6-extended.zip`, which are rejected as version-mismatched.
- Ran `git diff --check`.
- No build was run, in accordance with the repository build policy.

## Client asset install contract

- Static install-path verification: assets continue to install under `data/things/1525/`, sounds under `data/sounds/1525/`, and archive extras under their configured runtime destination (default `bin/`).
- Expected runtime load behavior is unchanged: OTClient continues to load the installed 15.25 assets from these standard runtime paths.
- Integrity defaults remain strict: `strictManifestSha256 = true` and `allowRawFallbackHashMismatch = false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release archive selection by scoring candidate assets against the client version for more accurate matches.
  * Added macOS-archive-path detection to exclude incompatible `.app.zip`/macos-variant archives from selection.
  * Refined the no-match behavior so the system cleanly falls back to the standard zip download when no best archive is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->