### PR TITLE
feat: Tibia-like temporary chat (single Enter to send and return to WASD)

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -145,6 +145,9 @@ consoleContentPanel = nil
 local extendedViewButtonToggleChat = nil
 local extendedViewButtonShowAlphaChat = nil
 local gameBottomPanel = nil
+-- Tibia-like: when returnDisablesChat is enabled, pressing Enter in walk (WASD) mode opens a
+-- temporary chat (marked with '*') that returns to WASD after a single message is sent.
+local walkAfterSend = false
 consoleTabBar = nil
 consoleTextEdit = nil
 consoleToggleChat = nil
@@ -358,9 +361,9 @@ function toggleChat()
     if consoleToggleChat.isChecked then
         consoleToggleChat:setText(tr('Chat Off'))
     else
-        consoleToggleChat:setText(tr('Chat On'))
+        consoleToggleChat:setText(walkAfterSend and (tr('Chat On') .. '*') or tr('Chat On'))
     end
-    
+
     updateChatMode()
 end
 
@@ -418,6 +421,7 @@ function switchChat(enabled)
         consoleToggleChat:setTooltip(tr('Disable chat mode, allow to walk using WASD'))
         Keybind.setChatMode(CHAT_MODE.ON)
     else
+        walkAfterSend = false -- leaving chat -> clear temporary state (covers manual button toggle too)
         bindMovingKeys()
         consoleToggleChat:setTooltip(tr('Enable chat mode'))
         Keybind.setChatMode(CHAT_MODE.OFF)
@@ -434,7 +438,16 @@ function switchChatOnCall()
     else
         local message = consoleTextEdit:getText()
         if message == '' then
-            if not isChatEnabled() or modules.client_options.getOption('returnDisablesChat') then
+            if not isChatEnabled() then
+                -- opening chat from walk mode: make it temporary ('*') when returnDisablesChat is on,
+                -- so a single Enter later sends the message and returns to WASD (Tibia-like)
+                if modules.client_options.getOption('returnDisablesChat') then
+                    walkAfterSend = true
+                end
+                toggleChat()
+            elseif walkAfterSend or modules.client_options.getOption('returnDisablesChat') then
+                -- empty Enter: cancel temporary chat / disable chat -> back to WASD
+                walkAfterSend = false
                 toggleChat()
             end
         end
@@ -1525,6 +1538,17 @@ function processMessageMenu(mousePos, mouseButton, creatureName, text, label, ta
 end
 
 function sendCurrentMessage()
+    -- Tibia-like: if chat was opened temporarily from walk mode (see switchChatOnCall),
+    -- a single Enter sends the message and returns to WASD (no extra empty Enter needed).
+    local hadText = #consoleTextEdit:getText() > 0
+    sendCurrentMessageImpl()
+    if hadText and walkAfterSend then
+        walkAfterSend = false
+        toggleChat()
+    end
+end
+
+function sendCurrentMessageImpl()
     local message = consoleTextEdit:getText()
     if #message == 0 then
         return


### PR DESCRIPTION
## Description

When `returnDisablesChat` is enabled and the player walks with WASD (chat off), pressing **Enter** currently needs **two** presses to get back to walking: one to send the message, and another on the empty line to disable chat again.

This PR makes that flow match the official Tibia client's *temporary chat*:

- In walk mode, pressing **Enter** opens a **temporary** chat — the toggle button shows `Chat On*`.
- Typing a message and pressing **Enter** once **sends it and returns to WASD** (no extra empty Enter).
- Pressing **Enter** on the empty line cancels the temporary chat and returns to WASD.
- Opening the chat with the on-screen toggle button still gives a normal **persistent** chat (no `*`, no auto-return).

The whole behavior is **gated behind the existing `returnDisablesChat` option**, so with it disabled (the default) **nothing changes**.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Tested on a live server (protocol 15.24):

- `returnDisablesChat` **on**: walk + Enter -> `Chat On*`; type + Enter -> message sent and back to WASD (single Enter); empty Enter -> cancels back to WASD; toggle-button chat -> persistent, no `*`, no auto-return; Esc -> back to WASD.
- `returnDisablesChat` **off** (default): behavior unchanged.

## Notes

Single-file change in `modules/game_console/console.lua`; no new options or assets (reuses the existing `returnDisablesChat` toggle added in #1546).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary chat mode while walking or using WASD controls.
  * Chat now indicates when it will automatically turn off after sending a message.
  * Pressing Enter can send the message and immediately return to movement controls.

* **Bug Fixes**
  * Temporary chat indicators are cleared when chat is manually disabled or exited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->