### PR TITLE
fix: creature information draw position when elevated

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -93,7 +93,7 @@ void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, L
                     creature->drawLight(cDest, lightView);
                 else {
                     creature->draw(cDest, flags & Otc::DrawThings);
-                    creature->drawInformation(mapRect, cDest, flags);
+                    creature->drawInformation(mapRect, cDest + creature->getDrawElevation() * g_drawPool.getScaleFactor(), flags);
                 }
             }
         }
@@ -170,7 +170,7 @@ void Tile::drawCreature(const MapPosInfo& mapRect, const Point& dest, const int 
             creature->drawLight(cDest, lightView);
         else {
             creature->draw(cDest, flags & Otc::DrawThings);
-            creature->drawInformation(mapRect, cDest, flags);
+            creature->drawInformation(mapRect, cDest + creature->getDrawElevation() * g_drawPool.getScaleFactor(), flags);
         }
     }
     g_drawPool.resetDrawOrder();
@@ -186,7 +186,7 @@ void Tile::drawCreature(const MapPosInfo& mapRect, const Point& dest, const int 
             }
 
             drawThing(thing, dest, flags, drawElevation, lightView);
-            static_cast<Creature*>(thing.get())->drawInformation(mapRect, dest - m_drawElevation * g_drawPool.getScaleFactor(), flags);
+            static_cast<Creature*>(thing.get())->drawInformation(mapRect, dest, flags);
         }
     }
 


### PR DESCRIPTION
# Description

Fix creature information position when creature is elevated.

## Behavior

### **Actual**

<img width="292" height="324" alt="image" src="https://github.com/user-attachments/assets/8fb17bcd-6f0e-428a-8d20-3432cd039842" />

### **Expected**

<img width="287" height="256" alt="image" src="https://github.com/user-attachments/assets/6e96334c-ddc0-4a81-9543-73e091b6c81c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of creature information during rendering, including diagonal movement and elevated areas.
  * Ensured creature details align correctly with the creature’s visual elevation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->