### PR TITLE
fix: gem atelier lock/destroy act on the wrong gem and show the inverted lock state

### DIFF
--- a/modules/game_wheel/classes/gematelier.lua
+++ b/modules/game_wheel/classes/gematelier.lua
@@ -248,7 +248,9 @@ function GemAtelier.showGems(selectFirst, lastIndex)
 			gemList:focusChild(gemList:getFirstChild())
 		elseif lastIndex then
 			gemList:focusChild(children[lastIndex])
-		elseif lastSelectedGem and lastSelectedGem:isVisible() and lastSelectedGem.gemID then
+		-- No llamar métodos sobre lastSelectedGem: puede ser un widget ya destruido por el
+		-- propio redraw (destroyChildren) y el método lanza error; leer .gemID sí es seguro.
+		elseif lastSelectedGem and lastSelectedGem.gemID then
 			local targetIndex = 0
 			for i, widget in ipairs(children) do
 				if widget.gemID == lastSelectedGem.gemID then
@@ -968,7 +970,7 @@ function GemAtelier.onDestroyGem(button)
 	if not button or not button:isOn() or not lastSelectedGem or destroyGemWindow ~= nil then
 	  return true
 	end
-  
+
 	local gemData = GemAtelier.getGemDataById(lastSelectedGem.gemID)
 	if not gemData then
 	  g_logger.debug("[GemAtelier] Failed to destroy: gemData not found.")

--- a/modules/game_wheel/classes/gematelier.lua
+++ b/modules/game_wheel/classes/gematelier.lua
@@ -936,27 +936,9 @@ function sendgemAction(actionType, param, pos)
 
 	g_logger.debug(string.format("[GemAtelier] Sending action -> type=%d param=%d pos=%d", actionType, param, pos))
 	g_game.gemAction(actionType, param, pos)
-
-	if actionType == 3 then
-		scheduleEvent(function()
-			local gem = GemAtelier.getGemDataById(param)
-			if not gem then
-				g_logger.debug(string.format("[GemAtelier] Failed to toggle lock: gem id=%d not found.", param))
-				return
-			end
-
-			gem.locked = gem.locked == 1 and 0 or 1
-			g_logger.debug(string.format("[GemAtelier] Toggled local lock of gem id=%d -> %s", 
-				param, gem.locked == 1 and "locked" or "unlocked"))
-
-			if lastSelectedGem and lastSelectedGem.locker then
-				lastSelectedGem.locker:setChecked(gem.locked == 1)
-			end
-
-			local lastIndex = lastSelectedGem and lastSelectedGem.gemIndex or 1
-			GemAtelier.showGems(false, lastIndex)
-		end, 300)
-	end
+	-- Sin toggle optimista para ToggleLock: el server responde SIEMPRE con el refresh completo
+	-- de la ventana (sendOpenWheelWindow) y ese estado es el real; el flip local a +300ms
+	-- llegaba DESPUÉS del refresh y lo invertía — la UI quedaba al revés del server en cada click.
 end
 
 

--- a/modules/game_wheel/classes/wheelclass.lua
+++ b/modules/game_wheel/classes/wheelclass.lua
@@ -726,6 +726,12 @@ function WheelOfDestiny.onDestinyWheel(playerId, canView, changeState, vocationI
     if GemAtelier.setupVesselPanel then
       GemAtelier.setupVesselPanel()
     end
+    -- Re-dibujar la lista de gemas con los datos frescos: el server re-manda la ventana tras
+    -- cada acción del atelier (toggle/destroy/switch) y sin esto los candados y la lista quedan
+    -- pintados con el estado anterior hasta cerrar/reabrir la ventana.
+    if GemAtelier.showGems then
+      GemAtelier.showGems(false)
+    end
   end
 
   wheelPanel.onMouseRelease = WheelOfDestiny.onMouseRelease

--- a/modules/game_wheel/classes/workshop.lua
+++ b/modules/game_wheel/classes/workshop.lua
@@ -343,37 +343,17 @@ end
 
 
 -- Sends gem actions (reveal, destroy, toggleLock, improve)
+-- OJO: esta función es GLOBAL y este archivo carga DESPUÉS de gematelier.lua (wheel.otmod),
+-- así que ESTA copia es la que ejecuta todo el módulo. Sin toggle optimista para ToggleLock:
+-- el server responde SIEMPRE con el refresh completo de la ventana y ese estado es el real;
+-- el flip local a +300ms llegaba DESPUÉS del refresh y lo invertía — la UI quedaba al revés
+-- del server en cada click.
 function sendgemAction(actionType, param, pos)
 	param = param or 0
 	pos = pos or 0
 
 	g_logger.debug(string.format("[GemAtelier] Sending action -> type=%d param=%d pos=%d", actionType, param, pos))
 	g_game.gemAction(actionType, param, pos)
-
-	if actionType == 3 then
-		-- Toggle Lock locally after brief delay (until server returns)
-		scheduleEvent(function()
-			local gem = GemAtelier.getGemDataById(param)
-			if not gem then
-				g_logger.debug(string.format("[GemAtelier] Failed to toggle lock: gem id=%d not found.", param))
-				return
-			end
-
-			-- Inverts correctly (0 = unlocked, 1 = locked)
-			gem.locked = gem.locked == 1 and 0 or 1
-			g_logger.debug(string.format("[GemAtelier] Toggled local lock of gem id=%d -> %s", 
-				param, gem.locked == 1 and "locked" or "unlocked"))
-
-			-- Updates button visual if visible
-			if lastSelectedGem and lastSelectedGem.locker then
-				lastSelectedGem.locker:setChecked(gem.locked == 1)
-			end
-
-			-- Reloads list maintaining current focus
-			local lastIndex = lastSelectedGem and lastSelectedGem.gemIndex or 1
-			GemAtelier.showGems(false, lastIndex)
-		end, 300)
-	end
 end
 
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2338,7 +2338,7 @@ void Game::openWheel(uint32_t playerId)
     m_protocolGame->sendOpenWheel(playerId);
 }
 
