### PR TITLE
fix(client): guard null mount thing type

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -401,8 +401,8 @@ void Creature::internalDraw(Point dest, const Color& color)
 
         // outfit is a real creature
         if (m_outfit.isCreature()) {
-            if (m_outfit.hasMount()) {
-                dest -= getMountThingType()->getDisplacement() * g_drawPool.getScaleFactor();
+            if (const auto mountType = getMountThingType(); mountType) {
+                dest -= mountType->getDisplacement() * g_drawPool.getScaleFactor();
 
                 if (!replaceColorShader && hasMountShader()) {
                     g_drawPool.setShaderProgram(g_shaders.getShaderById(m_mountShaderId), true/*, [this]()-> void {
@@ -410,7 +410,7 @@ void Creature::internalDraw(Point dest, const Color& color)
                         m_mountShader->setUniformValue(ShaderManager::MOUNT_ID_UNIFORM, m_outfit.getMount());
                     }*/);
                 }
-                getMountThingType()->draw(dest, 0, m_numPatternX, 0, 0, getCurrentAnimationPhase(true), color);
+                mountType->draw(dest, 0, m_numPatternX, 0, 0, getCurrentAnimationPhase(true), color);
 
                 dest += getDisplacement() * g_drawPool.getScaleFactor();
             }
@@ -680,7 +680,8 @@ void Creature::updateWalkAnimation()
     if (!m_outfit.isCreature())
         return;
 
-    int footAnimPhases = m_outfit.hasMount() ? getMountThingType()->getAnimationPhases() : getAnimationPhases();
+    const auto mountType = getMountThingType();
+    int footAnimPhases = mountType ? mountType->getAnimationPhases() : getAnimationPhases();
     if (!g_game.getFeature(Otc::GameEnhancedAnimations) && footAnimPhases > 2) {
         --footAnimPhases;
     }
@@ -1172,8 +1173,8 @@ int Creature::getDisplacementX() const
     if (m_outfit.isItem())
         return 0;
 
-    if (m_outfit.hasMount())
-        return getMountThingType()->getDisplacementX();
+    if (const auto mountType = getMountThingType(); mountType)
+        return mountType->getDisplacementX();
 
     return Thing::getDisplacementX();
 }
@@ -1186,8 +1187,8 @@ int Creature::getDisplacementY() const
     if (m_outfit.isItem())
         return 0;
 
-    if (m_outfit.hasMount())
-        return getMountThingType()->getDisplacementY();
+    if (const auto mountType = getMountThingType(); mountType)
+        return mountType->getDisplacementY();
 
     return Thing::getDisplacementY();
 }


### PR DESCRIPTION
# Description

Mounts whose client id isn't present in the loaded assets crash the client instead of just not rendering.

- `Creature::getMountThingType()` (`src/client/creature.cpp:1206`) returns whatever `ThingTypeManager::getRawThingType` gives back, and that returns `nullptr` (after logging "Invalid thing type client id ... in category ...") for any id past the end of the category table — `src/client/thingtypemanager.cpp:400-405`.
- Five call sites dereferenced it with no check: `creature.cpp:405` (`getDisplacement`), `:413` (`draw`), `:683` (`getAnimationPhases`, inside `updateWalkAnimation`, so it fires on every step of a mounted creature), `:1176` and `:1190` (`getDisplacementX/Y`). `getCurrentAnimationPhase` was the only one that already guarded (`if (!thingType) return 0;`).
- That explains the report: the listed ids (1867, 1834-1836, 1724, 1363, 1430, 1866) are simply not in whatever .dat/appearances the client loaded, and "worse when another player nearby" is exactly the draw/animate path for someone else's mount.
- Each function now caches the pointer in a local and falls back the way the existing guard does: skip the mount draw entirely, use the creature's own animation phases, defer to `Thing::getDisplacementX/Y` (which are themselves already null-guarded the same way).

Note `getMountThingType()` already returns nullptr when the outfit has no mount, so the `m_outfit.hasMount()` checks it replaced were redundant with the new guard.

## Behavior

### **Actual**

A creature wears a mount whose client id is not in the loaded .dat/appearances (e.g. ids 1867, 1834-1836, 1724, 1363, 1430, 1866 on the reporter's assets): the client crashes as soon as it is drawn or walks, worse when another mounted player is nearby.

### **Expected**

Unknown mount ids are logged (already the case in getRawThingType) and the creature is drawn without the mount instead of crashing.

## Fixes

Closes #1729

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Not compiled here (vcpkg deps unavailable), checked by reading; every guarded call site falls back the same way getCurrentAnimationPhase already did

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only (C++ relies on the CI build)
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_