### PR TITLE
fix: NPC dialog window shows the wrong NPC when several are in talk range

### DIFF
--- a/modules/game_npctrade/controllers/npc_dialog.lua
+++ b/modules/game_npctrade/controllers/npc_dialog.lua
@@ -169,7 +169,10 @@ function onNpcChatWindow(data)
     if type(data) ~= "table" or type(data.npcIds) ~= "table" or #data.npcIds == 0 then
         return
     end
-    local creature = g_map.getCreatureById(data.npcIds[1])
+    -- The server appends every greeting NPC to the list and builds the buttons from the
+    -- LAST id (the active conversation); npcIds[1] is the oldest, e.g. a bystander that
+    -- happened to be in talk range. Showing npcIds[1] paints the wrong name and outfit.
+    local creature = g_map.getCreatureById(data.npcIds[#data.npcIds])
     if creature then
         controllerNpcTrader:initNpcWindow(creature, data.buttons)
     end


### PR DESCRIPTION
### Bug

With two NPCs inside talk range, the NPC dialog window opens with the name and outfit of the **wrong** NPC while the buttons and the conversation belong to the right one.

Reproducible in Thais: say `hi` in front of the **King Tibianus** (32311,32172,6) while **Stutch** stands two tiles away (32310,32170,6). Both NPCs greet, and the window opens titled *"Stutch"*, wearing Stutch's outfit, with the King's greeting text and buttons.

### Root cause

Both sides of the `0x1C` payload disagree on which id identifies the conversation:

* the server (Canary `data/modules/scripts/npc/npc_dialog.lua`) keeps a per-player list of NPCs in dialog, **appends** every NPC that greets, sends the whole list, and builds the buttons from `npcIds[#npcIds]` — the active conversation;
* the client painted the name and outfit of `npcIds[1]` — the oldest entry, which is any bystander that happened to be in talk range first.

### Fix

Use `data.npcIds[#data.npcIds]`, so the window shows the NPC the buttons belong to.

The name label is a reactive `*text` binding and `initNpcWindow` refreshes the outfit, so when the second NPC greets after the first, the already-open window repaints correctly.

### Testing

* Reproduced and verified in-game (macOS client, protocol 15.25): the King Tibianus dialog now opens as *"King Tibianus"* with the King's outfit while Stutch is in range.
* Regression with a single NPC in range: unchanged behaviour (`#npcIds == 1`, so the last element is the first).
* One-off LuaJIT harness over `onNpcChatWindow`: bug scenario, single-NPC regression, malformed payloads and an unknown creature id — 7/7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NPC conversations now open with the currently active NPC instead of the oldest listed NPC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->