### PR TITLE
fix(game_inventory): register player events at controller init to dodge the callLuaField negative-cache race

### DIFF
--- a/modules/game_inventory/inventory.lua
+++ b/modules/game_inventory/inventory.lua
@@ -280,6 +280,18 @@ function inventoryController:onInit()
     connect(pvpModeRadioGroup, {
         onSelectionChange = onSetPVPMode
     })
+
+    -- Register player events at module init (connected at startup, before any
+    -- login). If registered in onGameStart (deferred via addEvent), the login
+    -- packet burst can win the race against the connection: LuaObject::callLuaField
+    -- negative-caches "no handler" per object/field and never calls Lua again for
+    -- that event, leaving the inventory frozen for the whole session (stale slot
+    -- widgets + "Sorry, not possible" when dragging them).
+    inventoryController:registerEvents(LocalPlayer, {
+        onInventoryChange = inventoryEvent,
+        onSoulChange = onSoulChange,
+        onFreeCapacityChange = onFreeCapacityChange
+    })
 end
 
 function inventoryController:onGameStart()
@@ -298,12 +310,7 @@ function inventoryController:onGameStart()
             end
         end
     end
-    inventoryController:registerEvents(LocalPlayer, {
-        onInventoryChange = inventoryEvent,
-        onSoulChange = onSoulChange,
-        onFreeCapacityChange = onFreeCapacityChange
-    }):execute()
-
+    -- LocalPlayer events are registered in onInit (see note there).
     inventoryController:registerEvents(g_game, {
         onWalk = walkEvent,
         onAutoWalk = walkEvent,


### PR DESCRIPTION
## Description

The inventory panel can permanently stop reacting to equipment changes for a whole session: slot widgets keep showing (and holding) a stale item while the client data is up to date — `look` answers correctly, but dragging the slot describes the stale item, so the server answers **"Sorry, not possible."** (`item->getID() != itemId`). Nothing repaints it (hover, clicks, focus, resizing); relogging re-rolls the dice.

### Root cause

`LuaObject::callLuaField` keeps a per-object/per-field event cache:

```cpp
auto it = m_events.find(fieldStr);
if (it != m_events.end() && !it->second)
    return; // never calls Lua again for this field

const int rets = luaCallLuaField(field, args...);
...
if (it == m_events.end())
    m_events[fieldStr] = rets > -1; // cached on FIRST call, forever
```

If the **first** `onInventoryChange` fired on a fresh `LocalPlayer` finds no handler, the field is negative-cached forever — and connecting a handler later does not invalidate the cache (`luaSetField`/`connect` never touch `m_events`).

`game_inventory` registered its `LocalPlayer` events inside `onGameStart`, which `Controller` defers via `addEvent(...)`. During the login packet burst the inventory slot packets (0x78/0x79) can be parsed **before** that deferred connection runs → the race is lost → inventory events are dead for the entire session. It is probabilistic per login and heavily load-dependent: with two or more clients running on the same machine it happens almost every login (which also makes it look like a mysterious "only on my machine" bug).

### Diagnosis evidence (live session)

- `player:getInventoryItem(1):getId()` = `3351` (fresh) while the slot widget's `:getItem():getId()` = `30397` (stale), single inventory panel in the UI tree, `mainpanel_shrink_inventory` off.
- `modules.game_inventory.reloadInventory()` repaints once (direct call), but the very next equipment change freezes again (event still dead).
- `LocalPlayer.onInventoryChange` held the connected handler, and **invoking it manually painted the slot** — proving handler and painter healthy, with only the C++ event dispatch muted.

### Fix

Register the `LocalPlayer` events at controller **init** (they get connected at module startup, before any login), so the first event of the login burst always finds a handler and the cache is populated as `true`. The initial paint is unaffected — `onGameStart` still calls `refreshInventory_panel()`.

The framework-level footgun (`m_events` negative cache being permanent and not invalidated by later connects) remains, and can bite any Controller-based module whose events first fire during the login burst — happy to open a separate issue/PR for that if there's interest in a framework-level fix.

## Behaviour

### Actual
After an unlucky login (frequent with multiple clients on one machine), equipment slot widgets never update again for the session: stale sprites, stale drag ("Sorry, not possible."), only a relog may fix it.

### Expected
Slot widgets always follow equipment changes.

## Fixed Issues

No open issue found for this — happy to file one if preferred.

## How Has This Been Tested

- Live reproduction on macOS (protocol 15.25, two clients on one machine): before the change the freeze reproduced on nearly every login; after it, repeated equip/unequip/swap cycles (drag and equip-hotkey paths) never froze again.
- Automated scenario comparing widget item vs `getInventoryItem` per slot after swaps via `g_game.move` and `g_game.equipItem`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory, soul, and capacity updates are now registered earlier during initialization, improving event handling consistency.
  * Combat and movement event registration continues during game startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->