### PR TITLE
fix(market): read create-offer amount from the scroll bar

### DIFF
--- a/modules/game_market/t_market.lua
+++ b/modules/game_market/t_market.lua
@@ -1805,8 +1805,10 @@ function createMarketOffer()
         return
     end
 
-    local n = mainMarket.createOfferAmount:getText()
-    local amount = tonumber(n:gsub("%D", ""))
+    local amount = mainMarket.amountCreateScrollBar:getValue()
+    if mainMarket.amountCreateScrollBar:getIncrementValue() > 1 then
+        amount = math.cround(amount, mainMarket.amountCreateScrollBar:getIncrementValue())
+    end
     local piecePrice = tonumber(mainMarket.grossAmount.value)
 
     if not amount or not piecePrice then


### PR DESCRIPTION
# Description

Creating a market offer sent the wrong quantity because the amount was parsed in base 8.

- `modules/game_market/t_market.lua:1809` did `tonumber(n:gsub("%D", ""))` on the "Amount: N" label. `gsub` returns two values (result string, substitution count) and both were forwarded to `tonumber`, so the count landed in the `base` parameter. The label prefix `"Amount: "` is exactly 8 non-digit characters, so every offer was parsed as octal: 12 was sent as 10, 400 as 256, and any amount containing an 8 or a 9 came back `nil` and got rejected as "Invalid amount or price".
- Replaced the label parsing with `mainMarket.amountCreateScrollBar:getValue()` plus the same `math.cround` increment rounding `onPiecePriceEdit` already applies, so the amount that is sent is the one the fee/price preview was computed from and the one shown in the label.
- Grepped `modules/` and `mods/` for the same `tonumber(x:gsub(...))` anti-pattern; this was the only occurrence in the tree.

## Behavior

### **Actual**

Set the create-offer amount to 12 and click Create Offer: the server receives 10. Amount 400 sends 256. Any amount containing an 8 or a 9 is rejected as "Invalid amount or price".

### **Expected**

The amount shown in the offer panel is the amount sent to the server.

## Fixes

Closes #1813

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file (same check the Lua CI job runs)
  - [x] luacheck against the unpatched file: no new warning class

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market offers now use the selected amount from the creation control, respecting its increment steps for more accurate offer quantities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->