### PR TITLE
fix(wheel): read conviction perks by name in the summary

### DIFF
--- a/modules/game_wheel/classes/bonus.lua
+++ b/modules/game_wheel/classes/bonus.lua
@@ -771,29 +771,31 @@ function getConvictionBonus(index, fullMessage)
 	return ""
 end
 
+WheelConvictionOrder = {
+	["special_1"] = 1,
+	["special_2"] = 2,
+	["special_3"] = 3,
+	["special_4"] = 4,
+	["skill"] = 5,
+	["lifeleech"] = 6,
+	["manaleech"] = 7,
+	["spell_1"] = 8,
+	["spell_2"] = 9,
+	["spell_3"] = 10,
+	["spell_4"] = 11,
+	["spell_5"] = 12,
+	["vessel.1"] = 13,
+	["vessel.2"] = 14,
+	["vessel.3"] = 15,
+	["vessel.4"] = 16,
+}
+
 function getConvictionPerks()
 	local convictions = {}
-  
+
 	local vocation = WheelOfDestiny.vocationId
-	local order = {
-	  ["special_1"] = 1,
-	  ["special_2"] = 2,
-	  ["special_3"] = 3,
-	  ["special_4"] = 4,
-	  ["skill"] = 5,
-	  ["lifeleech"] = 6,
-	  ["manaleech"] = 7,
-	  ["spell_1"] = 8,
-	  ["spell_2"] = 9,
-	  ["spell_3"] = 10,
-	  ["spell_4"] = 11,
-	  ["spell_5"] = 12,
-	  ["vessel.1"] = 13,
-	  ["vessel.2"] = 14,
-	  ["vessel.3"] = 15,
-	  ["vessel.4"] = 16,
-	}
-  
+	local order = WheelConvictionOrder
+
 	for id, bonus in pairs(WheelBonus) do
 	  repeat
 	  local index = id + 1

--- a/modules/game_wheel/classes/wheelclass.lua
+++ b/modules/game_wheel/classes/wheelclass.lua
@@ -1489,7 +1489,7 @@ function WheelOfDestiny.configureSummary()
       widget.info:setTooltip('Increase your mitigation multiplicatively.')
       widget.info:setVisible(true)
     elseif t == "Life Leech" then
-      local lifeleech = convictions[4]
+      local lifeleech = convictions[WheelConvictionOrder["lifeleech"]]
       if not lifeleech or lifeleech.points == 0 then
         widget:destroy()
         break
@@ -1498,7 +1498,7 @@ function WheelOfDestiny.configureSummary()
       widget.value:setText(lifeleech.stringPoint)
       widget.info:setVisible(false)
     elseif t == "Mana Leech" then
-      local manaleech = convictions[5]
+      local manaleech = convictions[WheelConvictionOrder["manaleech"]]
       if not manaleech or manaleech.points == 0 then
         widget:destroy()
         break
@@ -1519,50 +1519,30 @@ function WheelOfDestiny.configureSummary()
   local f_table = {
     [1] = "special_1",
     [2] = "special_2",
-    [3] = "skill",
+    [3] = "special_3",
+    [4] = "special_4",
+    [5] = "skill",
   }
 
   local hasCreated = false
-  for _, t in pairs(f_table) do
+  for _, t in ipairs(f_table) do
     repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
-    if t == "special_1" then
-      local c = convictions[1]
-      if not c then
-        widget:destroy()
-        break
-      end
-
-      widget.perk:setText(c.perk)
-      widget.value:setVisible(false)
-      widget.info:setVisible(true)
-      widget.info:setTooltip(c.tooltip)
-      hasCreated = true
-    elseif t == "special_2" then
-      local c = convictions[2]
-      if not c then
-        widget:destroy()
-        break
-      end
-
-      widget.perk:setText(c.perk)
-      widget.value:setVisible(false)
-      widget.info:setVisible(true)
-      widget.info:setTooltip(c.tooltip)
-      hasCreated = true
-    elseif t == "skill" then
-      local c = convictions[3]
-      if not c then
-        widget:destroy()
-        break
-      end
-
-      widget.perk:setText(c.perk)
-      widget.value:setText(c.stringPoint)
-      widget.info:setVisible(true)
-      widget.info:setTooltip(c.tooltip)
-      hasCreated = true
+    local c = convictions[WheelConvictionOrder[t]]
+    if not c then
+      widget:destroy()
+      break
     end
