### PR TITLE
docs(agents): document instruction loading budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## AGENTS.md Loading Budget
+
+- Keep this root file limited to repository-wide invariants and precise routing gates; place detailed workflows in versioned documentation or skills.
+- Codex applies a combined instruction budget (32 KiB by default) across global, root, and nested guidance. Keep mandatory gates first and preserve headroom for narrower scopes.
+- Do not raise `project_doc_max_bytes` as the first response to oversized guidance; remove duplication and route conditional detail first.
+
 ## Client Assets Gate (Mandatory)
 
 Any change touching client-assets auto-installation must preserve the runtime contract below:
@@ -25,4 +31,3 @@ Any change touching client-assets auto-installation must preserve the runtime co
    - Explicitly state tested install paths and expected runtime load behavior.
 
 Reference: `docs/client-assets-auto-install.md`
-


### PR DESCRIPTION
Document the repository's AGENTS.md loading budget without changing the existing client-asset routing contract.

## Improvements

- Adds a concise loading-budget notice at the start of AGENTS.md.
- Directs detailed workflows to repository documentation or skills instead of expanding the always-loaded file or raising the byte cap first.
- Preserves the existing client-assets contract unchanged.

## Tests/Validation

- Audited the effective global-plus-repository instruction chain at 11,106 bytes, below the 24 KiB maintenance target and the default Codex cap.
- Verified the existing routed client-assets documentation path remains valid.
- Reviewed the complete committed diff and ran Git whitespace validation successfully.
- No build was run because this is a documentation-only change and no build was requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing loading budgets, instruction limits, and documentation duplication.
  * Clarified scope boundaries for efficient documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->