### PR TITLE
fix: read the full MonkData Virtue payload (count u8 + virtue id u16)

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -5140,8 +5140,14 @@ void ProtocolGame::parseMonkData(const InputMessagePtr& msg) {
             break;
         }
         case Otc::TYPES_MONK_VIRTUE: {
-            const uint8_t virtueValue = msg->getU8();
-            g_logger.debug("Unused {} TO-DO L4381", virtueValue);
+            // official format: count (u8) followed by one u16 virtue id per entry.
+            // Reading only the count desynced the stream and dropped the rest of
+            // the login bundle (VIP groups/list) for monk characters.
+            const uint8_t virtueCount = msg->getU8();
+            for (uint8_t i = 0; i < virtueCount; ++i) {
+                const uint16_t virtueId = msg->getU16();
+                g_logger.debug("Unused virtue {} TO-DO L4381", virtueId);
+            }
             break;
         }
         default:


### PR DESCRIPTION
## The bug

When a **monk** character logs in, the client logs:

```
[1525] Unhandled opcode 0x01 (1) with 4401 unread bytes; previous opcode: 0xC1 (193); next bytes: 00 C1 01 01 D4 03 01 07 00 45 6E 65 6D 69 65 73 ...
```

and silently **discards the rest of the login bundle** — VIP groups (`0xD4`), the VIP list and everything after it.

## Root cause

Canary sends the `Virtue` subtype of opcode `0xC1` (`GameServerMonkData`) in the official 15.25 format: **count (u8) + one u16 virtue id per entry** (`ProtocolGame::sendMonkData`, `OfficialVocationSpecificPlayerData` branch). The client's `parseMonkData` read a single `u8` (marked `TO-DO` in the code) and left the `u16` unread, so the stream desyncs on the next opcode dispatch.

The hex dump decodes exactly to that: the phantom opcode `0x01 0x00` is the unread u16 `virtueId=1` (Harmony — Canary sends `Virtue_t::Harmony` as the default at login), followed by `C1 01 01` (Serenity=1) and `D4 03 …` ("Enemies"/"Friends"/"Trading Partner" VIP groups), matching Canary's monk login sequence 1:1. Enum values agree on both sides (Harmony=0, Serene=1, Virtue=2); the Virtue payload was the only gap.

## The fix

Read the count and loop the u16 virtue ids (future-proof for count > 1). The values remain unused pending the Virtue UI, same as before — but the stream stays aligned and monk logins keep their VIP data.

## Testing

- Compiles and links (incremental macOS arm64 build).
- The bug itself was reproduced and decoded byte-by-byte against a live Canary 15.25 production server (dump analysis above). In-game verification of the fixed binary is pending our next client build batch; I will report results here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of monk virtue data so multiple virtues are read and processed correctly.
  * Prevented incorrect parsing of game messages containing multiple virtue entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->