### PR TITLE
fix(ui): expose setOverflow to Lua so reactive *overflow works

### DIFF
--- a/meta.lua
+++ b/meta.lua
@@ -4912,6 +4912,12 @@ function UIWidget:setOpacity(opacity) end
 ---@param degress number
 function UIWidget:setRotation(degress) end
 
+---@param overflow "visible" | "hidden" | "scroll" | "auto" | "clip"
+function UIWidget:setOverflow(overflow) end
+
+---@return integer
+function UIWidget:getOverflow() end
+
 ---@return integer
 function UIWidget:getX() end
 

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -576,6 +576,8 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIWidget>("setVisible", &UIWidget::setVisible);
     g_lua.bindClassMemberFunction<UIWidget>("setDisplay", &UIWidget::setDisplay);
     g_lua.bindClassMemberFunction<UIWidget>("getDisplay", &UIWidget::getDisplay);
+    g_lua.bindClassMemberFunction<UIWidget>("setOverflow", static_cast<void (UIWidget::*)(std::string)>(&UIWidget::setOverflow));
+    g_lua.bindClassMemberFunction<UIWidget>("getOverflow", &UIWidget::getOverflow);
     g_lua.bindClassMemberFunction<UIWidget>("setConditionIf", &UIWidget::setResultConditionIf);
     g_lua.bindClassMemberFunction<UIWidget>("setOn", &UIWidget::setOn);
     g_lua.bindClassMemberFunction<UIWidget>("setChecked", &UIWidget::setChecked);

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -478,6 +478,7 @@ public:
     AlignSelf getAlignSelf() const { return m_flexItem.alignSelf; }
     void setHtmlNode(const HtmlNodePtr& node) { m_htmlNode = node; }
     void setOverflow(OverflowType type);
+    void setOverflow(std::string type);
     void setPositionType(PositionType t) {
         m_positionType = t;
 
@@ -524,6 +525,7 @@ public:
     int getChildIndex(const UIWidgetPtr& child = nullptr) { return child ? (child->getParent().get() == this ? child->m_childIndex : -1) : m_childIndex; }
     auto getDisplay() { return m_displayType; }
     auto getFloat() { return m_floatType; }
+    auto getOverflow() { return m_overflowType; }
     auto getJustifyItems() { return m_JustifyItems; }
 
     UIWidgetPtr getVirtualParent() const;

--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -592,15 +592,7 @@ void UIWidget::parseBaseStyle(const OTMLNodePtr& styleNode)
         } else if (node->tag() == "align-self") {
             setAlignSelf(parseAlignSelf(node->value<std::string>()));
         } else if (node->tag() == "overflow") {
-            auto v = node->value<std::string>();
-            stdext::tolower(v);
-            OverflowType type = OverflowType::Visible;
-            if (v == "hidden") type = OverflowType::Hidden;
-            else if (v == "scroll") type = OverflowType::Scroll;
-            else if (v == "auto") type = OverflowType::Auto;
-            else if (v == "clip") type = OverflowType::Clip;
-            setOverflow(type);
-            setClipping(type == OverflowType::Clip || type == OverflowType::Scroll || type == OverflowType::Hidden);
+            setOverflow(node->value<std::string>());
         } else if (node->tag() == "position") {
             auto v = node->value<std::string>();
             stdext::tolower(v);

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1479,6 +1479,19 @@ void UIWidget::setOverflow(OverflowType type) {
     }
 }
 
+void UIWidget::setOverflow(std::string type) {
+    stdext::tolower(type);
+
+    OverflowType overflow = OverflowType::Visible;
+    if (type == "hidden") overflow = OverflowType::Hidden;
+    else if (type == "scroll") overflow = OverflowType::Scroll;
+    else if (type == "auto") overflow = OverflowType::Auto;
+    else if (type == "clip") overflow = OverflowType::Clip;
+
+    setOverflow(overflow);
+    setClipping(overflow == OverflowType::Clip || overflow == OverflowType::Scroll || overflow == OverflowType::Hidden);
+}
+
 void UIWidget::setPositions(std::string_view type, std::string_view value) {
     const Unit unit = detectUnit(value);
     int32_t v = stdext::to_number(std::string(numericPart(value)));


### PR DESCRIPTION
# Description

`overflow: hidden` in a `style` attribute works, `*overflow="expr"` does nothing, because the reactive path can only reach setters that are actually bound to Lua.

- `parseBaseStyle` (`src/framework/ui/uiwidgetbasestyle.cpp:594-603`) parsed the keyword inline and called `setOverflow(OverflowType)` — a C++-only enum overload with no Lua binding (`grep setOverflow src/framework/luafunctions.cpp` was empty).
- `UIWidget:__applyOrBindHtmlAttribute` (`modules/corelib/ui/uiwidget.lua:223`) resolves `*overflow` to `self['setOverflow']`, finds nil, and falls through to `self.overflow = value` (`uiwidget.lua:225-227`), which is inert.
- Moved the keyword parsing plus the `setClipping` call it was paired with into a new `UIWidget::setOverflow(std::string)` in `src/framework/ui/uiwidgethtml.cpp`; `parseBaseStyle` now just calls it, so the static and reactive paths share one keyword table instead of two.
- Bound `setOverflow` (string overload) and `getOverflow` next to `setDisplay`/`getDisplay` in `src/framework/luafunctions.cpp`, and added both to `meta.lua`.

Worth noting for follow-up: most other enum-typed style props are in the same boat and still have no Lua setter, so their `*` form is a no-op too — `float`, `clear`, `position`, `justify-items`, `justify-content`, `align-items`, `align-content`, `align-self`, `flex-direction`, `flex-wrap`, `flex-basis`, `line-height`, `gap`. `display` and `text-align` are bound but only take the raw enum value, not the CSS keyword. Left alone here to keep this change to one property.

## Behavior

### **Actual**

In an html module `*overflow="expr"` has no effect; `style="overflow: hidden"` works.

### **Expected**

`*overflow` calls the same setter as the static style keyword; `widget:setOverflow("hidden")` / `getOverflow()` are available from Lua.

## Fixes

Closes #1404

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b meta.lua passes; luacheck: no new warning category
  - [x] C++ not compiled here (vcpkg deps unavailable), checked by reading

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only (C++ relies on the CI build)
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_