### PR TITLE
fix: incorrect draw order of creature when walking diagonally

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -742,25 +742,23 @@ void Creature::updateWalkingTile()
         g_gameConfig.getSpriteSize() + (m_walkOffset.y - displacementY),
         g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize());
 
+    for (int xi = -1; xi <= 1 && !newWalkingTile; ++xi) {
+        for (int yi = -1; yi <= 1 && !newWalkingTile; ++yi) {
+            Rect virtualTileRect((xi + 1) * g_gameConfig.getSpriteSize(), (yi + 1) * g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize());
+
+            // only render creatures where bottom right is inside tile rect
+            if (virtualTileRect.contains(virtualCreatureRect.bottomRight()))
+                newWalkingTile = g_map.getOrCreateTile(getPosition().translated(xi, yi, 0));
+        }
+    }
+
+    // NW - for the effect of going behind the object west of it, walking creature will be drawn in front of the object for the half of the way, and after behind
+    // SE - for the effect of going in front the object south of it, walking creature will be drawn behind the object for the half of the way, and after in front
     if (m_walkedPixels < g_gameConfig.getSpriteSize() / 2) {
         if (m_direction == Otc::Direction::NorthWest)
             newWalkingTile = m_walkingTile ? m_walkingTile : getTile();
         else if (m_direction == Otc::Direction::SouthEast)
             newWalkingTile = g_map.getTile(getPosition().translated(-1, -1, 0));
-    }
-
-    for (int xi = -1; xi <= 1 && !newWalkingTile; ++xi) {
-        for (int yi = -1; yi <= 1 && !newWalkingTile; ++yi) {
-            Rect virtualTileRect((xi + 1) * g_gameConfig.getSpriteSize(), (yi + 1) * g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize());
-
-            // when creature is moving to the upper left tile, because of drawing order (we want creature to be behind the object to the left if its a tree for example)
-            if (m_direction == Otc::Direction::NorthWest && virtualTileRect.contains(virtualCreatureRect.topLeft())) {
-                newWalkingTile = g_map.getOrCreateTile(getPosition().translated(xi, yi, 0));
-            } else if (virtualTileRect.contains(virtualCreatureRect.bottomRight())) {
-                // only render creatures where bottom right is inside tile rect
-                newWalkingTile = g_map.getOrCreateTile(getPosition().translated(xi, yi, 0));
-            }
-        }
     }
 
     if (newWalkingTile == m_walkingTile) return;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -78,12 +78,37 @@ void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, L
         return;
     }
 
