### PR TITLE
fix(protocol): update 15.25 tactics payload

### DIFF
--- a/modules/game_features/features.lua
+++ b/modules/game_features/features.lua
@@ -287,6 +287,10 @@ controller:registerEvents(g_game, {
             g_game.enableFeature(GameLevelPercentU16)
             g_game.enableFeature(GameTaskboard)
         end
+
+        if version >= 1525 then
+            g_game.enableFeature(GameTacticsWithoutFightMode)
+        end
         
     end
 })

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -229,6 +229,7 @@ GameEffectSource = 132
 GameNpcWindowRedesign = 133
 GameTaskboard = 134
 GameProficiency = 135
+GameTacticsWithoutFightMode = 136
 
 TextColors = {
     red = '#f55e5e',    -- '#c83200'

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -665,6 +665,7 @@ namespace Otc
         GameNpcWindowRedesign = 133,
         GameTaskboard = 134,
         GameProficiency = 135,
+        GameTacticsWithoutFightMode = 136,
         LastGameFeature
     };
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2817,6 +2817,15 @@ void ProtocolGame::parsePlayerCancelAttack(const InputMessagePtr& msg)
 
 void ProtocolGame::parsePlayerModes(const InputMessagePtr& msg)
 {
+    if (g_game.getFeature(Otc::GameTacticsWithoutFightMode)) {
+        const auto chaseMode = static_cast<Otc::ChaseModes>(msg->getU8());
+        const bool safeMode = static_cast<bool>(msg->getU8());
+        const auto pvpMode = static_cast<Otc::PVPModes>(msg->getU8());
+
+        g_game.processPlayerModes(g_game.getFightMode(), chaseMode, safeMode, pvpMode);
+        return;
+    }
+
     const auto fightMode = static_cast<Otc::FightModes>(msg->getU8());
     const auto chaseMode = static_cast<Otc::ChaseModes>(msg->getU8());
     const bool safeMode = static_cast<bool>(msg->getU8());

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -651,6 +651,15 @@ void ProtocolGame::sendChangeFightModes(const Otc::FightModes fightMode, const O
 {
     const auto& msg = std::make_shared<OutputMessage>();
     msg->addU8(Proto::ClientChangeFightModes);
+
+    if (g_game.getFeature(Otc::GameTacticsWithoutFightMode)) {
+        msg->addU8(chaseMode);
+        msg->addU8(safeFight);
+        msg->addU8(pvpMode);
+        send(msg);
+        return;
+    }
+
     msg->addU8(fightMode);
     msg->addU8(chaseMode);
     msg->addU8(safeFight);


### PR DESCRIPTION
## Summary

- Add `GameTacticsWithoutFightMode` and enable it for client version 15.25 and newer.
- Serialize client packet `0xA0` as `chase`, `secure`, and `PvP`, omitting the removed fight-mode byte.
- Parse server packet `0xA7` with the same three-field layout while preserving the locally selected fight mode.
- Keep the legacy packet layout unchanged for earlier client versions.

## Root cause

Tibia 15.25 removed the fight-mode byte from the tactics payload. OTC still used the legacy four-field layout (`fight`, `chase`, `secure`, `PvP`) in both directions. With the current Canary protocol profile introduced by [opentibiabr/canary#4051](https://github.com/opentibiabr/canary/pull/4051), outgoing fields were shifted and incoming `0xA7` parsing could consume the next opcode as the PvP byte.

## Protocol compatibility

- Client to server: `0xA0` now sends `chase`, `secure`, and `PvP` for 15.25+.
- Server to client: `0xA7` now reads `chase`, `secure`, and `PvP` for 15.25+.
- The existing modern sequenced transport envelope is unchanged.
- Versions before 15.25 retain the previous feature-gated layout.

## Validation

- Confirmed the branch was created directly from the current `origin/main` commit.
- Compared both packet directions with the merged Canary protocol change and its TibiaAPI-backed byte record.
- `git diff --check`

Build not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new game protocol mode that allows tactics settings to function without transmitting fight mode.
  * Updated compatibility handling for supported client versions.

* **Bug Fixes**
  * Improved reading and sending of chase, safe-fight, and PvP mode settings when the new protocol mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->