### PR TITLE
fix: some draw order bugs

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -78,26 +78,11 @@ void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, L
         return;
     }
 
-    std::vector<ThingPtr> skipped_non_walkable;
     for (const auto& thing : m_things) {
-        if (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnBottom())
+        if (!thing->isGround() && !thing->isGroundBorder())
             break;
-        // delay drawing after NE/SW walking creature
-        if (thing->isNotWalkable()) {
-            skipped_non_walkable.push_back(thing);
-            continue;
-        }
 
         drawThing(thing, dest, flags, drawElevation);
-    }
-
-    drawAttachedEffect(dest, dest, lightView, false);
-
-    if (hasCommonItem()) {
-        for (auto& item : std::ranges::reverse_view(m_things)) {
-            if (!item->isCommon()) continue;
-            drawThing(item, dest, flags, drawElevation);
-        }
     }
 
     // when walking diagonally over a tile that has a non-walkable object on it (for example - a tree) the creature should be drawn behind it
@@ -125,8 +110,24 @@ void Tile::draw(const MapPosInfo& mapRect, const Point& dest, const int flags, L
         g_drawPool.resetDrawOrder();
     }
 
-    for (const auto& thing : skipped_non_walkable) 
+    for (const auto& thing : m_things) {
+        if (thing->isGround() || thing->isGroundBorder())
+            continue;
+        if (!thing->isOnBottom())
+            break;
+
         drawThing(thing, dest, flags, drawElevation);
+    }
+
+
+    drawAttachedEffect(dest, dest, lightView, false);
+
+    if (hasCommonItem()) {
+        for (auto& item : std::ranges::reverse_view(m_things)) {
+            if (!item->isCommon()) continue;
+            drawThing(item, dest, flags, drawElevation);
+        }
+    }
 
     // after we render 2x2 lying corpses, we must redraw previous creatures/ontop above them
     if (m_tilesRedraw) {


### PR DESCRIPTION
# Description

fix some draw order bugs introduced in #1793

## Behavior

### **Actual**
<img width="520" height="421" alt="image" src="https://github.com/user-attachments/assets/43e12743-12e8-40c0-a8cd-23840ba26133" />

### **Expected**

<img width="482" height="408" alt="image" src="https://github.com/user-attachments/assets/c3c091ad-b9bb-4e2a-8d1d-1dd32868ef7e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tile rendering order for more consistent visual layering.
  * Ground elements, creatures, items, and visual effects now appear in the correct sequence.
  * Updated scenes should display overlapping objects more naturally, reducing visual inconsistencies during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->