### PR TITLE
fix: client crashes when logging back in after an AFK kick

### DIFF
--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -310,9 +310,13 @@ void MapView::updateVisibleTiles()
         return;
 
     // clear current visible tiles cache
-    do {
-        m_floors[m_floorMin].cachedVisibleTiles.clear();
-    } while (++m_floorMin <= m_floorMax);
+    for (uint8_t z = m_floorMin; z <= m_floorMax; ++z)
+        m_floors[z].cachedVisibleTiles.clear();
+
+    // empty range, recomputed below. m_floorMin must never be used as the loop
+    // counter itself: when no tile is added and the camera does not move, nothing
+    // restores it and it walks past the end of m_floors.
+    m_floorMin = m_floorMax + 1;
 
     m_lockedFirstVisibleFloor = m_floorViewMode == Otc::LOCKED ? m_posInfo.camera.z : -1;
 


### PR DESCRIPTION
### What happens

Get kicked for being AFK, then log back in: the client dies with `SIGSEGV`, no error dialog. Reproduced twice on the same day on macOS (crash reports with PIDs 19905 and 54531), both with the identical stack, in a thread-pool worker rather than the main thread:

```
MapView::updateVisibleTiles()  <-  MapView::preLoad()  <-  Client::preLoad()
```

`EXC_BAD_ACCESS`, but with a **different faulting address each run** (`0x68636e6120202028` — which is the ASCII bytes `"(   anch"` — and `0x02000102220101f9`). Garbage addresses that vary per run point at an out-of-bounds access, not a deterministic null deref.

### Root cause

The loop that opens `MapView::updateVisibleTiles()` uses the `m_floorMin` **member** as its own loop counter:

```cpp
do {
    m_floors[m_floorMin].cachedVisibleTiles.clear();
} while (++m_floorMin <= m_floorMax);
```

On exit it is left at `m_floorMax + 1` — one index past the last valid floor. `m_floors` holds `getMapMaxZ() + 1` = 16 slots (0..15) and `m_floorMin` is a `uint8_t`.

There are only three writes to that member in the whole tree: the `++` in this loop, the reset when the camera moved, and the correction when a tile is added. **If the function runs again with the camera still and no tile added, nothing brings it back into range and it grows by +1 per call, with no ceiling.** Each out-of-range access runs `MapObject::clear()` — two `std::vector<TilePtr>::clear()` calls that destroy `shared_ptr`s read from unrelated memory and dereference invented control blocks.

### Why an AFK kick triggers it

On disconnect, `Map::clean()` -> `cleanDynamicThings()` calls `followCreature(nullptr)` on every map view, and that path does `setCameraPosition(<last position>)`: the camera is **not invalidated, it is frozen**. The map is empty and an update is requested on top of that. Valid-but-still camera + zero tiles is exactly the drifting case, and it accumulates for the entire time the client sits on the login screen.

It only crashes on the way back in because while idle the memory past the buffer holds harmless garbage (bytes that read as empty vectors, so `clear()` is a no-op). Logging in reallocates that region with real objects — hence the ASCII `"(   anch"` in one faulting address: a freshly allocated string. As a final twist, the code that would repair the counter (`m_lastCameraPosition = {}` in `followCreature`, which triggers the reset) exists but sits one block *below* the line that crashes.

### The fix

Bounded loop that never touches the member, plus an empty-range sentinel derived from `m_floorMax` (always <= 15), so the drift is structurally impossible:

```cpp
for (uint8_t z = m_floorMin; z <= m_floorMax; ++z)
    m_floors[z].cachedVisibleTiles.clear();

m_floorMin = m_floorMax + 1;
```

### Testing

Since `MapView` cannot be instantiated without a graphics context, I replicated the three writes to the counter in a standalone harness and ran five scenarios (15 assertions, all passing):

- normal play (camera moves, tiles present), standing still with a loaded map, floor changes, and floor 15: **0 out-of-range accesses**, and the behaviour is **identical frame by frame** to the current code — same floors cleared, same resulting `min`/`max`. That equivalence was the real risk in touching this loop.
- camera still + empty map (the crash scenario): current code makes its **first out-of-range access on call #11**, reaches index **255** (up to 13,440 bytes past the buffer) and is out of range on **283 of 301 calls**. With the fix: **0**.

Verified in-game on all three platforms with the patched build: an automated run idles until the server issues a real AFK kick (~16 min), logs back in, and completes a clean logout with no crash.

### Notes

`git blame` attributes the loop to 2022 (*"Better format (#249)"*) and I could not find any fix for it in the history, so this affects any OTClient carrying this code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map floor visibility updates when no tiles are available.
  * Prevented invalid floor-range calculations during map refreshes.
  * Ensured cached visible tiles are cleared consistently across all floors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->