-void Game::gemAction(const uint8_t actionType, const uint8_t param, const uint8_t pos)
+void Game::gemAction(const uint8_t actionType, const uint16_t param, const uint8_t pos)
 {
     if (!canPerformGameAction())
         return;

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -476,7 +476,7 @@ public:
     //whell of destiny 
     void openWheel(uint32_t playerId);
     void sendApplyWheelPoints(const std::vector<uint16_t>& slotPoints,uint16_t greenGem,uint16_t redGem,uint16_t acquaGem,uint16_t purpleGem);
-    void gemAction(uint8_t actionType, uint8_t param, uint8_t pos);
+    void gemAction(uint8_t actionType, uint16_t param, uint8_t pos);
 
     void updateMapLatency() {
         if (!m_mapUpdateTimer.first) {

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -184,7 +184,7 @@ public:
     // Wheel of Destiny
     void sendOpenWheel(uint32_t playerId);
     void sendApplyWheelPoints(const std::vector<uint16_t>& slotPoints,uint16_t greenGem,uint16_t redGem,uint16_t acquaGem,uint16_t purpleGem);
-    void sendWheelGemAction(const uint8_t actionType, const uint8_t param, const uint8_t pos);
+    void sendWheelGemAction(const uint8_t actionType, const uint16_t param, const uint8_t pos);
 
     // Weapon Proficiency
     void sendWeaponProficiencyAction(uint8_t actionType, uint16_t itemId = 0);

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -987,12 +987,18 @@ void ProtocolGame::sendRuleViolation(const std::string_view target, const uint8_
     send(msg);
 }
 
-void ProtocolGame::sendWheelGemAction(uint8_t actionType, uint8_t param, uint8_t pos)
+void ProtocolGame::sendWheelGemAction(uint8_t actionType, uint16_t param, uint8_t pos)
 {
     const auto& msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientWheelGemAction); // 0xE7
     msg->addU8(actionType);
-    msg->addU8(param);
+
+    // Canary lê o índice da gema como U16 em Destroy(0)/SwitchDomain(2)/ToggleLock(3);
+    // Reveal(1) e ImproveGrade(4) usam U8
+    if (actionType == 0 || actionType == 2 || actionType == 3)
+        msg->addU16(param);
+    else
+        msg->addU8(static_cast<uint8_t>(param));
 
     // Apenas "ImproveGrade" (actionType == 4) envia o byte extra
     if (actionType == 4)


### PR DESCRIPTION
## Description

Four chained holes around the Gem Atelier lock (verified against a live Canary 15.11 server; all four present in `main`):

1. **Wrong gem index on the wire (C++).** Canary reads a `uint16_t` for Destroy / SwitchDomain / ToggleLock in the `0xE7` wheel packet, but the client sends the gem index as **U8** — the server silently reads 0 and acts on the gem at index 0. On our server this destroyed a *locked* gem the player never selected (`destroyed locked gem` in the server logs).
2. **Optimistic lock flip arrives late (Lua, `gematelier.lua`).** The local toggle scheduled at +300 ms lands **after** the real refresh from the server and inverts it — every click changes the lock server-side but the UI shows the opposite state.
3. **List not redrawn on refresh (Lua).** When the server refresh arrives, the lock icons stay painted with the previous state until the window is reopened.
4. **The flip lives duplicated in `workshop.lua` (Lua).** `workshop.lua` defines a global `sendgemAction` that overrides the one in `gematelier.lua` due to module load order (`wheel.otmod`), so fixing only `gematelier.lua` leaves dead code. Also, the `showGems` re-focus called `isVisible()` on a destroyed widget, aborting the redraw.

## Fix

4 commits, one per hole: send the index as U16 (matching Canary's reader), remove both optimistic flips, redraw the list on server refresh, and guard the re-focus. The U16 change matches what Canary reads for these three actions.

## Testing

Running on our live 15.11 server's macOS client, verified in-game: the lock toggles instantly and persists (UI matches the DB), and dismantle destroys the selected gem (8→7) and credits the fragments. Before the fix, every lock click showed the inverted state and destroy targeted index 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)