### PR TITLE
fix: flickering of creature information when walking

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -239,6 +239,10 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, con
 
     Rect barsRect = backgroundRect;
 
+    g_drawPool.select(DrawPoolType::CREATURE_INFORMATION);
+    if (isScaled)
+        g_drawPool.scale(g_app.getCreatureInformationScale());
+
     if ((drawFlags & Otc::DrawBars) && (g_game.getClientVersion() >= 1100 ? !isNpc() : true)) {
         g_drawPool.addFilledRect(backgroundRect, Color::black);
         g_drawPool.addFilledRect(healthRect, fillColor);
@@ -359,6 +363,7 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, con
     }
 
     g_drawPool.resetDrawOrder();
+    g_drawPool.select(DrawPoolType::MAP);
 }
 
 void Creature::internalDraw(Point dest, const Color& color)

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -125,7 +125,11 @@ void MapView::drawFloor()
 {
     const auto& cameraPosition = m_posInfo.camera;
 
-    const uint32_t flags = Otc::DrawThings;
+    uint32_t flags = Otc::DrawThings;
+    if (m_drawNames) { flags |= Otc::DrawNames; }
+    if (m_drawHealthBars) { flags |= Otc::DrawBars; }
+    if (m_drawManaBar) { flags |= Otc::DrawManaBar; }
+    if (m_drawHarmony) { flags |= Otc::DrawHarmony; }
 
     for (int_fast8_t z = m_floorMax; z >= m_floorMin; --z) {
         const float fadeLevel = getFadeLevel(z);
@@ -149,7 +153,7 @@ void MapView::drawFloor()
                 g_drawPool.setOpacity(inRange ? .16 : .7);
             }
 
-            tile->draw(transformPositionTo2D(tile->getPosition()), tileFlags);
+            tile->draw(m_posInfo, transformPositionTo2D(tile->getPosition()), tileFlags);
 
             if (alwaysTransparent)
                 g_drawPool.resetOpacity();
@@ -205,7 +209,7 @@ void MapView::drawLights() {
         }
 
         for (const auto& tile : map.tiles)
-            tile->drawLight(transformPositionTo2D(tile->getPosition()), m_lightView.get());
+            tile->drawLight(m_posInfo, transformPositionTo2D(tile->getPosition()), m_lightView.get());
 
         for (const auto& missile : g_map.getFloorMissiles(z))
             missile->draw(transformPositionTo2D(missile->getPosition()), false, m_lightView.get());

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -23,6 +23,7 @@
 #include "tile.h"
 
 #include "client.h"
+#include "client/const.h"
 #include "localplayer.h"
 #include "effect.h"
 #include "game.h"
@@ -66,7 +67,7 @@ void drawThing(const ThingPtr& thing, const Point& dest, const int flags, uint8_
     }
 }
 
-void Tile::draw(const Point& dest, const int flags, LightView* lightView)
+void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, LightView* lightView)
 {
     m_lastDrawDest = dest;
 
@@ -96,18 +97,18 @@ void Tile::draw(const Point& dest, const int flags, LightView* lightView)
     // after we render 2x2 lying corpses, we must redraw previous creatures/ontop above them
     if (m_tilesRedraw) {
         for (const auto& tile : *m_tilesRedraw) {
-            tile->drawCreature(tile->m_lastDrawDest, flags, true, drawElevation);
+            tile->drawCreature(mapRect, tile->m_lastDrawDest, flags, true, drawElevation);
             tile->drawTop(tile->m_lastDrawDest, flags, true, drawElevation);
         }
     }
 
-    drawCreature(dest, flags, false, drawElevation);
+    drawCreature(mapRect, dest, flags, false, drawElevation);
     drawTop(dest, flags, false, drawElevation);
     drawAttachedEffect(dest, dest, lightView, true);
     drawAttachedParticlesEffect(dest);
 }
 
