### PR TITLE
fix: stop peekBytes from truncating its length to 8 bits

### DIFF
--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -24,6 +24,7 @@
 
 #include "declarations.h"
 #include <framework/luaengine/luaobject.h>
+#include <algorithm>
 
  // @bindclass
 class InputMessage final : public LuaObject
@@ -94,7 +95,9 @@ public:
 
         // std::min<uint8_t> would narrow both operands to uint8_t, so any value
         // above 255 wraps: an `available` of 256 yields 0 bytes (empty result).
-        bytes = std::min<int>(bytes, available);
+        // Clamp instead of min so a negative `bytes` cannot reach the vector
+        // constructor, where it would convert to a huge size_t.
+        bytes = std::clamp(bytes, 0, available);
         std::vector<uint8_t> data(bytes);
         std::memcpy(data.data(), m_buffer + m_readPos, bytes);
         return data;

--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -92,7 +92,9 @@ public:
         if (available <= 0)
             return {};
 
-        bytes = std::min<uint8_t>(bytes, available);
+        // std::min<uint8_t> would narrow both operands to uint8_t, so any value
+        // above 255 wraps: an `available` of 256 yields 0 bytes (empty result).
+        bytes = std::min<int>(bytes, available);
         std::vector<uint8_t> data(bytes);
         std::memcpy(data.data(), m_buffer + m_readPos, bytes);
         return data;


### PR DESCRIPTION
# Description

`InputMessage::peekBytes` clamps the requested length with an explicitly
instantiated `std::min<uint8_t>`:

```cpp
std::vector<uint8_t> peekBytes(int bytes) const
{
    const int available = m_messageSize - (m_readPos - m_headerPos);
    if (available <= 0)
        return {};

    bytes = std::min<uint8_t>(bytes, available);   // both operands narrowed
    ...
}
```

`bytes` and `available` are both `int`, but naming `uint8_t` as the template
argument converts **both** operands to `uint8_t` before the comparison, so any
value above 255 wraps modulo 256:

| requested | available | returned | expected |
|-----------|-----------|----------|----------|
| 32        | 100       | 32       | 32       |
| 32        | 256       | **0**    | 32       |
| 32        | 270       | **14**   | 32       |
| 600       | 700       | **88**   | 600      |

The clamp is still safe in the memory sense — the result is bounded by
`uint8_t(available) <= available`, so no extra bytes are read — but the length
is wrong, and an `available` that is a multiple of 256 collapses to zero.

Both call sites are diagnostics in `ProtocolGame::parseMessage`: the unknown
opcode warning (`peekBytes(previewSize)`, capped at 32) and the parse exception
handler (`peekBytes(unread)`, uncapped). The hex dumps they emit are therefore
silently shortened, or empty, precisely on the larger messages where they are
most useful for diagnosing a parse failure.

The fix widens the comparison to `int`, which is what the surrounding code
already uses:

```cpp
bytes = std::min<int>(bytes, available);
```

## Behavior

### **Actual**

Hex dumps produced when an unknown opcode is hit or a parse exception is thrown
are truncated to an arbitrary length, and are empty whenever the number of
unread bytes is a multiple of 256.

### **Expected**

The dump contains the requested number of bytes, bounded by the bytes actually
available.

## Fixes

# (no existing issue — found while reading the parser diagnostics added around the unknown opcode path)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Exhaustively compared the old and new expressions over `available` in
        [1, 4096] x `bytes` in [1, 1024] (4,194,304 combinations, MSVC 19.x,
        `/std:c++20`). The new expression matches `min(bytes, available)` in
        every case and never exceeds `available` (0 occurrences), confirming no
        additional bytes become readable. The old expression returns a wrong
        length in 84.4% of the combinations, of which 32,704 return an empty
        vector.
  - [x] Reviewed both call sites in `protocolgameparse.cpp` to confirm the only
        observable change is the length of the emitted hex dump.

**Test Configuration**:

  - Client: this branch, Windows
  - Compiler: MSVC 19.x, `/std:c++20`
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where peeking for more than 255 bytes could return an incorrectly sized result.
  * Peek operations now correctly clamp requested sizes to the amount of data actually available, ensuring returned buffers match the available data and avoiding edge-case miscalculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->