### PR TITLE
fix(forge): cancel pending scheduled events on terminate

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -11,6 +11,23 @@ local normalizeTierPriceEntries = Helpers.normalizeTierPriceEntries
 -- Store all callback references to prevent garbage collection
 ForgeController.callbacks = {}
 
+-- scheduleEvent holds callbacks weakly; cancel every pending event before callbacks is dropped
+ForgeController.events = {}
+
+local function scheduleForgeEvent(name, callback, delay)
+    removeEvent(ForgeController.events[name])
+    local event = scheduleEvent(callback, delay)
+    ForgeController.events[name] = event
+    return event
+end
+
+local function removeForgeEvents()
+    for name, event in pairs(ForgeController.events) do
+        removeEvent(event)
+        ForgeController.events[name] = nil
+    end
+end
+
 ForgeController.showResult = false
 ForgeController.showBonus = false
 
@@ -50,7 +67,7 @@ function ForgeController:onGameStart()
         self.callbacks.unloadModule = function()
             g_modules.getModule("game_forge"):unload()
         end
-        scheduleEvent(self.callbacks.unloadModule, 100)
+        scheduleForgeEvent('unloadModule', self.callbacks.unloadModule, 100)
     end
 end
 
@@ -192,11 +209,9 @@ end
 
 function ForgeController:terminate()
     -- Clean up any pending events
-    if ForgeController.resultTimeout then
-        removeEvent(ForgeController.resultTimeout)
-        ForgeController.resultTimeout = nil
-    end
-    
+    removeForgeEvents()
+    ForgeController.resultTimeout = nil
+
     -- Clean up all stored callbacks
     if ForgeController.callbacks then
         for key, _ in pairs(ForgeController.callbacks) do
@@ -297,7 +312,7 @@ ForgeController.callbacks.showBonusCallback = function()
     ForgeController.showBonus = true
 
     -- Use the stored callback
-    scheduleEvent(ForgeController.callbacks.updateBonusButton, 150)
+    scheduleForgeEvent('updateBonusButton', ForgeController.callbacks.updateBonusButton, 150)
 end
 
 function ForgeController:closeResult()
@@ -348,7 +363,8 @@ function ForgeController:forgeAction(isTransfer)
         end
     end
     
-    ForgeController.resultTimeout = scheduleEvent(ForgeController.callbacks.timeoutCallback, 5000)
+    ForgeController.resultTimeout = scheduleForgeEvent('timeoutCallback', ForgeController.callbacks.timeoutCallback,
+        5000)
 
     g_game.forgeRequest(actionType, data.isConvergence, data.selected.id, data.selected.tier,
         data.selectedTarget.id, chanceImproved, reduceTierLoss)
@@ -424,7 +440,7 @@ function ForgeController:resultSystemEvent()
                 ForgeController.result.rightItemId = -1
                 ForgeController.result.rightTier = 0
             end
-            scheduleEvent(ForgeController.callbacks.clearRightItem, 1000)
+            scheduleForgeEvent('clearRightItem', ForgeController.callbacks.clearRightItem, 1000)
         end
         return
     end
@@ -434,7 +450,7 @@ function ForgeController:resultSystemEvent()
     ForgeController.callbacks.continueAnimation = function()
         ForgeController:resultSystemEvent()
     end
-    scheduleEvent(ForgeController.callbacks.continueAnimation, 750)
+    scheduleForgeEvent('continueAnimation', ForgeController.callbacks.continueAnimation, 750)
 end
 
 function forgeResultData(rawData)
@@ -535,7 +551,7 @@ function forgeResultData(rawData)
     ForgeController.callbacks.startResultAnimation = function()
         ForgeController:resultSystemEvent()
     end
-    scheduleEvent(ForgeController.callbacks.startResultAnimation, 750)
+    scheduleForgeEvent('startResultAnimation', ForgeController.callbacks.startResultAnimation, 750)
 end
 
 local buttonClip = { x = 0, y = 0, width = 43, height = 20 }


### PR DESCRIPTION
# Description

Forge interactions spam "attempt to call an expired lua function from C++" because the module drops the only strong reference to callbacks that still have events queued.

- `scheduleEvent` hands the dispatcher a weak Lua ref (`src/framework/luaengine/luavaluecasts.h`, "the script must hold another reference to this function, otherwise it will expire"), and `modules/corelib/globals.lua:23-33` keeps the strong one on the returned event object.
- `modules/game_forge/game_forge.lua` instead anchored callbacks in `ForgeController.callbacks` and discarded every `scheduleEvent` return value (lines 53, 300, 427, 437, 538). `ForgeController:terminate()` (193-208) cancelled only `resultTimeout` and then emptied the whole callbacks table, so `updateBonusButton` (150ms), `clearRightItem` (1s), `continueAnimation` / `startResultAnimation` (750ms) and `unloadModule` (100ms) were left queued with no owner. After the next GC pass the weak ref resolves to nil and the dispatcher throws.
- Added `ForgeController.events` plus a small `scheduleForgeEvent(name, callback, delay)` helper used by all six call sites; it also cancels the previous event under the same name, which is what the recursive `continueAnimation` chain and the re-armed `resultTimeout` were already doing by hand.
- `terminate()` now calls `removeForgeEvents()` before clearing the callbacks, so nothing is pending when the references go away.
- Audited the module: those six are the only `scheduleEvent` calls, and there are no `addEvent`/`cycleEvent` calls in it.

## Behavior

### **Actual**

Use the forge (fusion/transfer, open the bonus panel) and log out or reload the module while an animation or the result timeout is still pending: the console logs "attempt to call an expired lua function from C++, did you forget to hold a reference for that function?".

### **Expected**

Pending forge timers are cancelled on terminate; no expired-function errors.

## Fixes

Closes #1691

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file
  - [x] luacheck: two warnings fewer, no new class

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved forge event scheduling to prevent duplicate or outdated events from running.
  - Fixed cleanup of pending forge events when the forge session ends.
  - Improved reliability for bonus, timeout, item-clearing, continuation, and result animations by ensuring scheduled actions are replaced and cleared correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->