-void Tile::drawLight(const Point& dest, LightView* lightView) {
+void Tile::drawLight(const MapPosInfo& mapRect, const Point& dest, LightView* lightView) {
     uint8_t drawElevation = 0;
 
     for (const auto& thing : m_things) {
@@ -117,7 +118,7 @@ void Tile::drawLight(const Point& dest, LightView* lightView) {
         updateElevation(thing, drawElevation);
     }
 
-    drawCreature(dest, Otc::DrawLights, true, drawElevation, lightView);
+    drawCreature(mapRect, dest, Otc::DrawLights, true, drawElevation, lightView);
 
     if (m_effects) {
         for (const auto& effect : *m_effects)
@@ -127,7 +128,7 @@ void Tile::drawLight(const Point& dest, LightView* lightView) {
     drawAttachedLightEffect(dest, lightView);
 }
 
-void Tile::drawCreature(const Point& dest, const int flags, const bool forceDraw, uint8_t drawElevation, LightView* lightView)
+void Tile::drawCreature(const MapPosInfo& mapRect, const Point& dest, const int flags, const bool forceDraw, uint8_t drawElevation, LightView* lightView)
 {
     if (!forceDraw && !m_drawTopAndCreature)
         return;
@@ -143,6 +144,7 @@ void Tile::drawCreature(const Point& dest, const int flags, const bool forceDraw
             }
 
             drawThing(thing, dest, flags, drawElevation, lightView);
+            static_cast<Creature*>(thing.get())->drawInformation(mapRect, dest - m_drawElevation * g_drawPool.getScaleFactor(), flags);
         }
     }
 
@@ -155,8 +157,10 @@ void Tile::drawCreature(const Point& dest, const int flags, const bool forceDraw
 
         if (flags == Otc::DrawLights)
             creature->drawLight(cDest, lightView);
-        else
+        else {
             creature->draw(cDest, flags & Otc::DrawThings);
+            creature->drawInformation(mapRect, cDest, flags);
+        }
     }
     g_drawPool.resetDrawOrder();
 

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -38,8 +38,8 @@ public:
     bool isTile() override { return true; }
 
     void onAddInMapView();
-    void draw(const Point& dest, int flags, LightView* lightView = nullptr);
-    void drawLight(const Point& dest, LightView* lightView);
+    void draw(const MapPosInfo& mapRect, const Point& dest, int flags, LightView* lightView = nullptr);
+    void drawLight(const MapPosInfo& mapRect, const Point& dest, LightView* lightView);
 
     void clean();
 
@@ -162,7 +162,7 @@ public:
 private:
     void updateThingStackPos();
     void drawTop(const Point& dest, int flags, bool forceDraw, uint8_t drawElevation);
-    void drawCreature(const Point& dest, int flags, bool forceDraw, uint8_t drawElevation, LightView* lightView = nullptr);
+    void drawCreature(const MapPosInfo& mapRect, const Point& dest, int flags, bool forceDraw, uint8_t drawElevation, LightView* lightView = nullptr);
 
     void updateCreatureRangeForInsert(int16_t stackPos, const ThingPtr& thing);
     void rebuildCreatureRange();

--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -22,6 +22,7 @@
 
 #include "uimap.h"
 
+#include "framework/graphics/declarations.h"
 #include "gameconfig.h"
 #include "lightview.h"
 #include "map.h"
@@ -59,6 +60,8 @@ void UIMap::draw(const DrawPoolType drawPane) {
             m_mapView->registerEvents();
         }, m_mapView->m_posInfo.rect, m_mapView->m_posInfo.srcRect,
            m_mapView->getCameraPosition().z == g_gameConfig.getMapSeaFloor() ? Color(0xFFA54C27U) : Color::black);
+
+        g_drawPool.preDraw(DrawPoolType::CREATURE_INFORMATION, [] {});
     } else if (drawPane == DrawPoolType::LIGHT) {
         g_drawPool.preDraw(drawPane, [this] {
             m_mapView->m_lightView->clear();
@@ -66,9 +69,12 @@ void UIMap::draw(const DrawPoolType drawPane) {
             m_mapView->m_lightView->draw(m_mapView->m_posInfo.rect, m_mapView->m_posInfo.srcRect);
         });
     } else if (drawPane == DrawPoolType::CREATURE_INFORMATION) {
-        g_drawPool.preDraw(drawPane, [this] {
-            m_mapView->drawCreatureInformation();
-        });
+        // FIXME: disabled multithreading of creature information drawing (instead draw it at the same time as MAP)
+        // due to an unknown reason creature information of other creatures are noticeably flickering when player is moving
+        //
+        // g_drawPool.preDraw(drawPane, [this] {
+        //     m_mapView->drawCreatureInformation();
+        // });
     } else if (drawPane == DrawPoolType::FOREGROUND_MAP) {
         g_drawPool.preDraw(drawPane, [this] {
             m_mapView->drawForeground(m_mapviewRect);

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -25,6 +25,7 @@
 #include "asyncdispatcher.h"
 #include "clock.h"
 #include "eventdispatcher.h"
+#include "framework/graphics/declarations.h"
 #include "garbagecollection.h"
 #include "client/game.h"
 #include "framework/graphics/drawpoolmanager.h"
@@ -168,7 +169,7 @@ bool GraphicalApplication::canDrawMap() const {
     if (!m_drawEvents->canDraw(MAP))
         return false;
 
-    static constexpr std::array<DrawPoolType, 3> types{ MAP, LIGHT, FOREGROUND_MAP };
+    static constexpr std::array<DrawPoolType, 4> types{ MAP, LIGHT, FOREGROUND_MAP, CREATURE_INFORMATION };
 
     for (DrawPoolType type : types) {
         if (g_drawPool.isDrawing(type))


### PR DESCRIPTION
# Description

When creature information drawing went multithreaded in #688 it introduced slight (but noticeable) jittering when moving. Not really sure why yet, but for the time being I disabled it and moved the drawing as part of the MAP as it was before. 

This is a performance hit, but I think that correctness should always come first before speed. Sadly I don't have any stats to show how much of a performance hit this is, if someone wants to do some test please post your results here. However, I feel like it shouldn't be a big difference.

I have left a FIXME comment if anyone would like to debug why multithreading in this way causes this.

## Behavior

### **Actual**

1x scale
https://streamable.com/7vsi0b

1.5x scale
https://streamable.com/ejbkxf

### **Expected**

1x scale
https://streamable.com/gwabv0

1.5x scale
https://streamable.com/p197q2

## Fixes

\#1435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature information rendering across map tiles, including scaled display modes.
  * Ensured creature names, health, mana, and harmony indicators render according to map display settings.
  * Improved lighting and elevation handling for creature visuals.
  * Prevented map rendering conflicts while creature information is being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->