### PR TITLE
fix: XP bar renders full and the tooltip reads "-5500 percent to go"

### DIFF
--- a/modules/game_analyser/analyser.lua
+++ b/modules/game_analyser/analyser.lua
@@ -544,7 +544,13 @@ function checkNumber(self, text)
 end
 
 function onLevelChange(localPlayer, value, percent)
-  XPAnalyser:setupLevel(value, percent)
+  -- See game_skills/skills.lua onLevelChange: the callback passes the level percent raw
+  -- (centipercent with GameLevelPercentU16, protocol >= 1520). Normalize it with
+  -- getLevelPercent() or the analyser bar renders full.
+  if not localPlayer then
+    return
+  end
+  XPAnalyser:setupLevel(value, localPlayer:getLevelPercent())
 end
 
 function managerDropTracker(itemId, checked)

--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -1105,7 +1105,11 @@ function onLevelChange(localPlayer, value, percent)
     if not localPlayer then
         return
     end
-    percent = percent or localPlayer:getLevelPercent()
+    -- The C++ onLevelChange callback passes m_levelPercent raw, which is centipercent
+    -- (0-10000) once GameLevelPercentU16 is enabled (protocol >= 1520), not the 0-100 the
+    -- UI expects. getLevelPercent() normalizes it, so always use the getter: otherwise the
+    -- bar renders full and the tooltip reads "-5500 percent to go" at high levels.
+    percent = localPlayer:getLevelPercent()
     setSkillValue('level', comma_value(value))
     local text = tr('You have %s percent to go', 100 - percent)
     setSkillPercent('level', percent, text)


### PR DESCRIPTION
### Bug

On protocols with `GameLevelPercentU16` (>= 1520), the XP bar in the skills window and in the analyser render **completely full** for any level whose progress is above 1%, and the tooltip shows a negative value such as *"You have -5500 percent to go"*.

Most visible right after login or on level up while not hunting, since that is when the callback fires without a later correction.

### Root cause

With `GameLevelPercentU16` the level percent travels as **centipercent** (0-10000). `LocalPlayer` keeps it raw in `m_levelPercent` and `getLevelPercent()` divides it by 100 — but the `onLevelChange` callback hands listeners the **raw** value.

Both listeners then fed 0-10000 into widgets that expect 0-100:

* `modules/game_skills/skills.lua` — `percent = percent or localPlayer:getLevelPercent()` keeps the raw argument, since it is truthy;
* `modules/game_analyser/analyser.lua` — passes it straight to `XPAnalyser:setupLevel`.

The tooltip text is computed as `100 - percent`, which is how 55% becomes *"-5500 percent to go"*.

### Fix

Both listeners read `localPlayer:getLevelPercent()` — the normalized getter — instead of the value handed to them. The analyser also gains the `nil` guard the skills listener already had.

### Testing

Verified in-game with a high-level character (protocol 15.25): the bar reflects real progress on login and on level up, and the tooltip shows the real remaining percentage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved experience and level progress accuracy when handling level-change updates.
  - Prevented analyser updates when no local player is available.
  - Normalized level percentages for newer protocols, ensuring progress bars and tooltips display correct values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->