### PR TITLE
ci(vcpkg): keep baseline updates synchronized and auto-mergeable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
               - ".github/workflows/reusable-build-windows.yml"
               - ".github/workflows/reusable-checks.yml"
               - ".github/workflows/reusable-tests-lua.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
             macos:
               - "src/**"
               - "cmake/**"
@@ -122,6 +123,7 @@ jobs:
               - "CMakePresets.json"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-macos.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
             android:
               - "src/**"
               - "android/**"
@@ -134,6 +136,7 @@ jobs:
               - "setup_android_deps.sh"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-android-apk.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
             docker:
               - "Dockerfile"
               - ".dockerignore"
@@ -147,6 +150,7 @@ jobs:
               - ".yamllint.yaml"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-docker.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
             browser:
               - "Dockerfile.browser"
               - "Dockerfile.browser.sh"
@@ -160,6 +164,7 @@ jobs:
               - ".yamllint.yaml"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-browser.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
 
   checks:
     name: Fast Checks

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -171,5 +171,9 @@ jobs:
 
             trigger_ci
             new_pr="${pr_url##*/}"
-            queue_auto_merge "${new_pr}"
+            if [[ "${new_pr}" =~ ^[0-9]+$ ]]; then
+              queue_auto_merge "${new_pr}"
+            else
+              echo "::warning::Created a baseline PR, but could not parse its number for auto-merge."
+            fi
           fi

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -111,7 +111,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          existing_pr="$(gh pr list --state open --base main --head "${GITHUB_REPOSITORY_OWNER}:${branch_name}" --limit 1 --json number --jq '.[0].number // empty')"
+          existing_pr="$(gh api \
+            --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f base=main \
+            -f head="${GITHUB_REPOSITORY_OWNER}:${branch_name}" \
+            -f per_page=1 \
+            --jq '.[0].number // empty')"
 
           if [[ -n "${existing_pr}" ]]; then
             echo "Found existing baseline PR #${existing_pr}, updating it"

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: main
 
       - name: Get latest vcpkg release
@@ -75,6 +76,34 @@ jobs:
             gh workflow run ci.yml --ref "${branch_name}"
           }
 
