### PR TITLE
fix(browser): set HttpResponse.connected in the emscripten HTTP login path

### DIFF
--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -324,6 +324,7 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
 
             HttpResponse response;
             if (fetch) {
+                response.connected = true;
                 response.status = static_cast<int>(fetch->status);
                 response.body.assign(fetch->data, fetch->numBytes);
                 emscripten_fetch_close(fetch);


### PR DESCRIPTION
### The bug

In the `__EMSCRIPTEN__` branch of `LoginHttp::httpLogin()`, the `doRequest` lambda fills `response.status` and `response.body` but never sets `response.connected`. Since `HttpResponse` is:

```cpp
bool connected{ false };
explicit operator bool() const { return connected; }
```

`if (result && result.status == Success)` is **always false** in wasm builds — even for a perfect HTTP 200 with a valid login JSON. Every browser HTTP login therefore falls through to the error branch with an empty `errorMessage` and surfaces as **"Login Error: Unknown error"**.

The desktop paths (`loginHttpsJson` / `loginHttpJson`) already return `{ true, ... }`, which is why native login works and the regression is browser-only.

### The fix

Set `connected = true` when `emscripten_fetch()` returned a response object (mirroring the desktop paths, which set it whenever a response was received; HTTP-level errors are still handled via `status`). The `fetch == nullptr` branch keeps `connected == false`.

### How it was found

Verified against a live server: the wasm client's `POST /login` reached the server and got a 200 + full success JSON (confirmed via proxy logs and a synchronous XHR in a worker on the same page), yet the client still reported "Unknown error". Tracing the response handling led to the unset `connected` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web-based login request handling by correctly recognizing successfully established connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->