### PR TITLE
fix(corelib): give new characters their own mini-window layout

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -132,13 +132,7 @@ function UIMiniWindow:setupOnStart()
             [char] = {}
         }
     elseif not settings[char] then
-        -- if there are no settings for this character, we'll copy the settings from
-        -- another one, so we'll have something better than all the windows randomly positioned
-        for k, v in pairs(settings) do
-            settings[char] = v
-            g_settings.setNode('CharMiniWindows', settings)
-            break
-        end
+        settings[char] = {}
     end
 
     local selfSettings = settings[char][self:getId()]
@@ -358,7 +352,7 @@ function UIMiniWindow:getSettings(name)
     end
 
     local settings = g_settings.getNode('CharMiniWindows')
-    if settings then
+    if settings and settings[char] then
         local selfSettings = settings[char][self:getId()]
         if selfSettings then
             return selfSettings[name]


### PR DESCRIPTION
# Description

A character logging in for the first time inherited another character's mini-window layout, and from then on the two characters shared it.

- `modules/corelib/ui/uiminiwindow.lua:134-141`: when `CharMiniWindows` had no entry for the current character, `setupOnStart` looped over the node and did `settings[char] = v` with the first entry it found. That is a reference, not a copy, so both characters pointed at the same table and every later `setSettings()` on the new character rewrote the older character's saved positions, heights and closed flags as well.
- The old comment there described this as deliberate ("so we'll have something better than all the windows randomly positioned"), but the shared reference makes it destructive, and #1811 reports the inherited layout itself as the bug. New characters now start from `{}` and get the per-window defaults.
- `getSettings()` needed a companion guard: `CharMiniWindows` can now contain a character key with nothing under it, and an empty OTML node reads back as nil (`push_otml_subnode_luavalue`, `src/framework/luaengine/luavaluecasts.cpp:298-303`), so `settings[char][id]` would have thrown for callers like `modules/game_battle/battle.lua:56`. It now checks `settings[char]` first, matching what `setSettings`/`eraseSettings` already do.

The repo checkout is shallow (history starts at the grafted boundary), so `git log -S"settings[char] = v"` only reports that boundary commit - I could not recover the original intent from history beyond the comment itself.

## Behavior

### **Actual**

Log in with a character that has no saved mini-window layout: it inherits another character's layout, and from then on both characters share the same settings table so saving one overwrites the other.

### **Expected**

A new character starts from the default layout and gets its own settings entry.

## Fixes

Refs #1811

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] luajit -b on the changed file; luacheck three warnings fewer, none new

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_