### PR TITLE
fix: dont call preLoad unless player is logged into the game

### DIFF
--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -212,7 +212,7 @@ void GraphicalApplication::run()
                 continue;
             }
 
-            {
+            if (g_game.isOnline()) {
                 AutoStat s(STATS_RENDER, "DrawPreload");
                 m_drawEvents->preLoad();
             }


### PR DESCRIPTION
# Description

fix #1778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline behavior by preventing draw-event preparation while the application is disconnected.
  * Draw-event setup now resumes automatically when an online game session is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->