+
+    widget.perk:setText(c.perk)
+    if t == "skill" then
+      widget.value:setText(c.stringPoint)
+    else
+      widget.value:setVisible(false)
+    end
+    widget.info:setVisible(true)
+    widget.info:setTooltip(c.tooltip)
+    hasCreated = true
     until true
   end
 
@@ -1571,19 +1551,19 @@ function WheelOfDestiny.configureSummary()
   end
 
   local f_table = {
-    [6] = "spell_1",
-    [7] = "spell_2",
-    [8] = "spell_3",
-    [9] = "spell_4",
-    [10] = "spell_5",
+    [1] = "spell_1",
+    [2] = "spell_2",
+    [3] = "spell_3",
+    [4] = "spell_4",
+    [5] = "spell_5",
   }
 
   --- Convictions
   local hasCreated = false
-  for _, t in pairs(f_table) do
+  for _, t in ipairs(f_table) do
     repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
-    local c = convictions[_]
+    local c = convictions[WheelConvictionOrder[t]]
     if not c then
       widget:destroy()
       break
@@ -1812,17 +1792,17 @@ function WheelOfDestiny.configureSummary()
   -----------------------------------------------------------------------------------
 
   local f_table = {
-    [11] = "vessel.1",
-    [12] = "vessel.2",
-    [13] = "vessel.3",
-    [14] = "vessel.4",
+    [1] = "vessel.1",
+    [2] = "vessel.2",
+    [3] = "vessel.3",
+    [4] = "vessel.4",
   }
 
   local hasCreated = false
-  for _, t in pairs(f_table) do
+  for _, t in ipairs(f_table) do
     repeat
     local widget = g_ui.createWidget("PerksPanel", wheelOfDestinyWindow.summary.tabContent)
-    local c = convictions[_]
+    local c = convictions[WheelConvictionOrder[t]]
     if not c then
       widget:destroy()
       break


### PR DESCRIPTION
# Description

The Wheel of Destiny summary read the conviction perk list with a second set of hardcoded indices that no longer matched the ones the producer writes.

- `modules/game_wheel/classes/bonus.lua:778` (`getConvictionPerks`) stores each perk at `order[bonus.conviction]`: special_1..4 = 1..4, skill = 5, lifeleech = 6, manaleech = 7, spell_1..5 = 8..12, vessel.1..4 = 13..16.
- `modules/game_wheel/classes/wheelclass.lua` (`configureSummary`) read life leech at 4 (line 1492), mana leech at 5 (1501), skill at 3 (1554), spells at 6..10 (1573-1586) and vessels at 11..14 (1814-1825). Everything from skill on was two slots low, so the summary showed a special perk in the skill row, the skill boost as life leech, and life leech as mana leech; spell_4/spell_5 and all four vessel resonances landed past the end of the table and were never shown.
- Moved the order table to a shared `WheelConvictionOrder` in bonus.lua, next to the existing `WheelDomainOrder` global that is already shared the same way, and both sides now look perks up by name so the two lists cannot drift apart again.
- The special/skill, spell and vessel loops iterate real sequences with `ipairs` now instead of `pairs` over a table keyed 6..10 / 11..14, which also gives a stable display order.
- special_3 and special_4 (monk only) were never rendered in the summary although the conviction perks tab lists them; they are drawn like special_1/special_2 and are skipped for vocations that do not have them.

## Behavior

### **Actual**

Open the Wheel of Destiny summary with conviction perks assigned: the skill row shows a special perk, life leech shows the skill boost, mana leech shows life leech, spell_4/spell_5 and vessel resonances never appear, special_3/special_4 (monk) are missing.

### **Expected**

Every conviction perk shows in its own row with its own value, in the same order the perks tab lists them.

## Fixes

Closes #1753

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on both files
  - [x] luacheck: no new warning class, two "unused loop variable" warnings gone

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Wheel of Destiny summary to display conviction perks in the correct order.
  * Updated the summary to include all four special conviction perks alongside skill, spell, vessel, life leech, and mana leech perks.
  * Standardized conviction perk handling for more consistent summary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->