### PR TITLE
feat(console): make chat scrollback length configurable

### DIFF
--- a/modules/client_options/data_options.lua
+++ b/modules/client_options/data_options.lua
@@ -177,6 +177,16 @@ return {
             end
         end
     },
+    consoleMaxLines                   = {
+        value = 100,
+        action = function(value, options, controller, panels, extraWidgets)
+            panels.interfaceConsole:recursiveGetChildById('consoleMaxLines'):setText(tr('Chat scrollback: %d lines',
+                value))
+            if modules and modules.game_console and modules.game_console.setMaxLines then
+                modules.game_console.setMaxLines(value)
+            end
+        end
+    },
     showOutfitsOnList                 = {
         value = true,
         action = function(value, options, controller, panels, extraWidgets)

--- a/modules/client_options/styles/interface/console.otui
+++ b/modules/client_options/styles/interface/console.otui
@@ -110,3 +110,21 @@ UIWidget
       id: showHighlightedUnderline
       !text: tr('Show highlighted text underline')
 
+  SmallReversedQtPanel
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 7
+    height: 22
+
+    OptionScaleScroll
+      id: consoleMaxLines
+      !text: tr('Chat scrollback: 100 lines')
+      anchors.fill: parent
+      &minimumScrollValue: 50
+      &maximumScrollValue: 10000
+      &scrollSize: 50
+      @onSetup: |
+        local value = modules.client_options.getOption('consoleMaxLines')
+        self:setText(tr('Chat scrollback: %d lines', value))
+

--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -556,10 +556,32 @@ function load()
         end
     end
     loadCommunicationSettings()
+
+    if modules.client_options then
+        setMaxLines(modules.client_options.getOption('consoleMaxLines'))
+    end
 end
 
 function setShowHighlightedUnderline(value)
     showHighlightedUnderline = value
+end
+
+function setMaxLines(value)
+    MAX_LINES = math.max(tonumber(value) or MAX_LINES, 1)
+
+    if not consoleTabBar then
+        return
+    end
+
+    for _, tab in pairs(consoleTabBar.tabs) do
+        local consoleBuffer = tab.tabPanel:getChildById('consoleBuffer')
+        if consoleBuffer and consoleBuffer:getChildCount() > MAX_LINES then
+            clearSelection(consoleBuffer)
+            while consoleBuffer:getChildCount() > MAX_LINES do
+                consoleBuffer:getFirstChild():destroy()
+            end
+        end
+    end
 end
 
 function isEnabledWASD()


### PR DESCRIPTION
# Description

Chat scrollback was fixed at 100 lines per tab with no way to change it, so messages scrolled out of reach much sooner than in the old clients this gets compared to.

- `modules/game_console/console.lua:138` declared `MAX_LINES = 100`, used only by the trim at `console.lua:1404` that drops the oldest label whenever a tab buffer grows past it. Nothing in `modules/client_options` touched it.
- Added `consoleMaxLines` to `modules/client_options/data_options.lua` (default 100) following the same shape as the other numeric options, and an `OptionScaleScroll` for it on `modules/client_options/styles/interface/console.otui`, range 50-10000 with a step of 50.
- `setMaxLines()` in `console.lua` updates the constant and, when the value is lowered, trims every tab's `consoleBuffer` right away instead of waiting for new messages to push the old ones out. It is called through the option action, guarded the same way `showHighlightedUnderline` calls into the console module. `load()` also applies the saved value once the console is up, since client_options runs its actions before game_console exists.

## Behavior

### **Actual**

Chat keeps at most 100 lines per tab and there is no setting for it.

### **Expected**

Options > Interface > Console has a "Chat scrollback" slider (50-10000, default 100); lowering it trims the open tabs right away and the saved value is applied on startup.

## Fixes

Closes #1538

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

  - [x] luajit -b on both changed Lua files; luacheck: no new warning class
  - [ ] Not run in the client (no build toolchain here), so the new options widget has not been seen rendered

**Test Configuration**:

  - Server Version: not run against a server
  - Client: not run, static checks only
  - Operating System: Linux (Ubuntu 24.04, checks only)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQp7kq6H2pNjH8dWktfLCV)_