### PR TITLE
fix(luaengine): dispatch events connected after a failed field lookup

### DIFF
--- a/modules/corelib/util.lua
+++ b/modules/corelib/util.lua
@@ -45,6 +45,13 @@ function connect(object, arg1, arg2, arg3)
         return
     end
 
+    -- Connecting to a class table (e.g. connect(LocalPlayer, ...)) does not go
+    -- through the object's __newindex, so the engine cannot notice on its own
+    -- that a handler showed up. Without this, a callLuaField that failed before
+    -- the connect stays cached as "this event does not exist" and is never
+    -- dispatched again.
+    invalidateEventCache()
+
     local signalsAndSlots
     local pushFront
     if type(arg1) == 'string' then

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -465,7 +465,9 @@ void LocalPlayer::setInventoryItem(const Otc::InventorySlot inventory, const Ite
     if (m_inventoryItems[inventory] == item)
         return;
 
-    const auto& oldItem = m_inventoryItems[inventory];
+    // must be a copy: binding a reference to the array element made it alias
+    // the assignment below, so Lua received the new item as "oldItem"
+    const ItemPtr oldItem = m_inventoryItems[inventory];
     m_inventoryItems[inventory] = item;
 
     if (item && g_game.getFeature(Otc::GameThingClock) && item->getDurationTime() > 0

--- a/src/framework/luaengine/luainterface.cpp
+++ b/src/framework/luaengine/luainterface.cpp
@@ -248,7 +248,8 @@ int LuaInterface::luaObjectSetEvent(LuaInterface* lua)
     assert(obj);
 
     if (key.starts_with("on")) {
-        obj->m_events[key] = true;
+        // The handler now exists on this instance, so any cached "absent" verdict is stale.
+        obj->m_missingEvents.erase(key);
     }
 
     lua->remove(-2); // removes key

--- a/src/framework/luaengine/luaobject.h
+++ b/src/framework/luaengine/luaobject.h
@@ -91,9 +91,21 @@ public:
     template<typename T>
     std::shared_ptr<T> dynamic_self_cast() { return std::dynamic_pointer_cast<T>(shared_from_this()); }
 
+    /// Invalidates every negative entry of the callLuaField cache.
+    /// Must be called whenever a handler may have been attached to a class
+    /// table (`connect(LocalPlayer, {onFoo = f})`), because such an assignment
+    /// bypasses the object's __newindex and is therefore invisible to us.
+    static void invalidateEventCache() { ++s_eventCacheGeneration; }
+
 private:
     int m_fieldsTableRef;
-    std::unordered_map<std::string, bool> m_events;
+
+    /// Fields that were looked up and did not exist, stamped with the
+    /// generation in which the lookup happened. A stamp older than the current
+    /// generation means "recheck", not "absent".
+    std::unordered_map<std::string, uint32_t> m_missingEvents;
+
+    inline static uint32_t s_eventCacheGeneration = 1;
 
     friend class LuaInterface;
 };
@@ -222,16 +234,21 @@ void LuaObject::callLuaField(const std::string_view field, const T&... args)
     const std::string fieldStr = field.data();
 
     // Avoids unnecessary overhead by checking if the field is registered before invoking the Lua event.
-    auto it = m_events.find(fieldStr);
-    if (it != m_events.end() && !it->second)
+    // The generation stamp is what keeps this cache honest: a handler connected
+    // AFTER a failed lookup would otherwise never be reached again.
+    if (const auto it = m_missingEvents.find(fieldStr);
+        it != m_missingEvents.end() && it->second == s_eventCacheGeneration)
         return;
 
     const int rets = luaCallLuaField(field, args...);
     if (rets > 0)
         g_lua.pop(rets);
 
-    if (it == m_events.end())
-        m_events[fieldStr] = rets > -1;
+    // -1 means the field did not exist; 0 or more means a handler ran.
+    if (rets == -1)
+        m_missingEvents[fieldStr] = s_eventCacheGeneration;
+    else
+        m_missingEvents.erase(fieldStr);
 }
 
 template<typename... T>

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -78,6 +78,10 @@
 
 void Application::registerLuaFunctions()
 {
+    // Lets corelib's connect() tell the engine that a handler may have appeared
+    // on a class table, which no metamethod can observe.
+    g_lua.bindGlobalFunction("invalidateEventCache", [] { LuaObject::invalidateEventCache(); });
+
     // conversion globals
     g_lua.bindGlobalFunction("torect", [](const std::string_view v) { return stdext::from_string<Rect>(v); });
     g_lua.bindGlobalFunction("topoint", [](const std::string_view v) { return stdext::from_string<Point>(v); });


### PR DESCRIPTION
# Description

`LuaObject::callLuaField` caches a "this field does not exist" verdict and never revisits it. The verdict is recorded on the **first** emission of a signal — so if that emission happens before the Lua module connects its handler, the signal is dead for the rest of that object's lifetime.

The cache is never corrected because `connect()` writes to the **class table**:

```lua
connect(LocalPlayer, { onInventoryChange = handler })   -- sets LocalPlayer.onInventoryChange
```

Only an assignment on the *instance* (`obj.onFoo = f`) goes through `__newindex` / `luaObjectSetEvent`, which was the sole updater of `m_events`.

Introduced in cce5a54be ("perf: prevent attempt to call unregistered events").

I found it through the inventory, but it is not inventory-specific: any `LuaObject` signal that can be emitted before the first `connect` is affected.

## Behavior

### **Actual**

Equip an item. The server accepts it, and the client's own state is correct — `getInventoryItem()` returns the new item, and `look` reports the new item. But the inventory slot keeps drawing the **previous** item's sprite until you relog.

It is intermittent: it is a race between the login bundle (which emits `onInventoryChange` for every slot) and `game_inventory`'s `onGameStart` (which connects the handler). Anything that shifts that timing makes it come and go.

Relogging "fixes" it because a fresh `LocalPlayer` starts with an empty cache, and `refreshInventory_panel()` populates the UI by reading `getInventoryItem()` directly instead of relying on the signal.

### **Expected**

The slot updates as soon as the server confirms the change.

## Fixes

No issue filed — found while debugging a local 15.25 server.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Instrumented `callLuaField` to log every cache decision, then ran a controlled A/B on the same binary, changing only whether the generation stamp is consulted.

**A — without invalidation (current `main` behavior):**

```
18:41:23.769  getField returned nil? true   rets=-1  generation=871   <- login poisons the cache
18:41:23.770  short-circuited by cache (stored generation 871, current 871)   <- slots 2..11
18:41:23.847  onInventoryChange connected
18:41:27.841  (inventory change emitted)
18:41:27.841  short-circuited by cache (stored generation 871, current 986)
```

The handler is connected and the emission arrives, and the stale entry still wins. Note `current 986`: the engine *was* told a connect happened, and the cache ignored it.

**B — with this patch:** same emission, stored generation 871 != current 989, so the lookup is retried, the handler runs, and the sprite updates:

```
[cpp-inv]      entry slot=4 item=0 current=3388
[cpp-dispatch] getField returned nil? false
[inv]          slot=4 item=nil old=3388
[sprite]       slot=4 ok: id=3359
```

  - [x] Test A — equipping/swapping items updates the slot immediately, repeatedly, without relogging
  - [x] Test B — full login, walking, combat, containers, market: no regressions observed

**Test Configuration**:

  - Server Version: Canary (opentibiabr), protocol 15.25
  - Client: this branch, `local-windows-release` (MSVC 19.44, Ninja, vcpkg)
  - Operating System: Windows 11 Pro 26200

## Notes for reviewers

The optimization is **kept**, not removed — repeated emissions with no handler still short-circuit. The negative entry is simply stamped with a generation counter that `connect()` bumps, so a stale verdict means "recheck" rather than "absent". Cost is one `unordered_map` lookup plus an integer compare, and `connect()` is not a hot path.

`invalidateEventCache()` is global rather than per-object on purpose: the write that invalidates the cache lands on a class table shared by every instance, so there is no single object to target.

Also included: a one-line fix in `LocalPlayer::setInventoryItem`, in the same code path. `oldItem` bound a reference to the array element that the next line overwrites, so handlers received the *new* item as `oldItem`:

```cpp
const auto& oldItem = m_inventoryItems[inventory];  // reference to the element
m_inventoryItems[inventory] = item;                 // overwrites what it points at
```

Happy to split that into its own PR if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handlers being skipped after they become available.
  * Improved event registration so newly connected handlers are recognized immediately.
  * Fixed inventory-change callbacks to report the actual previous item.
  * Added event-cache refresh support to ensure updated handlers are retried correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->