### PR TITLE
fix(stats): collect stats only while the debug window is open

### DIFF
--- a/modules/client_debug_info/debug_info.lua
+++ b/modules/client_debug_info/debug_info.lua
@@ -90,10 +90,13 @@ function terminate()
 
 	removeEvent(updateEvent)
 	removeEvent(monitorEvent)
+
+	g_stats.pause()
 end
 
 function onClose()
 	debugInfoButton:setOn(false)
+	g_stats.pause()
 end
 
 function onMiniWindowClose()
@@ -104,7 +107,9 @@ function toggle()
 	if debugInfoButton:isOn() then
 		debugInfoWindow:hide()
 		debugInfoButton:setOn(false)
+		g_stats.pause()
 	else
+		g_stats.resume()
 		debugInfoWindow:show()
 		debugInfoWindow:raise()
 		debugInfoWindow:focus()

--- a/src/framework/util/stats.h
+++ b/src/framework/util/stats.h
@@ -109,6 +109,7 @@ public:
 
     inline void pause() { paused = true; }
     inline void resume() { paused = false; }
+    inline bool isPaused() const { return paused; }
 
 private:
     struct
@@ -127,7 +128,7 @@ private:
     int destroyedThings = 0;
     int createdCreatures = 0;
     int destroyedCreatures = 0;
-    std::atomic_bool paused { false };
+    std::atomic_bool paused { true };
     std::mutex m_mutex;
 };
 
@@ -137,9 +138,18 @@ class AutoStat
 {
 public:
     AutoStat(int type, const std::string& description, const std::string& extraDescription = "") :
-        m_type(type), m_stat(new Stat(0, description, extraDescription)), m_timePoint(std::chrono::high_resolution_clock::now()) {}
+        m_type(type) {
+        if (g_stats.isPaused())
+            return;
+
+        m_stat = new Stat(0, description, extraDescription);
+        m_timePoint = std::chrono::high_resolution_clock::now();
+    }
 
     ~AutoStat() {
+        if (!m_stat)
+            return;
+
         m_stat->executionTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - m_timePoint).count();
         m_stat->executionTime -= m_minusTime;
         g_stats.add(m_type, m_stat);
@@ -150,7 +160,7 @@ public:
 
 private:
     int m_type;
-    Stat* m_stat;
+    Stat* m_stat{ nullptr };
 
 protected:
     uint64_t m_minusTime = 0;


### PR DESCRIPTION
# Description

The stats system has a pause switch that nothing ever flips, so everyone pays for profiling they never look at.

- `Stats::add` (`src/framework/util/stats.cpp:38-42`) skips its work when `paused`, but `g_stats.pause()`/`resume()` had no caller anywhere in `src/` or `modules/`, and `paused` defaulted to false.
- `AutoStat` (`src/framework/util/stats.h:139-146`) is constructed unconditionally in the hot paths: every dispatcher and scheduled event (`eventdispatcher.cpp:55,138,152,183`), every render sub-stage (`graphicalapplication.cpp`, 13 sites), every Lua global/class field call (`luaengine/luainterface.h:531`, `luaengine/luaobject.h:187`) and every incoming packet (`protocolgameparse.cpp:55`). Even paused, each one did a `new Stat`, two string copies, two `high_resolution_clock` reads, then a mutex lock and a hash map insert in `add()`.
- `paused` now starts true, and `modules/client_debug_info/debug_info.lua` resumes on show and pauses on hide/close/terminate. `pause` and `resume` were already bound to Lua (`src/framework/luafunctions.cpp:298-299`), so no new binding was needed.
- `AutoStat`'s constructor now returns early when paused and the destructor no-ops on a null `m_stat`, so the allocation, the copies and the clock reads are skipped rather than being done and thrown away in `add()`.

One cost is left on the table: the two Lua sites build their description string (`std::string(global) + ":" + std::string(field)`) at the call site, before the constructor runs, so that concat still happens. Removing it means changing the call sites themselves, which felt out of scope here.

There is no `--stats` flag or `STATS_ENABLED` ifdef in the tree, so nothing else to keep working.

## Behavior

### **Actual**

Stats collection (AutoStat in every dispatcher event, render stage, Lua field call and packet) runs for every player all the time; nothing ever calls g_stats.pause().

### **Expected**

Stats are paused by default and collected only while the Debug Info window (Ctrl+Alt+D) is open.

## Fixes

Closes #1601

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on debug_info.lua; luacheck: no new warning category
  - [x] C++ not compiled here (vcpkg deps unavailable), checked by reading

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only (C++ relies on the CI build)
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_