### PR TITLE
fix(protocol): consume the Cyclopedia Map Data subtype byte in parseAutomapFlag (Tibia 12+)

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3623,6 +3623,16 @@ void ProtocolGame::parseTutorialHint(const InputMessagePtr& msg)
 
 void ProtocolGame::parseAutomapFlag(const InputMessagePtr& msg)
 {
+    if (g_game.getClientVersion() >= 1200) {
+        // Tibia 12+: 0xDD is the "Cyclopedia Map Data" packet family and carries a
+        // subtype byte before the payload (Canary: CyclopediaMapData_t). The classic
+        // minimap marker is subtype 0 (MinimapMarker) — the only one Canary sends.
+        const uint8_t subtype = msg->getU8();
+        if (subtype != 0) {
+            throw Exception("ProtocolGame::parseAutomapFlag: unhandled cyclopedia map data subtype {}", subtype);
+        }
+    }
+
     const auto& pos = getPosition(msg);
     const uint8_t icon = msg->getU8();
     const auto& description = msg->getString();


### PR DESCRIPTION
## Description

With protocol 12+, `0xDD` is no longer the bare "add automap flag" packet: it is the **Cyclopedia Map Data** family, and Canary prepends a subtype byte (`CyclopediaMapData_t`) before the payload — the classic minimap marker is subtype 0 (`MinimapMarker`), the only one Canary currently sends.

`parseAutomapFlag` did not consume that byte, so the whole payload was read shifted by one: the position was wrong and the mark was never painted. Server-side this breaks, for example, the city guide NPCs (`{map}` → `yes` flow), which send their landmarks through this packet — the guides say they marked the map but nothing appears on the minimap.

## Fix

`src/client/protocolgameparse.cpp` (+10): for client version ≥ 1200, read the subtype byte first; subtype 0 continues into the classic marker parsing, any other subtype raises the standard parse exception so future subtypes fail loudly instead of corrupting the stream.

## Testing

Running on our live 15.11 (Canary) server's macOS client, verified in-game: asking a city guide for directions (`hi` → `map` → `yes`) now paints the marks on the minimap; before the fix the same flow painted nothing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)