### PR TITLE
fix: Wheel fragment counters show the bank balance instead of fragments

### DIFF
--- a/modules/game_wheel/classes/wheelclass.lua
+++ b/modules/game_wheel/classes/wheelclass.lua
@@ -712,8 +712,8 @@ function WheelOfDestiny.onDestinyWheel(playerId, canView, changeState, vocationI
   local player = g_game.getLocalPlayer()
   local bankMoney = player:getResourceBalance(ResourceTypes.BANK_BALANCE)
   local characterMoney = player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
-  local lesserFragment = player:getResourceBalance(ResourceTypes.LESSER_FRAGMENTS)
-  local greaterFragment = player:getResourceBalance(ResourceTypes.GREATER_FRAGMENTS)
+  local lesserFragment = player:getResourceBalance(ResourceTypes.LESSER_FRAGMENT)
+  local greaterFragment = player:getResourceBalance(ResourceTypes.GREATER_FRAGMENT)
 
   local value = bankMoney + characterMoney
   wheelWindow.moneyPanel.gold:setText(formatMoney(value, ','))

--- a/modules/game_wheel/classes/workshop.lua
+++ b/modules/game_wheel/classes/workshop.lua
@@ -304,7 +304,7 @@ function Workshop.onSelectChild(list, selected)
     local player = g_game.getLocalPlayer()
     local goldCost = isSupreme and greaterResources[supremeTier].price or lesserResources[basicTier].price
     local fragmentCost = isSupreme and greaterResources[supremeTier].fragment or lesserResources[basicTier].fragment
-    local resourceCheck = isSupreme and player:getResourceBalance(ResourceTypes.GREATER_FRAGMENTS) or player:getResourceBalance(ResourceTypes.LESSER_FRAGMENTS)
+    local resourceCheck = isSupreme and player:getResourceBalance(ResourceTypes.GREATER_FRAGMENT) or player:getResourceBalance(ResourceTypes.LESSER_FRAGMENT)
     local iconOffset = isSupreme and "0 12 12 12" or "0 0 12 12"
     local iconTooltip = isSupreme and "Greater Fragments" or "Lesser Fragments"
 

--- a/modules/game_wheel/wheel.lua
+++ b/modules/game_wheel/wheel.lua
@@ -317,8 +317,8 @@ function onResourceBalance()
   
   local bankMoney = player:getResourceBalance(ResourceTypes.BANK_BALANCE)
   local characterMoney = player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
-  local lesserFragment = player:getResourceBalance(ResourceTypes.LESSER_FRAGMENTS)
-  local greaterFragment = player:getResourceBalance(ResourceTypes.GREATER_FRAGMENTS)
+  local lesserFragment = player:getResourceBalance(ResourceTypes.LESSER_FRAGMENT)
+  local greaterFragment = player:getResourceBalance(ResourceTypes.GREATER_FRAGMENT)
 
   local value = bankMoney + characterMoney
 


### PR DESCRIPTION
### Bug

The two fragment counters on the Wheel of Destiny / workshop bar show the player's **bank gold** instead of their lesser/greater fragments, and the `Enhance` button is gated against that same wrong number.

### Root cause

`modules/gamelib/const.lua` defines the resources in the singular:

```lua
LESSER_FRAGMENT = 84,
GREATER_FRAGMENT = 85,
```

but `game_wheel` asks for the plural `ResourceTypes.LESSER_FRAGMENTS` / `GREATER_FRAGMENTS`, which do not exist. The lookup yields `nil`, and the C++ binding of `getResourceBalance` casts it to resource `0` — `RESOURCE_BANK_BALANCE`. The call never errors, it just silently returns the bank balance.

Five call sites were affected, across `wheel.lua`, `classes/wheelclass.lua` and `classes/workshop.lua`.

### Fix

Use the singular names as defined in `const.lua`.

### Testing

Verified in-game (protocol 15.25): the counters now match the actual `46625`/`46626` stacks in the backpack instead of `players.balance`, and spending fragments on a workshop `Enhance` decrements them immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fragment resource tracking to use the proper resource identifiers.
  * Improved accuracy when checking lesser and greater fragment balances in the game wheel and workshop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->