### PR TITLE
fix(walk): queue same-direction key presses during walk cooldown

### DIFF
--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -3,7 +3,6 @@ local smartWalkDir = nil
 local walkEvent = nil
 local lastTurn = 0
 local nextWalkDir = nil
-local lastWalkDir = nil
 local lastCancelWalkTime = 0
 
 
@@ -99,14 +98,11 @@ local function walk(dir)
     end
 
     if not player:canWalk() then
-        if lastWalkDir ~= dir then
-            nextWalkDir = dir
-        end
+        nextWalkDir = dir
         return
     end
 
     nextWalkDir = nil
-    lastWalkDir = dir
 
     if g_game.getFeature(GameAllowPreWalk) then
         local toPos = Position.translatedToDirection(player:getPosition(), dir)


### PR DESCRIPTION
# Description

Re-pressing the same direction key while the previous step is still on cooldown drops the press, which is why tapping a key walks in fits while holding it is smooth.

- `modules/game_walk/walk.lua:101-106`: when `player:canWalk()` is false, `walk()` only stored the request as `nextWalkDir` when `lastWalkDir ~= dir`. A repeated press in the direction the player just walked matched `lastWalkDir`, so nothing was queued and `onWalkFinish` (line 234) had no direction to resume with.
- Holding the key masks the bug: the key-down handler sets `g_keyboard.setKeyDelay(key, 1)` (line 295), so repeats fire densely enough that one lands after the cooldown expires. Discrete taps do not, and the slower the character the wider the window in which a tap is lost - matching the report that low-speed characters are worst hit.
- `nextWalkDir = dir` is now set for any press that arrives during the cooldown. `lastWalkDir` had no other reader once the condition went away, so it is gone too.
- Checked that this cannot keep walking after key release: only one direction can be buffered, the successful path clears `nextWalkDir` before stepping, `isWalkLocked()` clears it, and `cancelWalkEvent()` clears it on every new walk event. A press made during cooldown yields exactly the one step the player asked for, the same as the direction-change case did already.

## Behavior

### **Actual**

Tap the same direction key repeatedly (do not hold it): steps are dropped whenever a tap lands during the previous step cooldown, so the character stutters. Worst on slow characters.

### **Expected**

A tap during the cooldown queues one step in that direction, same as a direction change already did.

## Fixes

Closes #1338

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file
  - [x] luacheck output identical to the unpatched file

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved movement handling when the player cannot walk, ensuring the next movement attempt consistently follows the requested direction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->