### PR TITLE
fix(textmessage): honour the "show others status messages" option

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -176,9 +176,9 @@ MessageTypes = {
     [MessageModes.Heal] = MessageSettings.statusOwn,
     [MessageModes.Exp] = MessageSettings.statusOwn,
 
-    [MessageModes.DamageOthers] = MessageSettings.statusOwn,
-    [MessageModes.HealOthers] = MessageSettings.statusOwn,
-    [MessageModes.ExpOthers] = MessageSettings.statusOwn,
+    [MessageModes.DamageOthers] = MessageSettings.othersStatus,
+    [MessageModes.HealOthers] = MessageSettings.othersStatus,
+    [MessageModes.ExpOthers] = MessageSettings.othersStatus,
     [MessageModes.Potion] = MessageSettings.potion,
 
     [MessageModes.TradeNpc] = MessageSettings.centerGreen,


### PR DESCRIPTION
# Description

The "Show others status messages in console" checkbox did nothing: nothing in the client ever read the setting it writes.

- `modules/game_textmessage/textmessage.lua:179-181` mapped `DamageOthers`, `HealOthers` and `ExpOthers` to `MessageSettings.statusOwn`, whose `consoleOption` is `showStatusMessagesInConsole`.
- The entry meant for these modes, `MessageSettings.othersStatus` (line 65-69, `consoleOption = 'showOthersStatusMessagesInConsole'`), was defined but referenced by no message mode, so the checkbox in `modules/client_options/styles/interface/console.otui:44` (default `false`, `data_options.lua:166`) was dead and other players' damage/heal/exp lines always followed the own-status setting.
- Fix: point the three "…Others" modes at `MessageSettings.othersStatus`. Both entries are console-only (no `screenTarget`), so only the console gating changes.

## Behavior

### **Actual**

Toggle "Show others status messages in console": nothing changes, other players' damage/heal/exp lines follow the own-status option instead.

### **Expected**

The three "...Others" message modes follow the "others status messages" option.

## Fixes

Refs #1811

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file; luacheck count identical to the unpatched file

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_