### PR TITLE
fix: player diagonal walk cost now looks at the value from config

### DIFF
--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -1101,7 +1101,7 @@ PathFindResult_ptr Map::newFindPath(const Position& start, const Position& goal,
                 if (it->second->unseen > 50)
                     continue;
 
-                const float diagonal = ((i == 0 || j == 0) ? 1.0f : 3.0f);
+                float diagonal = ((i == 0 || j == 0) ? 1.0f : g_gameConfig.getPlayerDiagonalWalkSpeed());
                 float cost = it->second->cost * diagonal;
                 cost += diagonal * (50.0f * std::max<float>(5.0f, it->second->pos.distance(goal))); // heuristic
                 if (node->totalCost + cost + 50 < it->second->totalCost) {
@@ -1444,7 +1444,7 @@ std::map<std::string, std::tuple<int, int, int, std::string>> Map::findEveryPath
                     continue;
                 }
 
-                float diagonal = ((i == 0 || j == 0) ? 1.0f : 3.0f);
+                float diagonal = ((i == 0 || j == 0) ? 1.0f : g_gameConfig.getPlayerDiagonalWalkSpeed());
                 float cost = it->second->cost * diagonal;
                 if (ignoreCost)
                     cost = 1;


### PR DESCRIPTION
# Description

Instead of hardcoded cost for diagonal walk take the value of "diagonal-walk-speed" from setup.otml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagonal pathfinding accuracy by applying the configured diagonal movement speed when calculating routes.
  * Ensured path costs consistently reflect player movement settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->