### PR TITLE
fix(corelib): prevent duplicate child insertion in UIMiniWindowContainer

### DIFF
--- a/modules/corelib/ui/uiminiwindowcontainer.lua
+++ b/modules/corelib/ui/uiminiwindowcontainer.lua
@@ -176,20 +176,26 @@ function UIMiniWindowContainer:scheduleInsert(widget, index)
                 oldParent:removeChild(widget)
             end
             self:insertChild(index, widget)
+        end
 
-            while true do
-                local placed = false
-                for nIndex, nWidget in pairs(self.scheduledWidgets) do
-                    if nIndex - 1 <= self:getChildCount() then
+        while true do
+            local placed = false
+            for nIndex, nWidget in pairs(self.scheduledWidgets) do
+                if nIndex - 1 <= self:getChildCount() then
+                    local nOldParent = nWidget:getParent()
+                    if nOldParent ~= self then
+                        if nOldParent then
+                            nOldParent:removeChild(nWidget)
+                        end
                         self:insertChild(nIndex, nWidget)
-                        self.scheduledWidgets[nIndex] = nil
-                        placed = true
-                        break
                     end
-                end
-                if not placed then
+                    self.scheduledWidgets[nIndex] = nil
+                    placed = true
                     break
                 end
+            end
+            if not placed then
+                break
             end
         end
     end


### PR DESCRIPTION
## Problem / Motivation
- When logging in or restoring miniwindow layouts (`skillsWindow:setupOnStart()`), the client console logged the following warning traceback:
  `[warning] attempt to insert a child again into a UIWidget`
  `[C]: in function 'insertChild'`
  `/corelib/ui/uiminiwindowcontainer.lua:184: in function 'scheduleInsert'`
- When `scheduleInsert` looped through `self.scheduledWidgets`, it called `self:insertChild(nIndex, nWidget)` directly without detaching `nWidget` from its previous parent (`nOldParent`), or when `nWidget` was already attached to `self`.

## Solution
- In `UIMiniWindowContainer:scheduleInsert`, before inserting each scheduled widget:
  1. Checks if `nOldParent ~= self`, and if so, detaches it via `nOldParent:removeChild(nWidget)`.
  2. If `nWidget` is already part of `self`, avoids redundant insertion and clears it from `self.scheduledWidgets`.

## Verification
- Verified character login and miniwindow drag/dock operations restore layout cleanly without `insertChild` warnings.