### PR TITLE
fix: do not start the local countdown for equipped items with expirestop

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -470,7 +470,9 @@ void LocalPlayer::setInventoryItem(const Otc::InventorySlot inventory, const Ite
 
     if (item && g_game.getFeature(Otc::GameThingClock) && item->getDurationTime() > 0
             && item->getClothSlot() == static_cast<int>(inventory)){
-        item->setDecaying(true);
+        // expirestop-only items (e.g. toggled-off magic light wand) are paused
+        // server-side, so their countdown must not tick client-side either
+        item->setDecaying(item->hasExpire() || item->hasClockExpire());
     }
 
     callLuaField("onInventoryChange", inventory, item, oldItem);


### PR DESCRIPTION
## Description

`LocalPlayer::setInventoryItem` (introduced in #1712) starts the client-side duration countdown for **any** equipped item that has a duration, ignoring the appearance flags. Items whose appearance carries `expirestop` are paused on the server (`stopduration` in items.xml) — e.g. the **switched-off light wand (3046)** carries `expirestop`, while the lit one (3047) carries `expire`.

Result: the displayed timer of a switched-off light wand keeps counting down even though the real duration is not being consumed. The displayed value drifts further from the truth on every toggle and only resyncs on relog — players believe the wand is burning charge while off.

## Fix

One line in `src/client/localplayer.cpp`: only start the local decay when the thing has `expire` or `clockexpire`:

```cpp
item->setDecaying(item->hasExpire() || item->hasClockExpire());
```

`expirestop` items stay frozen, matching the server behaviour.

## Testing

Running on our live 15.11 server's macOS client, verified in-game: switching the light wand off freezes the countdown; switching it on resumes it. Server-side pause behaviour cross-checked against Canary (`stopduration`, decay toggle in `decay_to.lua`) and the appearance flags confirmed by parsing the .dat (3046 = expirestop, 3047 = expire).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)