### PR TITLE
fix(entergame): force TLS when the login URL is https

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -653,6 +653,7 @@ function EnterGame.tryHttpLogin(clientVersion, httpLogin)
     })
 
     local host, path = G.host, "/"
+    local httpsScheme = G.host:find("^https://") ~= nil
     if G.host:find("https?://") then
         local url = G.host:gsub("https?://", "")
         host, path = url:match("([^/]+)(/.*)")
@@ -675,6 +676,10 @@ function EnterGame.tryHttpLogin(clientVersion, httpLogin)
         else
             G.port = 80
         end
+    end
+
+    if httpsScheme or G.port == 443 then
+        httpLogin = false
     end
 
     math.randomseed(os.time())


### PR DESCRIPTION
# Description

An `https://` login URL (or port 443) still sent the account name and password over plain HTTP, because the scheme was only ever used for parsing, never for picking the transport.

- `modules/client_entergame/entergame.lua:655-670` strips `https?://` from `G.host` just to split host/path/port; the `httpLogin` checkbox value is then handed to `http:httpLogin(...)` at line 684 unchanged.
- On the C++ side `LoginHttp::httpLogin` (`src/framework/net/httplogin.cpp:220-232`) treats that bool as "use plain HTTP": `true` selects `loginHttpJson()` (`httplib::Client`), `false` selects `loginHttpsJson()` (`httplib::SSLClient`). So with the box ticked, an https URL was requested in clear text.
- Fix: remember whether the entered URL starts with `https://` and clear `httpLogin` when it does or when the resolved port is 443. Plain host entries keep the checkbox meaning, and the existing HTTPS-then-HTTP fallback inside `LoginHttp::httpLogin` is untouched.

## Behavior

### **Actual**

Enter an `https://` login URL (or port 443) with the HTTP login checkbox ticked: account and password go out over plain HTTP.

### **Expected**

An https:// URL or port 443 always uses TLS; plain host entries keep the checkbox meaning.

## Fixes

Refs #1811

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file; luacheck: no new warning class

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_