### PR TITLE
fix(corelib): stop forcing centered text on combo boxes

### DIFF
--- a/modules/corelib/ui/uicombobox.lua
+++ b/modules/corelib/ui/uicombobox.lua
@@ -47,7 +47,6 @@ function UIComboBox:setCurrentOption(text, dontSignal)
         if v.text == text and self.currentIndex ~= i then
             self.currentIndex = i
             self:setText(text)
-            self:setTextAlign(AlignCenter)
             if not dontSignal then
                 signalcall(self.onOptionChange, self, text, v.data)
             end


### PR DESCRIPTION
# Description

A combo box could never keep the `text-align` its style asked for, so long labels ended up centered and clipped.

- `modules/corelib/ui/uicombobox.lua:50` called `self:setTextAlign(AlignCenter)` on every `setCurrentOption()`, overriding whatever OTUI set. The other two setters (`setCurrentOptionByData`, `setCurrentIndex`) never did this, so the resulting alignment also depended on which one the caller used.
- Removing the call keeps the current look: `UIWidget::initText()` (`src/framework/ui/uiwidgettext.cpp:165`) already defaults `m_textAlign` to `Fw::AlignCenter`, so the base `ComboBox`/`ComboBoxRounded` styles, which declare no `text-align`, stay centered.
- Checked every ComboBox-derived style and instance in `data/`, `modules/` and `mods/`: `QtComboBox` (`data/styles/10-comboboxes.otui:159`) and the cyclopedia bestiary/items/house combos all declare `text-align: center` explicitly, so nothing relied on the forced call to look centered.

## Behavior

### **Actual**

Give a ComboBox `text-align: left` in OTUI and pick an option: the text snaps back to centered and long labels get clipped.

### **Expected**

The combo keeps the alignment its style asked for; combos without an explicit text-align stay centered (widget default).

## Fixes

Refs #1811

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file; luacheck one warning fewer, none new
  - [x] grepped every ComboBox style/instance in data/, modules/, mods/

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_