### PR TITLE
fix(ui): clip selection background rects to the widget's visible area

### DIFF
--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -172,8 +172,13 @@ void UITextEdit::drawSelf(const DrawPoolType drawPane)
                     }
                 }
 
-                if (width > 0)
-                    m_glyphsSelectBgRectCache.emplace_back(Rect(pos.x, pos.y, width, lineHeight));
+                if (width > 0) {
+                    // clip to the widget's visible area, like glyph coords do; otherwise
+                    // selection rects for scrolled-out lines are drawn outside the widget
+                    const Rect bgRect = Rect(pos.x, pos.y, width, lineHeight).intersection(getPaddingRect());
+                    if (bgRect.isValid())
+                        m_glyphsSelectBgRectCache.emplace_back(bgRect);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Since the word-wrapping feature (#1383), selecting text in a `UITextEdit` can paint selection background rectangles **outside the widget's box**: glyph coordinates are clipped to the visible area, but the selection background rects built from them were not, so the selection for scrolled-out lines is drawn beyond the widget (visible e.g. in the chat input and in dialogs with text fields).

## Fix

`src/framework/ui/uitextedit.cpp` (+7/−2): intersect each selection background rect with `getPaddingRect()` before caching it, exactly like glyph coords already do, and skip rects that end up empty. The cache is rebuilt on scroll (`PropGlyphsMustRecache`), so clipping at build time is safe.

## Testing

Running in production on our live server's clients (Linux, Windows and macOS) since 2026-07-08, verified in-game on all three: the selection stays inside the box in every field where the leak reproduced before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)