-    // when walking diagonally over a tile that has a object on it like a tree the creature should be rendered behind it
-    // i.e. render creature first then the tree
+    std::vector<ThingPtr> skipped_non_walkable;
+    for (const auto& thing : m_things) {
+        if (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnBottom())
+            break;
+        // delay drawing after NE/SW walking creature
+        if (thing->isNotWalkable()) {
+            skipped_non_walkable.push_back(thing);
+            continue;
+        }
+
+        drawThing(thing, dest, flags, drawElevation);
+    }
+
+    drawAttachedEffect(dest, dest, lightView, false);
+
+    if (hasCommonItem()) {
+        for (auto& item : std::ranges::reverse_view(m_things)) {
+            if (!item->isCommon()) continue;
+            drawThing(item, dest, flags, drawElevation);
+        }
+    }
+
+    // when walking diagonally over a tile that has a non-walkable object on it (for example - a tree) the creature should be drawn behind it
     if (hasWalkingCreature()) {
         g_drawPool.setDrawOrder(DrawOrder::THIRD);
         for (const auto& creature : m_walkingCreatures) {
             if (creature->getDirection() == Otc::Direction::NorthEast || creature->getDirection() == Otc::Direction::SouthWest) {
+                // if creature is stepping into this tile then draw it later
+                if (creature->getLastStepToPosition() == getPosition())
+                    continue;
+
                 const auto& cDest = Point(
                     dest.x + ((creature->getPosition().x - m_position.x) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor(),
                     dest.y + ((creature->getPosition().y - m_position.y) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor()
@@ -100,21 +125,8 @@ void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, L
         g_drawPool.resetDrawOrder();
     }
 
-    for (const auto& thing : m_things) {
-        if (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnBottom())
-            break;
-
+    for (const auto& thing : skipped_non_walkable) 
         drawThing(thing, dest, flags, drawElevation);
-    }
-
-    drawAttachedEffect(dest, dest, lightView, false);
-
-    if (hasCommonItem()) {
-        for (auto& item : std::ranges::reverse_view(m_things)) {
-            if (!item->isCommon()) continue;
-            drawThing(item, dest, flags, drawElevation);
-        }
-    }
 
     // after we render 2x2 lying corpses, we must redraw previous creatures/ontop above them
     if (m_tilesRedraw) {
@@ -155,26 +167,6 @@ void Tile::drawCreature(const MapPosInfo& mapRect, const Point& dest, const int 
     if (!forceDraw && !m_drawTopAndCreature)
         return;
 
-    g_drawPool.setDrawOrder(DrawOrder::THIRD);
-    for (const auto& creature : m_walkingCreatures) {
-        // already drawn by this point
-        if (creature->getDirection() == Otc::Direction::NorthEast || creature->getDirection() == Otc::Direction::SouthWest)
-            continue;
-
-        const auto& cDest = Point(
-            dest.x + ((creature->getPosition().x - m_position.x) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor(),
-            dest.y + ((creature->getPosition().y - m_position.y) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor()
-        );
-
-        if (flags == Otc::DrawLights)
-            creature->drawLight(cDest, lightView);
-        else {
-            creature->draw(cDest, flags & Otc::DrawThings);
-            creature->drawInformation(mapRect, cDest + creature->getDrawElevation() * g_drawPool.getScaleFactor(), flags);
-        }
-    }
-    g_drawPool.resetDrawOrder();
-
     bool localPlayerDrawed = false;
     if (hasCreatures()) {
         for (const auto& thing : m_things) {
@@ -189,6 +181,27 @@ void Tile::drawCreature(const MapPosInfo& mapRect, const Point& dest, const int 
             static_cast<Creature*>(thing.get())->drawInformation(mapRect, dest, flags);
         }
     }
+
+    g_drawPool.setDrawOrder(DrawOrder::THIRD);
+    for (const auto& creature : m_walkingCreatures) {
+        // already drawn by this point
+        if (creature->getDirection() == Otc::Direction::NorthEast || creature->getDirection() == Otc::Direction::SouthWest)
+            if (creature->getLastStepToPosition() != getPosition())
+                continue;
+
+        const auto& cDest = Point(
+            dest.x + ((creature->getPosition().x - m_position.x) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor(),
+            dest.y + ((creature->getPosition().y - m_position.y) * g_gameConfig.getSpriteSize() - creature->getDrawElevation()) * g_drawPool.getScaleFactor()
+        );
+
+        if (flags == Otc::DrawLights)
+            creature->drawLight(cDest, lightView);
+        else {
+            creature->draw(cDest, flags & Otc::DrawThings);
+            creature->drawInformation(mapRect, cDest + creature->getDrawElevation() * g_drawPool.getScaleFactor(), flags);
+        }
+    }
+    g_drawPool.resetDrawOrder();
 
     // draw the local character if he is on a virtual tile, that is, his visual position is not the same as the server.
     if (!localPlayerDrawed && g_game.getLocalPlayer() && !g_game.getLocalPlayer()->isWalking() && g_game.getLocalPlayer()->getPosition() == m_position) {


### PR DESCRIPTION
# Description

Fixed 2 draw order bugs when creature is walking diagonally introduced in #1779. Creature was incorrectly being drawn behind some objects in some scenarios, check the screenshots below.

## Behavior

### **Actual**

<img width="240" height="235" alt="image" src="https://github.com/user-attachments/assets/0b967086-978f-40cb-95eb-7ae6a1d9c5fc" />

<img width="249" height="239" alt="image" src="https://github.com/user-attachments/assets/ec2b9eba-1c4e-4226-bd51-b77e1f40e3ea" />

### **Expected**

<img width="185" height="183" alt="image" src="https://github.com/user-attachments/assets/a37f7cb5-c5f7-4687-929b-da1507324bcf" />

<img width="197" height="206" alt="image" src="https://github.com/user-attachments/assets/07db659c-0c6a-4f3d-a479-9d610cf2a289" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature positioning while walking across tiles, including diagonal movement.
  * Corrected rendering order so walking creatures appear properly relative to non-walkable ground objects.
  * Improved display of stationary creatures and local-player positioning.
  * Removed visual inconsistencies caused by outdated virtual-tile rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->