+          queue_auto_merge() {
+            local pr_number="$1"
+
+            if [[ -z "${pr_number}" ]]; then
+              echo "::error::Could not determine the baseline pull request number"
+              return 1
+            fi
+
+            if gh pr merge "${pr_number}" --auto --squash; then
+              echo "Queued native GitHub auto-merge for PR #${pr_number}"
+            else
+              echo "::warning::Could not queue auto-merge for PR #${pr_number}. Repository auto-merge may be disabled or branch protection may require a review."
+            fi
+          }
+
+          sync_update_branch() {
+            git fetch --prune origin main
+
+            if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
+              git fetch origin "${branch_name}"
+              git checkout -B "${branch_name}" "origin/${branch_name}"
+              git rebase origin/main
+              git push --force-with-lease origin "${branch_name}"
+            else
+              git checkout -B "${branch_name}" origin/main
+            fi
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -82,13 +111,13 @@ jobs:
 
           if [[ -n "${existing_pr}" ]]; then
             echo "Found existing baseline PR #${existing_pr}, updating it"
-            git fetch origin "${branch_name}"
-            git checkout "${branch_name}"
+            sync_update_branch
 
             current_in_branch="$(jq -r '."builtin-baseline"' vcpkg.json)"
             if [[ "${current_in_branch}" == "${NEW_BASELINE}" ]]; then
               echo "PR #${existing_pr} already has baseline ${NEW_BASELINE}"
               trigger_ci
+              queue_auto_merge "${existing_pr}"
               exit 0
             fi
 
@@ -100,7 +129,7 @@ jobs:
             else
               git add vcpkg.json
               git commit -m "chore: update vcpkg baseline to ${RELEASE_TAG}"
-              git push origin "${branch_name}"
+              git push --force-with-lease origin "${branch_name}"
             fi
 
             gh pr edit "${existing_pr}" --title "chore: Update vcpkg baseline to ${RELEASE_TAG}"
@@ -110,15 +139,11 @@ jobs:
 
             gh pr comment "${existing_pr}" --body "${comment_body}"
             trigger_ci
+            queue_auto_merge "${existing_pr}"
           else
             echo "No existing baseline PR found, creating new one"
 
-            if git ls-remote --heads origin "${branch_name}" | grep -q "${branch_name}"; then
-              git fetch origin "${branch_name}"
-              git checkout "${branch_name}"
-            else
-              git checkout -b "${branch_name}"
-            fi
+            sync_update_branch
 
             jq --arg baseline "${NEW_BASELINE}" '."builtin-baseline" = $baseline' vcpkg.json > vcpkg.json.tmp
             mv vcpkg.json.tmp vcpkg.json
@@ -141,4 +166,6 @@ jobs:
               --head "${branch_name}"
 
             trigger_ci
+            new_pr="$(gh pr list --state open --head "${branch_name}" --json number --jq '.[0].number')"
+            queue_auto_merge "${new_pr}"
           fi

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -79,8 +79,8 @@ jobs:
           queue_auto_merge() {
             local pr_number="$1"
 
-            if [[ -z "${pr_number}" ]]; then
-              echo "::error::Could not determine the baseline pull request number"
+            if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid baseline pull request number: ${pr_number}"
               return 1
             fi
 
@@ -95,7 +95,7 @@ jobs:
             git fetch --prune origin main
 
             if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
-              git fetch origin "${branch_name}"
+              git fetch origin "+refs/heads/${branch_name}:refs/remotes/origin/${branch_name}"
               git checkout -B "${branch_name}" "origin/${branch_name}"
               git rebase origin/main
               git push --force-with-lease origin "${branch_name}"
@@ -107,7 +107,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          existing_pr="$(gh pr list --state open --json number,headRefName | jq -r '.[] | select(.headRefName == "'"${branch_name}"'") | .number')"
+          existing_pr="$(gh pr list --state open --base main --head "${GITHUB_REPOSITORY_OWNER}:${branch_name}" --limit 1 --json number --jq '.[0].number // empty')"
 
           if [[ -n "${existing_pr}" ]]; then
             echo "Found existing baseline PR #${existing_pr}, updating it"
@@ -159,13 +159,13 @@ jobs:
             printf -v pr_body '## vcpkg Baseline Update\n\nThis PR updates the vcpkg baseline to the latest release.\n\n**Release:** `%s`\n**Previous:** `%s`\n**New:** `%s`\n\n**Release notes:** https://github.com/microsoft/vcpkg/releases/tag/%s\n\n---\nThis PR is automatically updated when new vcpkg releases are published.' \
               "${RELEASE_TAG}" "${PREVIOUS}" "${NEW_BASELINE}" "${RELEASE_TAG}"
 
-            gh pr create \
+            pr_url="$(gh pr create \
               --title "chore: Update vcpkg baseline to ${RELEASE_TAG}" \
               --body "${pr_body}" \
               --base main \
-              --head "${branch_name}"
+              --head "${branch_name}")"
 
             trigger_ci
-            new_pr="$(gh pr list --state open --head "${branch_name}" --json number --jq '.[0].number')"
+            new_pr="${pr_url##*/}"
             queue_auto_merge "${new_pr}"
           fi

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -78,13 +78,17 @@ jobs:
 
           queue_auto_merge() {
             local pr_number="$1"
+            local merge_subject="chore(vcpkg): update baseline to ${RELEASE_TAG}"
+            local merge_body="vcpkg baseline: ${NEW_BASELINE}"
 
             if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
               echo "::error::Invalid baseline pull request number: ${pr_number}"
               return 1
             fi
 
-            if gh pr merge "${pr_number}" --auto --squash; then
+            if gh pr merge "${pr_number}" --auto --squash \
+              --subject "${merge_subject}" \
+              --body "${merge_body}"; then
               echo "Queued native GitHub auto-merge for PR #${pr_number}"
             else
               echo "::warning::Could not queue auto-merge for PR #${pr_number}. Repository auto-merge may be disabled or branch protection may require a review."


### PR DESCRIPTION
## Summary

- keep the updater branch synchronized with the latest `main` before applying a baseline update;
- queue GitHub's native auto-merge after creating or updating the dependency PR;
- use `--force-with-lease` for bot branch refreshes.

## Why

The updater branch can otherwise become stale when `main` adds workflow or build dependencies, causing checks to run against an incomplete branch. Native auto-merge lets GitHub monitor the PR checks without keeping an updater runner alive.

## Safety

The updater does not approve reviews or bypass branch protection. Native auto-merge remains subject to the repository's required reviews and status checks. If auto-merge is disabled at repository level, the updater reports a warning and leaves the PR open.

## Validation

- `actionlint` passed for the workflow;
- YAML parsing passed;
- extracted updater shell script passed `bash -n`;
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated baseline updates for greater reliability.
  * Update branches are safely synchronized before changes are submitted.
  * Baseline update pull requests are automatically queued for merging after required checks pass.
  * New and existing update requests follow a streamlined process, reducing manual maintenance.
  * CI now runs when baseline update workflow changes affect supported build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->