### PR TITLE
fix(game_interface): use safe position table check in createThingMenu

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -635,7 +635,7 @@ function createThingMenu(menuPosition, lookThing, useThing, creatureThing)
                     g_game.inspectCharacter(lookThing:getId(), InspectCreaturesTypes.INSPECT_CREATURE)
                 elseif canInspect then
                     local pos = lookThing:getPosition()
-                    if pos and pos:isValid() then
+                    if pos and pos.x and pos.y and pos.z then
                         g_game.inspectionNormalObject(pos)
                     else
                         g_game.inspectionObject(InspectObjectTypes.INSPECT_CYCLOPEDIA, lookThing:getId())


### PR DESCRIPTION
## Problem / Motivation
- Right-clicking certain ground items or map objects to open the context menu could trigger a Lua runtime error when inspecting the object because `lookThing:getPosition()` can return a plain Lua coordinate table rather than an instance of the C++ / Lua `Position` class implementing `:isValid()`.

## Solution
- In `modules/game_interface/gameinterface.lua:createThingMenu`, replaced `pos:isValid()` with safe coordinate existence checks: `if pos and pos.x and pos.y and pos.z then`.

## Verification
- Verified right-click inspection on various map objects, items, and creatures opens context and inspect menus without Lua runtime errors.