### PR TITLE
fix(ui): set the right unit in bottom/left/right setters

### DIFF
--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -773,9 +773,9 @@ public:
     void setY(const int y) { move(getX(), y); }
 
     void setTop(int v) { m_positions.top.unit = Unit::Px; m_positions.top.value = v; scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setBottom(int v) { m_positions.top.unit = Unit::Px; m_positions.bottom.value = v; scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setLeft(int v) { m_positions.top.unit = Unit::Px; m_positions.left.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setRight(int v) { m_positions.top.unit = Unit::Px; m_positions.right.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setBottom(int v) { m_positions.bottom.unit = Unit::Px; m_positions.bottom.value = v; scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setLeft(int v) { m_positions.left.unit = Unit::Px; m_positions.left.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setRight(int v) { m_positions.right.unit = Unit::Px; m_positions.right.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
 
     void setHeight(std::string heightStr) { applyDimension(false, std::move(heightStr)); }
     void setWidth(std::string widthStr) { applyDimension(true, std::move(widthStr)); }


### PR DESCRIPTION
# Description

Reactive `*bottom`/`*left`/`*right` bindings were ignored because the setters they resolve to never marked their own field as set.

- `src/framework/ui/uiwidget.h:776-778` — `setBottom`, `setLeft` and `setRight` are copy-pasted from `setTop` and all three assign `m_positions.top.unit = Unit::Px` while writing `.value` to their own field. So `bottom.unit`/`left.unit`/`right.unit` stayed `Unit::Auto`.
- `UIWidget::updateSize()` (`src/framework/ui/uiwidgethtml.cpp:1737-1748`) uses `unit != Unit::Auto` as "this offset is set" and otherwise falls back to the containing block's padding — hence the "doesn't respect the parent's relative position" symptom.
- The static `style="left: ..."` path goes through `UIWidget::setPositions()` (`uiwidgethtml.cpp:1482-1498`), which assigns the unit per field correctly, which is why only the `*` form was broken.
- Fix is one token per line: each setter now writes its own `.unit`.

## Behavior

### **Actual**

In an html module use `*left="x"` / `*right="x"` / `*bottom="x"`: the offset is ignored and the widget falls back to the containing block padding. `*top` works, `style="left: x"` works.

### **Expected**

Reactive `*left/*right/*bottom` position the widget exactly like the static style form.

## Fixes

Closes #1399

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Not compiled here (vcpkg deps unavailable); three single-token edits in an inline header function, checked by reading

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only (C++ relies on the CI build)
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_