### PR TITLE
fix(sound): initialize effectSlot and fix OpenAL EFX slot binding

### DIFF
--- a/src/framework/sound/soundsource.cpp
+++ b/src/framework/sound/soundsource.cpp
@@ -34,7 +34,7 @@ SoundSource::SoundSource()
 
 SoundSource::~SoundSource()
 {
-    if (m_effectId != 0) {
+    if (m_effectSlot != 0) {
         removeEffect();
     }
     if (m_sourceId != 0) {
@@ -169,8 +169,11 @@ void SoundSource::update()
 
 void SoundSource::setEffect(const SoundEffectPtr soundEffect)
 {
-    m_effectId = soundEffect->m_effectId;
-    alSource3i(m_sourceId, AL_AUXILIARY_SEND_FILTER, static_cast<ALint>(soundEffect->m_effectId), 0, AL_FILTER_NULL);
+    if (!soundEffect || m_sourceId == 0)
+        return;
+
+    m_effectSlot = soundEffect->m_effectSlot;
+    alSource3i(m_sourceId, AL_AUXILIARY_SEND_FILTER, static_cast<ALint>(soundEffect->m_effectSlot), 0, AL_FILTER_NULL);
     const ALenum err = alGetError();
     if (err != AL_NO_ERROR) {
         g_logger.error("Failed to set effect on source: {}", alGetString(err));
@@ -179,12 +182,14 @@ void SoundSource::setEffect(const SoundEffectPtr soundEffect)
 
 void SoundSource::removeEffect()
 {
-    if (m_effectId != 0) {
-        m_effectId = 0;
-        alSource3i(m_sourceId, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, AL_FILTER_NULL);
-        const ALenum err = alGetError();
-        if (err != AL_NO_ERROR) {
-            g_logger.error("Failed to remove effect on source: {}", alGetString(err));
+    if (m_effectSlot != 0) {
+        m_effectSlot = 0;
+        if (m_sourceId != 0) {
+            alSource3i(m_sourceId, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, AL_FILTER_NULL);
+            const ALenum err = alGetError();
+            if (err != AL_NO_ERROR) {
+                g_logger.error("Failed to remove effect on source: {}", alGetString(err));
+            }
         }
     }
 }

--- a/src/framework/sound/soundsource.h
+++ b/src/framework/sound/soundsource.h
@@ -72,7 +72,7 @@ protected:
     float m_fadeTime{ 0 };
     float m_fadeGain{ 0 };
     float m_gain{ 1.f };
-    uint m_effectId;
+    uint m_effectSlot{ 0 };
 
     FadeState m_fadeState{ NoFading };
 


### PR DESCRIPTION
## Problem / Motivation
- The terminal and logs frequently emitted error messages on every sound destruction:
  `[error] Failed to remove effect on source: Invalid Name`
- The `m_effectId` member variable in `SoundSource` was uninitialized in the header (`uint m_effectId;`), causing it to contain undefined memory garbage.
- When any `SoundSource` was destroyed, `~SoundSource()` checked `if (m_effectId != 0)`, which evaluated to true on uninitialized memory, triggering `removeEffect()` on sources that had no active effect (including compound sources like `CombinedSoundSource` where `m_sourceId` is 0).
- In addition, `SoundSource::setEffect` passed the effect ID (`soundEffect->m_effectId`) instead of the auxiliary effect slot (`soundEffect->m_effectSlot`) to OpenAL's `AL_AUXILIARY_SEND_FILTER`, causing OpenAL to return `AL_INVALID_NAME`.

## Solution
- Renamed and initialized `uint m_effectSlot{ 0 };` in `soundsource.h`.
- Updated `SoundSource::setEffect` to bind `soundEffect->m_effectSlot` to `AL_AUXILIARY_SEND_FILTER`.
- Added safety validation `m_sourceId != 0` in both `setEffect` and `removeEffect` to prevent invalid OpenAL API calls on compound/dummy sources.

## Verification
- Recompiled and ran client; verified sound effects play, update, and destruct cleanly without any OpenAL errors in logs.