### PR TITLE
fix: stale loot-value frames in containers on in-place item updates

### DIFF
--- a/modules/game_containers/containers.lua
+++ b/modules/game_containers/containers.lua
@@ -1163,6 +1163,8 @@ function onContainerUpdateItem(container, slot, item, oldItem)
     end
     local itemWidget = container.itemsPanel:getChildById('item' .. slot)
     itemWidget:setItem(item)
+    ItemsDatabase.setRarityItem(itemWidget, item)
+    ItemsDatabase.setTier(itemWidget, item)
     itemWidget:setShowDuration(g_game.getFeature(GameThingClock) and modules.client_options.getOption('showExpiryInContainers'))
     itemWidget:setShowCharges(g_game.getFeature(GameThingCounter) and modules.client_options.getOption('showExpiryInContainers'))
     

--- a/modules/gamelib/items.lua
+++ b/modules/gamelib/items.lua
@@ -95,6 +95,13 @@ function ItemsDatabase.setRarityItem(widget, item, style)
     local clip, imagePath = ItemsDatabase.getClipAndImagePath(item)
 
     if not imagePath then
+        -- no frame applies (empty slot or frames disabled): clear a frame left by a previous item,
+        -- but only if this widget is currently showing one, to avoid clobbering custom backgrounds
+        local currentSource = widget:getImageSource()
+        if currentSource == "/images/ui/rarity_frames" or currentSource == "/images/ui/containerslot-coloredges" then
+            widget:setImageClip(nil)
+            widget:setImageSource('/images/ui/item')
+        end
         return
     end
 


### PR DESCRIPTION
## Description

When an item changes **in place** inside an open container — e.g. 100 gold pieces turning into a platinum coin — the slot keeps the loot-value (rarity) frame of the previous item. Two separate holes:

1. `onContainerUpdateItem` (`modules/game_containers/containers.lua`) never re-runs `setRarityItem`/`setTier`, so the in-place update keeps the frame of the item it replaced.
2. `setRarityItem(widget, nil)` (`modules/gamelib/items.lua`) returns early without clearing, so the orphaned frame survives even the full refresh in `onSizeChange` — only closing and reopening the container repaints it.

## Fix

+9 lines, Lua only: the update handler refreshes frame and tier, and `setRarityItem` clears the frame it painted itself. The clear is guarded by `getImageSource` (only resets widgets whose image is one of the rarity frames), so custom slot backgrounds are never touched.

## Testing

Running on our live 15.11 server's clients, verified in-game on macOS: exchanging 100 gp → platinum coin updates the frame correctly and leaves no orphaned frames, including with `framesRarity` set to each of the frame modes. Handler logic exercised with a LuaJIT one-off test (11/11 cases).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)