### PR TITLE
fix(platform): add XIM fallback with @im=none on Linux

### DIFF
--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -540,6 +540,11 @@ bool X11Window::internalSetupWindowInput()
     XSetLocaleModifiers("");
     m_xim = XOpenIM(m_display, nullptr, nullptr, nullptr);
     if (!m_xim) {
+        // Fallback to internal XIM if ibus/fcitx daemon is unavailable or incompatible
+        XSetLocaleModifiers("@im=none");
+        m_xim = XOpenIM(m_display, nullptr, nullptr, nullptr);
+    }
+    if (!m_xim) {
         g_logger.error("XOpenIM failed");
         return false;
     }


### PR DESCRIPTION
## Problem / Motivation
- On certain Linux distributions and environments (e.g. minimal setups, Wayland/XWayland, or desktop sessions without active `ibus` / `fcitx` daemons), `XOpenIM(m_display, nullptr, nullptr, nullptr)` fails during window creation, causing the client to log `XOpenIM failed` and terminate startup.

## Solution
- In `X11Window::internalSetupWindowInput`, if the initial `XOpenIM` call with default modifiers fails, set `XSetLocaleModifiers("@im=none")` as a fallback and retry `XOpenIM`.
- Only logs error and fails if the `@im=none` fallback also fails.

## Verification
- Tested client initialization on Linux environments with and without custom input method daemons running.